### PR TITLE
docs: rewrite README around the studio workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,72 @@
 # CozyClay
 
-CozyClay is an independent, browser-based 3D staging studio built with Three.js and React Three Fiber. It combines scene blocking, character posing, prompt-block sequencing, waypoint planning, IK editing, and generated-motion preview in one local workspace.
-
-CozyClay can connect to [NVIDIA ARDY](https://github.com/nv-tlabs/ardy) for motion generation. ARDY is a separate third-party project owned and maintained by NVIDIA; it is not included in this repository, and CozyClay is not affiliated with or endorsed by NVIDIA.
+CozyClay is a browser-based 3D staging studio built with Three.js and React Three Fiber. Block a scene, pose characters, sequence motion prompts on a timeline, and preview generated motion — in one local workspace that handles like the Unity Editor.
 
 ![CozyClay browser-based 3D staging studio](docs/images/cozyclay-studio.png)
+
+CozyClay can connect to [NVIDIA ARDY](https://github.com/nv-tlabs/ardy) for motion generation. ARDY is a separate third-party project owned and maintained by NVIDIA; it is not included in this repository, and CozyClay is not affiliated with or endorsed by NVIDIA.
 
 ## Requirements
 
 - Node.js 22 or newer
 - npm
 - A Chromium-based browser
-- Optional: an SSH-accessible NVIDIA machine with ARDY for motion generation
+- Optional: an SSH-accessible NVIDIA machine running ARDY, for motion generation
 
-## Install
+## Quick start
 
 ```bash
 git clone https://github.com/HaD0Yun/CozyClay.git
 cd CozyClay
 npm install
-```
-
-## Run locally
-
-Start the studio and its local ARDY bridge:
-
-```bash
 npm run dev
 ```
 
-Open `http://127.0.0.1:5180`.
+Open `http://127.0.0.1:5180`. `npm run dev` starts the studio together with its local ARDY bridge; `npm run dev:ui` starts the browser UI alone, without Block Generation.
 
-To run only the browser UI without Block Generation:
+The bridge listens on loopback only. The environment variables that point it at a remote ARDY machine are documented in `tools/ardy/BRIDGE.md`.
 
-```bash
-npm run dev:ui
-```
+## What you can do
 
-The ARDY bridge listens on loopback only. Configure the remote ARDY machine through the environment variables documented in `tools/ardy/BRIDGE.md`.
+**Stage a scene.** Create primitives and set pieces, then move, rotate, and scale them with a W/E/R gizmo. Grid snapping is a preference, not a law — hold `Ctrl` during a drag to invert it. A bird's-eye plan view drives 2D root waypoints for character paths.
 
-## Main features
+**Edit like Unity.** Right-drag flies the camera (WASD walks, Q/E cranes), middle-drag pans, Alt+drag orbits the selection, left click selects, `F` frames. The full rule set, its source in Unity's manual, and every deliberate divergence are recorded in `docs/unity-reference.md`.
 
-- Browser-based 3D scene staging
-- Scene objects: create primitives and set pieces, then move/rotate/scale them with a 3D gizmo
-- Unity-style viewport: right-drag flies, middle-drag pans, Alt+drag orbits, left click selects, W/E/R tools
-- Character pose editing and pose export
-- Prompt Block timeline for multi-phase motion
-- ARDY motion generation and playback
-- Sparse IK motion correction
-- 2D root waypoints and Bird's-eye planning
-- Resizable production workspace
-- Browser-driven visual QA
+**Generate motion.** Pose characters and export poses, sequence multi-phase motion as Prompt Blocks on a resizable timeline, send them to ARDY, then play the result back with sparse IK correction where the generated motion needs fixing.
+
+## Controls
+
+| Input | Action |
+| --- | --- |
+| Right-drag | Look around (fly) |
+| RMB + WASD | Walk while flying |
+| RMB + Q/E | Crane down / up |
+| Middle-drag | Pan |
+| Alt + drag | Orbit the selection |
+| Scroll | Dolly |
+| Click | Select; empty space clears |
+| W / E / R | Move / rotate / scale tool |
+| Ctrl (during drag) | Invert grid snapping |
+| Ctrl/Cmd+D | Duplicate the selection |
+| F | Frame the selection |
 
 ## Validate
 
-```bash
-npm run test:hierarchy
-npm run test:scene-objects
-npm run test:objects   # needs `npm run dev:ui` in another shell
-npm run test:theme
-npm run test:appearance
-npm run test:layout
-npm run test:ardy
-npm run build
-```
+| Command | Covers |
+| --- | --- |
+| `npm run test:scene-objects` | Scene-object model |
+| `npm run test:hierarchy` | Hierarchy panel model |
+| `npm run test:objects` | Gizmo interaction in a real browser — needs `npm run dev:ui` in another shell |
+| `npm run test:theme` / `test:appearance` / `test:layout` | UI theme, appearance, layout |
+| `npm run test:lifecycle` | Dev-server process lifecycle |
+| `npm run test:ardy` | ARDY conversion, playback, and IK pipeline |
+| `npm run build` | Production build |
 
-Run browser QA while the development server is available:
+Ad-hoc browser QA, while a dev server is available:
 
 ```bash
 npm run qa:browser -- <qa-script>
 ```
-
-## Interaction reference
-
-Viewport and hierarchy behaviour follows the Unity Editor. `docs/unity-reference.md` records the rules, their source in Unity's manual, and every place CozyClay deliberately diverges.
 
 ## Repository hygiene
 
@@ -81,6 +74,4 @@ Generated motion archives, QA output, build output, logs, and local runtime arti
 
 ## License
 
-CozyClay is licensed under the GNU General Public License v3.0 or later. See `LICENSE`.
-
-Third-party projects retain their own licenses and copyright. See `THIRD_PARTY_NOTICES.md`.
+GNU General Public License v3.0 or later — see `LICENSE`. Third-party projects retain their own licenses and copyright; see `THIRD_PARTY_NOTICES.md`.


### PR DESCRIPTION
Rewrites the README to match the current product direction: workflow-oriented prose instead of a feature list, a Controls table that mirrors the in-app shortcut reference, and a Validate table mapping each npm script to what it covers.

Scope note: documents only what exists on `main`. The undo/redo contract (Ctrl/Cmd+Z, Esc drag cancel, `test:history`) is deliberately excluded; it ships with the `dev` branch and its docs commit adds those rows.