### PR TITLE
feat(ardy): local generation backend with a persistent warm worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"ardy:pose": "node tools/ardy/pose-to-npz.mjs",
 		"test:ardy": "for t in fk rest pose-shape fill npz compare-npz playback-skinning sequence-bridge; do node test/ardy/verify-$t.mjs || exit 1; done && node test/ardy/verify-browser-motion.mjs && node test/ik/verify-ik.mjs",
 		"bridge": "node tools/ardy/bridge.mjs",
+		"ardy:setup": "node tools/ardy/setup-local.mjs",
 		"dev:full": "node tools/dev-full.mjs --host 127.0.0.1 --port 5180",
 		"qa:browser": "node tools/qa-browser.mjs --",
 		"test:shot-authoring": "node test/verify-shot-authoring.mjs",

--- a/test/ardy/verify-sequence-bridge.mjs
+++ b/test/ardy/verify-sequence-bridge.mjs
@@ -16,7 +16,8 @@ const editGenerator = readFileSync(new URL("../../tools/ardy/cclay_motion_edit.p
 
 expect(
 	"multi-block requests use the sequence runner once",
-	bridge.includes("const box = spawnTracked(\"bash\", args") &&
+	bridge.includes("await runner.sequenceCommand({") &&
+	bridge.includes("const box = spawnTracked(cmd.command, cmd.args") &&
 	bridge.includes("generating ${segments.length} blocks in one autoregressive ARDY session")
 );
 expect(
@@ -62,7 +63,7 @@ expect(
 );
 expect(
 	"the segments branch forwards the root path to the sequence runner",
-	bridge.includes("for (const wp of body.waypoints ?? [])") &&
+	bridge.includes("waypoints: body.waypoints,") &&
 	bridge.includes("with a ${body.waypoints.length}-pin root path")
 );
 expect(

--- a/tools/ardy/BRIDGE.md
+++ b/tools/ardy/BRIDGE.md
@@ -19,11 +19,77 @@ node tools/ardy/bridge.mjs                 # listens on 127.0.0.1:5181
 node tools/ardy/bridge.mjs --port 5182     # or COZYCLAY_BRIDGE_PORT=5182
 ```
 
-On startup it logs the bound address. Ctrl-C kills any in-flight generation
-process group (the ssh session is closed, so nothing is orphaned on the box).
+On startup it logs the bound address and the selected backend. Ctrl-C kills
+any in-flight generation process group (local children die with the bridge;
+an ssh session is closed, so nothing is orphaned on a box).
 
-The bridge reads the same env vars `run-on-box.sh` reads. The remote SSH host
-has no public default and must be configured by the operator:
+## Backends: local and remote
+
+The HTTP surface below is backend-agnostic; where generation actually runs
+is a runner behind it (`tools/ardy/runners/`). Exactly one is selected at
+startup:
+
+| env | default | meaning |
+| --- | --- | --- |
+| `CCLAY_ARDY_MODE` | (unset) | `local` or `remote`; unset = remote when `CCLAY_ARDY_HOST` is set, local otherwise |
+
+### Local backend (`runners/local.mjs` → `run-local.mjs`)
+
+Generation on this machine, no ssh anywhere. Provision once with
+`npm run ardy:setup` (`tools/ardy/setup-local.mjs`): it clones
+`github.com/nv-tlabs/ardy` (Apache-2.0), creates a venv with torch (CUDA
+wheels on Linux, MPS on Apple Silicon), pre-fetches the
+`nvidia/ARDY-Core-RP-20FPS-Horizon40` checkpoint from HuggingFace, and
+downloads the SHA-256-pinned ungated text-encoder stack (~16.4 GB, resumable)
+via the existing `setup-text-encoder.py` + `merge-text-encoder.py`. No model
+weights ever live in this repo.
+
+| env | default | meaning |
+| --- | --- | --- |
+| `CCLAY_ARDY_LOCAL_DIR` | `~/.cozyclay/ardy` | local ARDY checkout |
+| `CCLAY_ARDY_LOCAL_VENV` | `<local-dir>/.venv/bin/python` | generator venv python |
+| `CCLAY_ARDY_ENCODERS_DIR` | `~/.cozyclay/text-encoders` | encoder weights (`TEXT_ENCODERS_DIR`) |
+| `CCLAY_ARDY_ENCODER_URL` | `http://127.0.0.1:9550/` | text-encoder service |
+| `CCLAY_ARDY_ENCODER_DEVICE` | auto (cuda > mps > cpu) | force the encoder's torch device |
+| `CCLAY_ARDY_ENCODER_IDLE_S` | `900` | shut the encoder down after this idle time |
+| `CCLAY_ARDY_DEVICE` | auto (cuda > mps > cpu) | force the generator's torch device |
+
+Device selection is `cuda > mps > cpu` on both the generator and the encoder
+(`cclay_pick_device()` in the python scripts; `CCLAY_ARDY_DEVICE` overrides,
+and a request's `cpu:true` maps onto it). `PYTORCH_ENABLE_MPS_FALLBACK=1` is
+set so an MPS-unsupported op falls back to CPU instead of failing the run.
+
+Generation runs through a **persistent worker** (`cclay_worker.py`, loopback
+TCP on `CCLAY_ARDY_WORKER_PORT`, default 9552): the bridge prewarms it at
+startup (`CCLAY_ARDY_PREWARM=0` opts out), it loads the motion model once,
+compiles the GPU kernels with a no-text warmup call, and serves jobs from
+the warm process — on this class of hardware that turns a ~2-minute
+per-request cold spawn into seconds. The text encoder (Llama-3-8B, ~16 GB)
+rides **inside the worker** (ARDY's in-process fallback, moved to the GPU as
+fp16 with a NaN-guarded bf16 fallback), and a per-prompt embedding disk
+cache (`~/.cozyclay/embed-cache`) makes every repeated prompt free —
+re-seeding, re-pinning, or re-routing the same prompt skips Llama entirely.
+`run-local.mjs` falls back to a direct one-shot spawn whenever the worker is
+unavailable (and for forced-CPU runs), so the worker is an accelerator,
+never a dependency. The worker idles out after `CCLAY_ARDY_WORKER_IDLE_S`
+(default 3600 s); the standalone gradio encoder service is only started for
+those worker-less fallback runs, idling out after
+`CCLAY_ARDY_ENCODER_IDLE_S` (default 900 s). Health reports
+`encoder: "on-demand"` while the service is down — that is a normal state,
+not an error.
+
+Single-prompt runs use the repo-owned `cclay_constrained_generate.py`
+(pose pins via `FullBodyConstraintSet`, root paths via
+`Root2DConstraintSet`, free generation with no constraints — no base motion
+and no two-pass dance needed); segment schedules and motion edits run the
+same `cclay_sequence_generate.py` / `cclay_motion_edit.py` the box does,
+executed in place from this repo.
+
+### Remote backend (`runners/remote.mjs` → `run-*-on-box.sh`)
+
+The original ssh flow, byte-for-byte: the bridge reads the same env vars
+`run-on-box.sh` reads. The SSH host has no public default and must be
+configured by the operator:
 
 | env | default | meaning |
 | --- | --- | --- |

--- a/tools/ardy/bridge.mjs
+++ b/tools/ardy/bridge.mjs
@@ -41,15 +41,12 @@ import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { decodeMotionNpz } from "../../src/ardy/npz.js";
 import { motionArraysToNpzMembers, replaceMotionSegment, writeNpz } from "./npz.mjs";
+import { globalChildren, killGroup, runStreaming, track } from "./runners/proc.mjs";
+import { createRunner } from "./runners/index.mjs";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, "../..");
 const OUT_DIR = join(HERE, "out");
-const REFS_DIR = join(OUT_DIR, "refs");
-const DUMP_SCRIPT = join(HERE, "dump-npz.py");
 const POSE_TO_NPZ = join(HERE, "pose-to-npz.mjs");
-const RUN_ON_BOX = join(HERE, "run-on-box.sh");
-const RUN_SEQUENCE_ON_BOX = join(HERE, "run-sequence-on-box.sh");
-const RUN_EDIT_ON_BOX = join(HERE, "run-edit-on-box.sh");
 
 const BIND_HOST = "127.0.0.1"; // loopback only: this process shells out
 const DEFAULT_PORT = 5181;
@@ -74,29 +71,14 @@ const MOTION_ALLOWLIST_MAX = 64; // newest runs only; evicted ids become stale 4
 // path-free (the id is a lookup key, never a path).
 const MOTION_ID = /^[0-9]+-[0-9a-f]{6}$/;
 
-// Same env var names as run-on-box.sh, so health, the bases listing and
-// generation all talk to one operator-configured host/venv/encoder.
-const HOST = process.env.CCLAY_ARDY_HOST?.trim() || "";
-const REMOTE = process.env.CCLAY_ARDY_REPO || "$HOME/ardy"; // literal $HOME: the REMOTE shell expands it
-const VENV_PY = process.env.CCLAY_ARDY_VENV || "~/ardy/.venv-cuda/bin/python"; // generator venv (tilde expands on the box)
-const ENCODER_URL = process.env.CCLAY_ARDY_ENCODER_URL || "http://127.0.0.1:9550/";
-// Numpy-only read paths (bases listing, reference dumps) use the CPU venv on
-// purpose: the box's two venvs are NOT interchangeable, and this is the one
-// the dump tooling is verified under.
-const DUMP_PY = "~/ardy/.venv/bin/python";
+// The runner is the ONLY part of the bridge that knows where generation
+// actually happens. Selection (runners/index.mjs): CCLAY_ARDY_MODE=local or
+// remote when set; otherwise remote when CCLAY_ARDY_HOST is configured, local
+// otherwise. Everything below the runner boundary — validation, caching,
+// streaming, the motion allowlist — is backend-agnostic.
+let runner; // assigned after CLI parsing, before the server starts
 
-// BatchMode: never hang on a password prompt. ConnectTimeout fails fast on a
-// dead host; ServerAlive* drops a wedged connection (same set run-on-box.sh
-// uses).
-const SSH_OPTS = [
-	"-o", "BatchMode=yes",
-	"-o", "ConnectTimeout=10",
-	"-o", "ServerAliveInterval=30",
-	"-o", "ServerAliveCountMax=240",
-];
-const SCP_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"];
-
-// A box base path is produced by the box's own `ls outputs/*.npz` /
+// A base path is produced by the backend's own `ls outputs/*.npz` /
 // `ls outputs/omb/*.npz` and is still whitelisted before it is embedded in a
 // remote shell string: only a plain, metacharacter-free relative npz path is
 // ever allowed through.
@@ -104,220 +86,14 @@ const SAFE_BASE_PATH = /^outputs\/(?:omb\/)?[A-Za-z0-9._-]+\.npz$/;
 const SAFE_BASE_ID = /^[A-Za-z0-9._-]+$/;
 
 // ---------------------------------------------------------------------------
-// process helpers
+// backend probes (health, bases) with caching
 // ---------------------------------------------------------------------------
 
-// All children spawned for generation are detached so they lead their own
-// process group; killing the group takes down bash AND the ssh it is waiting
-// on, so no remote session is orphaned. Tracked globally so Ctrl-C can clean
-// up too.
-const globalChildren = new Set();
-
-function track(child) {
-	globalChildren.add(child);
-	child.once("close", () => globalChildren.delete(child));
-}
-
-function killGroup(child) {
-	try {
-		process.kill(-child.pid, "SIGTERM");
-	} catch {
-		/* process group already gone */
-	}
-	// SIGKILL backup for anything that ignores SIGTERM; unref'd so it never
-	// keeps the bridge alive on its own.
-	const backup = setTimeout(() => {
-		try {
-			process.kill(-child.pid, "SIGKILL");
-		} catch {
-			/* gone */
-		}
-	}, 3000);
-	backup.unref();
-}
-
-// Run a short, non-streaming child (ssh/scp probes) to completion.
-function run(argv, { timeoutMs = 0 } = {}) {
-	return new Promise((resolvePromise, reject) => {
-		const child = spawn(argv[0], argv.slice(1), { stdio: ["ignore", "pipe", "pipe"] });
-		let stdout = "";
-		let stderr = "";
-		let settled = false;
-		let timer = null;
-		const finish = (err, code) => {
-			if (settled) return;
-			settled = true;
-			if (timer) clearTimeout(timer);
-			if (err) reject(err);
-			else resolvePromise({ code, stdout, stderr });
-		};
-		child.stdout.setEncoding("utf8");
-		child.stderr.setEncoding("utf8");
-		child.stdout.on("data", (chunk) => {
-			stdout += chunk;
-		});
-		child.stderr.on("data", (chunk) => {
-			stderr += chunk;
-		});
-		child.on("error", (err) => finish(err));
-		child.on("close", (code) => finish(null, code));
-		if (timeoutMs > 0) {
-			timer = setTimeout(() => {
-				try {
-					child.kill("SIGKILL");
-				} catch {
-					/* gone */
-				}
-				finish(new Error(`timed out after ${timeoutMs} ms`));
-			}, timeoutMs);
-		}
-	});
-}
-
-// Split a child's stdout/stderr into lines as they arrive; empty lines are
-// dropped. The trailing partial line is flushed on end so the generator's
-// last line is never lost.
-function streamLines(stream, onLine) {
-	let buffer = "";
-	stream.setEncoding("utf8");
-	stream.on("data", (chunk) => {
-		buffer += chunk;
-		let idx;
-		while ((idx = buffer.indexOf("\n")) !== -1) {
-			const line = buffer.slice(0, idx).replace(/\r$/, "");
-			buffer = buffer.slice(idx + 1);
-			if (line) onLine(line);
-		}
-	});
-	stream.on("end", () => {
-		const rest = buffer.replace(/\r$/, "");
-		if (rest) onLine(rest);
-	});
-}
-
-// Resolves with the exit code; rejects when the child could not be started.
-function runStreaming(child, onLine) {
-	return new Promise((resolvePromise, reject) => {
-		let settled = false;
-		const finish = (fn, value) => {
-			if (!settled) {
-				settled = true;
-				fn(value);
-			}
-		};
-		child.on("error", (err) => finish(reject, err));
-		child.on("close", (code) => finish(resolvePromise, code));
-		for (const [streamName, stream] of [
-			["stdout", child.stdout],
-			["stderr", child.stderr],
-		]) {
-			streamLines(stream, (line) => onLine(line, streamName));
-		}
-	});
-}
-
-function lastLine(text) {
-	const lines = text
-		.split("\n")
-		.map((line) => line.trim())
-		.filter((line) => line.length > 0);
-	return lines.length ? lines[lines.length - 1] : "";
-}
-
-// ---------------------------------------------------------------------------
-// box probes (health, bases) with caching
-// ---------------------------------------------------------------------------
-
-// One ssh round trip covers everything health needs: the host answering is
-// the ssh call itself, then the encoder HTTP code and the device the
-// generator venv would pick are read on the box with the same env the
-// generator runs under. The device line mirrors run-on-box.sh's probe
-// exactly, so what health reports is what the generation will use.
-function healthRemoteCmd() {
-	return [
-		`ENC="$(curl -s -o /dev/null -w '%{http_code}' -m 10 ${ENCODER_URL})"`,
-		'[ -n "$ENC" ] || ENC="000"',
-		`DEV="$(cd ${REMOTE} && ${VENV_PY} -c 'import torch; print("cuda:0" if torch.cuda.is_available() else "cpu")')"`,
-		`printf 'encoder=%s\\ndevice=%s\\n' "$ENC" "$DEV"`,
-	].join(" && ");
-}
-
-async function probeHealth() {
-	const { code, stdout, stderr } = await run(
-		["ssh", ...SSH_OPTS, HOST, healthRemoteCmd()],
-		{ timeoutMs: 60_000 }
-	);
-	if (code !== 0) {
-		throw new Error(`ssh probe on ${HOST} failed (exit ${code}): ${lastLine(stderr)}`);
-	}
-	const fields = {};
-	for (const line of stdout.split("\n")) {
-		const match = /^(encoder|device)=(.*)$/.exec(line.trim());
-		if (match) fields[match[1]] = match[2];
-	}
-	if (!("encoder" in fields)) {
-		throw new Error(`encoder probe on ${HOST} produced no answer`);
-	}
-	if (fields.encoder !== "200") {
-		throw new Error(`text encoder at ${ENCODER_URL} answered ${fields.encoder}, not 200`);
-	}
-	if (!("device" in fields) || fields.device === "") {
-		const tail = lastLine(stderr);
-		throw new Error(
-			`device probe on ${HOST} produced no answer${tail ? `: ${tail}` : ""}`
-		);
-	}
-	if (!/^(cpu|cuda:\d+)$/.test(fields.device)) {
-		throw new Error(
-			`device probe on ${HOST} returned unexpected ${JSON.stringify(fields.device)}`
-		);
-	}
-	return { ok: true, host: HOST, encoder: Number(fields.encoder), device: fields.device };
-}
-
-// Frame counts come from a real load of each npz, in ONE ssh call: the script
-// is fed to the box's python over a quoted heredoc (no local shell step), and
-// entries that fail to load are skipped with a note on the box stderr instead
-// of failing the whole listing.
-function basesRemoteCmd() {
-	const script = [
-		"import glob, json, sys",
-		"import numpy as np",
-		"entries = []",
-		'for pattern in ("outputs/*.npz", "outputs/omb/*.npz"):',
-		"    for path in sorted(glob.glob(pattern)):",
-		"        try:",
-		'            data = np.load(path, allow_pickle=False)',
-		'            frames = int(data["posed_joints"].shape[0])',
-		"            data.close()",
-		"        except Exception as exc:",
-		'            print("bases: skipping %s: %s" % (path, exc), file=sys.stderr)',
-		"            continue",
-		'        entries.append({"id": path.rsplit("/", 1)[-1][:-4], "path": path, "frames": frames})',
-		"print(json.dumps(entries))",
-	].join("\n");
-	return `cd ${REMOTE} && ${DUMP_PY} - <<'COZYCLAY_PY_EOF'\n${script}\nCOZYCLAY_PY_EOF`;
-}
-
-async function listBases() {
-	const { code, stdout, stderr } = await run(
-		["ssh", ...SSH_OPTS, HOST, basesRemoteCmd()],
-		{ timeoutMs: 120_000 }
-	);
-	if (code !== 0) {
-		throw new Error(`bases listing on ${HOST} failed (exit ${code}): ${lastLine(stderr)}`);
-	}
-	let entries;
-	try {
-		entries = JSON.parse(stdout);
-	} catch (err) {
-		throw new Error(
-			`bases listing on ${HOST} did not parse as JSON: ${lastLine(stderr) || err.message}`
-		);
-	}
-	if (!Array.isArray(entries)) {
-		throw new Error(`bases listing on ${HOST} was not an array`);
-	}
+// The raw listing comes from the runner (a box's `ls outputs/*.npz` over ssh,
+// or a local directory scan); the bridge sanitizes every entry the same way
+// regardless of backend before anything downstream can see it.
+async function fetchBases() {
+	const entries = await runner.listBases();
 	const bases = [];
 	for (const entry of entries) {
 		if (
@@ -328,18 +104,18 @@ async function listBases() {
 			!Number.isInteger(entry.frames) ||
 			entry.frames < 0
 		) {
-			console.error(`[bridge] skipping malformed bases entry from ${HOST}: ${JSON.stringify(entry)}`);
+			console.error(`[bridge] skipping malformed bases entry: ${JSON.stringify(entry)}`);
 			continue;
 		}
 		if (!SAFE_BASE_ID.test(entry.id) || !SAFE_BASE_PATH.test(entry.path)) {
-			console.error(`[bridge] skipping unsafe bases entry from ${HOST}: ${JSON.stringify(entry)}`);
+			console.error(`[bridge] skipping unsafe bases entry: ${JSON.stringify(entry)}`);
 			continue;
 		}
 		bases.push({ id: entry.id, path: entry.path, frames: entry.frames });
 	}
 	// Duplicate ids (same name under outputs/ and outputs/omb/) are kept as-is;
-	// generate matches the first, which is exactly the lookup order
-	// run-on-box.sh uses, so the two cannot pick different files.
+	// generate matches the first, which is exactly the lookup order the
+	// generation path uses, so the two cannot pick different files.
 	return { bases };
 }
 
@@ -355,7 +131,7 @@ async function getHealth() {
 		return healthCache.value;
 	}
 	if (!healthInflight) {
-		healthInflight = probeHealth()
+		healthInflight = runner.probeHealth()
 			.then((value) => {
 				healthCache = { at: Date.now(), value };
 				return value;
@@ -381,7 +157,7 @@ async function getBases() {
 		return basesCache.value;
 	}
 	if (!basesInflight) {
-		basesInflight = listBases()
+		basesInflight = fetchBases()
 			.then((value) => {
 				basesCache = { at: Date.now(), value };
 				return value;
@@ -395,75 +171,6 @@ async function getBases() {
 			});
 	}
 	return basesInflight;
-}
-
-// ---------------------------------------------------------------------------
-// reference frame dumps
-// ---------------------------------------------------------------------------
-
-// The synthetic pose borrows its skeleton proportions and root from the base
-// clip, so a frame dump of the chosen base is required by pose-to-npz.mjs.
-// Dumps are cached on disk under tools/ardy/out/refs/<base>.json and produced
-// by running tools/ardy/dump-npz.py on the box (copied to /tmp, never into
-// ~/ardy, removed afterwards). Concurrent requests for the same base share
-// one dump via refInflight.
-const refInflight = new Map();
-
-function ensureReference(baseId, basePath) {
-	mkdirSync(REFS_DIR, { recursive: true });
-	const cachePath = join(REFS_DIR, `${baseId}.json`);
-	if (existsSync(cachePath)) {
-		try {
-			const cached = JSON.parse(readFileSync(cachePath, "utf8"));
-			if (cached && cached.schema === "ardy.frame.v1") return Promise.resolve(cachePath);
-			console.error(`[bridge] cached reference ${cachePath} is not ardy.frame.v1; re-dumping`);
-		} catch {
-			console.error(`[bridge] cached reference ${cachePath} is unreadable; re-dumping`);
-		}
-	}
-	if (refInflight.has(baseId)) return refInflight.get(baseId);
-	const promise = dumpReference(baseId, basePath, cachePath).finally(() => {
-		refInflight.delete(baseId);
-	});
-	refInflight.set(baseId, promise);
-	return promise;
-}
-
-async function dumpReference(baseId, basePath, cachePath) {
-	// basePath is already whitelisted by SAFE_BASE_PATH, so it cannot carry
-	// shell metacharacters into the remote command below.
-	const suffix = `${process.pid}-${randomBytes(4).toString("hex")}`;
-	const remoteScript = `/tmp/cozyclay-dump-${suffix}.py`;
-	try {
-		await run(
-			["scp", "-q", ...SCP_OPTS, DUMP_SCRIPT, `${HOST}:${remoteScript}`],
-			{ timeoutMs: 30_000 }
-		);
-		const { stdout, stderr } = await run(
-			["ssh", ...SSH_OPTS, HOST, `cd ${REMOTE} && ${DUMP_PY} ${remoteScript} ${basePath} 0`],
-			{ timeoutMs: 120_000 }
-		);
-		let parsed;
-		try {
-			parsed = JSON.parse(stdout);
-		} catch (err) {
-			throw new Error(
-				`reference dump for ${baseId} produced no JSON: ${lastLine(stderr) || err.message}`
-			);
-		}
-		if (!parsed || parsed.schema !== "ardy.frame.v1") {
-			throw new Error(
-				`reference dump for ${baseId} has schema ${JSON.stringify(parsed && parsed.schema)}`
-			);
-		}
-		writeFileSync(cachePath, stdout);
-		return cachePath;
-	} finally {
-		// Cleanup failure must never mask the real result.
-		await run(["ssh", ...SSH_OPTS, HOST, `rm -f ${remoteScript}`], { timeoutMs: 30_000 }).catch(
-			(err) => console.error(`[bridge] could not remove ${remoteScript} on ${HOST}: ${err.message}`)
-		);
-	}
 }
 
 // ---------------------------------------------------------------------------
@@ -774,18 +481,6 @@ function tryParseReport(line) {
 	return parsed;
 }
 
-// Force the same box config onto run-on-box.sh even when the bridge was
-// started with different env values; they must not disagree.
-function boxEnv() {
-	return {
-		...process.env,
-		CCLAY_ARDY_HOST: HOST,
-		CCLAY_ARDY_REPO: REMOTE,
-		CCLAY_ARDY_VENV: VENV_PY,
-		CCLAY_ARDY_ENCODER_URL: ENCODER_URL,
-	};
-}
-
 // ---------------------------------------------------------------------------
 // generated-motion delivery
 // ---------------------------------------------------------------------------
@@ -906,7 +601,7 @@ async function handleGenerate(req, res) {
 		try {
 			bases = await getBases();
 		} catch (err) {
-			sendJson(res, 503, { ok: false, reason: `cannot list base motions on ${HOST}: ${err.message}` });
+			sendJson(res, 503, { ok: false, reason: `cannot list base motions: ${err.message}` });
 			finish(503);
 			return;
 		}
@@ -1017,22 +712,21 @@ async function handleGenerate(req, res) {
 				})),
 			};
 			writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
-			const args = [
-				RUN_EDIT_ON_BOX,
-				"--source", sourceMotionPath,
-				"--manifest", manifestPath,
-				"--prompt", body.prompt,
-				"--context-before", String(body.motionEdit.contextBefore),
-				"--context-after", String(body.motionEdit.contextAfter),
-				"--output", outNpzPath,
-			];
-			if (Number.isInteger(body.seed)) args.push("--seed", String(body.seed));
-			for (const posePath of poseNpzPaths) args.push("--pose", posePath);
+			const cmd = await runner.editCommand({
+				source: sourceMotionPath,
+				manifest: manifestPath,
+				prompt: body.prompt,
+				contextBefore: body.motionEdit.contextBefore,
+				contextAfter: body.motionEdit.contextAfter,
+				seed: body.seed,
+				poseNpzPaths,
+				output: outNpzPath,
+			});
 			sendStatus(
 				`[bridge] editing frames ${body.motionEdit.startFrame}..${body.motionEdit.endFrame - 1} ` +
 				"with ARDY history and sparse constraints"
 			);
-			const box = spawnTracked("bash", args, { cwd: REPO, detached: true, env: boxEnv() });
+			const box = spawnTracked(cmd.command, cmd.args, { cwd: REPO, detached: true, env: cmd.env });
 			const last = { stderr: "", stdout: "" };
 			let report = null;
 			let done = null;
@@ -1044,7 +738,7 @@ async function handleGenerate(req, res) {
 						report = parsed;
 						return;
 					}
-					const marker = /^run-edit-on-box: done - (.+) \((\d+) bytes\)$/.exec(line);
+					const marker = cmd.doneRe.exec(line);
 					if (marker) {
 						done = { path: marker[1], bytes: Number(marker[2]) };
 						return;
@@ -1053,10 +747,10 @@ async function handleGenerate(req, res) {
 				sendStatus(line);
 			});
 			children.delete(box);
-			if (code !== 0) throw new Error(`run-edit-on-box failed (exit ${code}): ${last.stderr || last.stdout || "no output"}`);
-			if (!done || done.path !== outNpzPath) throw new Error("run-edit-on-box did not return the requested output");
+			if (code !== 0) throw new Error(`${cmd.label} failed (exit ${code}): ${last.stderr || last.stdout || "no output"}`);
+			if (!done || done.path !== outNpzPath) throw new Error(`${cmd.label} did not return the requested output`);
 			const finalSize = statSync(outNpzPath).size;
-			if (finalSize !== done.bytes) throw new Error("run-edit-on-box output size mismatch");
+			if (finalSize !== done.bytes) throw new Error(`${cmd.label} output size mismatch`);
 			if (report) send({ event: "report", report });
 			registerMotion(stamp, outNpzPath);
 			send({ event: "done", output: outNpzPath, bytes: finalSize, motionUrl: `/ardy/motions/${stamp}` });
@@ -1067,29 +761,25 @@ async function handleGenerate(req, res) {
 			return;
 		}
 		if (body.segments) {
-			const args = [RUN_SEQUENCE_ON_BOX];
-			for (const segment of segments) {
-				args.push(
-					"--segment",
-					segment.prompt,
-					String((segment.endFrame - segment.startFrame) / FPS)
-				);
-			}
 			// Root waypoints ride the same chained rollout (rollout-global
 			// frames): the sequence generator slices the constraint set per
 			// segment call, so a path and a prompt schedule coexist.
-			for (const wp of body.waypoints ?? []) {
-				args.push("--root-2d", String(wp.frame), String(wp.x), String(wp.z), wp.heading === null ? "none" : String(wp.heading));
-			}
-			if (Number.isInteger(body.seed)) args.push("--seed", String(body.seed));
-			if (body.cpu === true) args.push("--cpu");
-			args.push("--output", outNpzPath);
+			const cmd = await runner.sequenceCommand({
+				segments: segments.map((segment) => ({
+					prompt: segment.prompt,
+					durationS: (segment.endFrame - segment.startFrame) / FPS,
+				})),
+				waypoints: body.waypoints,
+				seed: body.seed,
+				cpu: body.cpu,
+				output: outNpzPath,
+			});
 			sendStatus(
 				`[bridge] generating ${segments.length} blocks in one autoregressive ARDY session` +
 				(body.waypoints?.length ? ` with a ${body.waypoints.length}-pin root path` : "")
 			);
 
-			const box = spawnTracked("bash", args, { cwd: REPO, detached: true, env: boxEnv() });
+			const box = spawnTracked(cmd.command, cmd.args, { cwd: REPO, detached: true, env: cmd.env });
 			const last = { stderr: "", stdout: "" };
 			let finalReport = null;
 			let done = null;
@@ -1101,7 +791,7 @@ async function handleGenerate(req, res) {
 						finalReport = parsed;
 						return;
 					}
-					const marker = /^run-sequence-on-box: done - (.+) \((\d+) bytes\)$/.exec(line);
+					const marker = cmd.doneRe.exec(line);
 					if (marker) {
 						done = { path: marker[1], bytes: Number(marker[2]) };
 						return;
@@ -1111,13 +801,13 @@ async function handleGenerate(req, res) {
 			});
 			children.delete(box);
 			if (code !== 0) {
-				throw new Error(`run-sequence-on-box failed (exit ${code}): ${last.stderr || last.stdout || "no output"}`);
+				throw new Error(`${cmd.label} failed (exit ${code}): ${last.stderr || last.stdout || "no output"}`);
 			}
-			if (!done) throw new Error('run-sequence-on-box exited 0 without a "done" marker');
-			if (done.path !== outNpzPath) throw new Error(`run-sequence-on-box returned unexpected output ${done.path}`);
+			if (!done) throw new Error(`${cmd.label} exited 0 without a "done" marker`);
+			if (done.path !== outNpzPath) throw new Error(`${cmd.label} returned unexpected output ${done.path}`);
 			const finalSize = statSync(outNpzPath).size;
 			if (finalSize === 0 || finalSize !== done.bytes) {
-				throw new Error(`run-sequence-on-box output size mismatch for ${outNpzPath}`);
+				throw new Error(`${cmd.label} output size mismatch for ${outNpzPath}`);
 			}
 			if (finalReport) send({ event: "report", report: finalReport });
 			registerMotion(stamp, outNpzPath);
@@ -1136,26 +826,23 @@ async function handleGenerate(req, res) {
 				throw new Error("generation has no pose constraint");
 			}
 			const segmentFrames = segment.endFrame - segment.startFrame;
-			const args = [RUN_ON_BOX];
-			for (const entry of localPoses) {
-				args.push(
-					"--pose-from",
-					poseNpzPaths[entry.poseIndex],
-					"0",
-					String(entry.frame - segment.startFrame)
-				);
-			}
-			if (match) args.push("--base", match.path);
-			args.push("--prompt", segment.prompt, "--duration", String(segmentFrames / FPS));
-			if (Number.isInteger(body.seed)) args.push("--seed", String(body.seed));
-			if (body.cpu === true) args.push("--cpu");
-			for (const wp of body.waypoints || []) {
-				args.push("--root-2d", String(wp.frame), String(wp.x), String(wp.z), wp.heading === null ? "none" : String(wp.heading));
-			}
-			args.push("--output", outputPath);
+			const cmd = await runner.singleCommand({
+				poseFroms: localPoses.map((entry) => ({
+					npz: poseNpzPaths[entry.poseIndex],
+					srcFrame: 0,
+					dstFrame: entry.frame - segment.startFrame,
+				})),
+				basePath: match ? match.path : null,
+				prompt: segment.prompt,
+				durationS: segmentFrames / FPS,
+				seed: body.seed,
+				cpu: body.cpu,
+				waypoints: body.waypoints,
+				output: outputPath,
+			});
 			sendStatus(`[bridge] generating frames ${segment.startFrame}..${segment.endFrame - 1}`);
 
-			const box = spawnTracked("bash", args, { cwd: REPO, detached: true, env: boxEnv() });
+			const box = spawnTracked(cmd.command, cmd.args, { cwd: REPO, detached: true, env: cmd.env });
 			const last = { stderr: "", stdout: "" };
 			let report = null;
 			let done = null;
@@ -1167,7 +854,7 @@ async function handleGenerate(req, res) {
 						report = parsed;
 						return;
 					}
-					const marker = /^run-on-box: done - (.+) \((\d+) bytes\)$/.exec(line);
+					const marker = cmd.doneRe.exec(line);
 					if (marker) {
 						done = { path: marker[1], bytes: Number(marker[2]) };
 						return;
@@ -1176,11 +863,11 @@ async function handleGenerate(req, res) {
 				sendStatus(line);
 			});
 			children.delete(box);
-			if (code !== 0) throw new Error(`run-on-box failed (exit ${code}): ${last.stderr || last.stdout || "no output"}`);
-			if (!done) throw new Error('run-on-box exited 0 without a "run-on-box: done" marker');
-			if (done.path !== outputPath) throw new Error(`run-on-box returned unexpected output ${done.path}`);
+			if (code !== 0) throw new Error(`${cmd.label} failed (exit ${code}): ${last.stderr || last.stdout || "no output"}`);
+			if (!done) throw new Error(`${cmd.label} exited 0 without a "done" marker`);
+			if (done.path !== outputPath) throw new Error(`${cmd.label} returned unexpected output ${done.path}`);
 			const size = statSync(outputPath).size;
-			if (size === 0 || size !== done.bytes) throw new Error(`run-on-box output size mismatch for ${outputPath}`);
+			if (size === 0 || size !== done.bytes) throw new Error(`${cmd.label} output size mismatch for ${outputPath}`);
 			return report;
 		};
 
@@ -1286,9 +973,18 @@ Dev-only HTTP sidecar for the ARDY loop. See tools/ardy/BRIDGE.md.
 
 env:
   COZYCLAY_BRIDGE_PORT    same as --port (default 5181)
-  CCLAY_ARDY_HOST         ssh destination for the ARDY host (required)
+  CCLAY_ARDY_MODE         "local" or "remote"; default: remote when
+                          CCLAY_ARDY_HOST is set, local otherwise
+
+remote mode (generation on an ssh box):
+  CCLAY_ARDY_HOST         ssh destination for the ARDY host
   CCLAY_ARDY_REPO         ARDY checkout on the box       (default $HOME/ardy)
   CCLAY_ARDY_VENV         generator venv python on the box (default ~/ardy/.venv-cuda/bin/python)
+  CCLAY_ARDY_ENCODER_URL  text encoder service           (default http://127.0.0.1:9550/)
+
+local mode (generation on this machine; run tools/ardy/setup-local.sh once):
+  CCLAY_ARDY_LOCAL_DIR    local ARDY checkout            (default ~/.cozyclay/ardy)
+  CCLAY_ARDY_LOCAL_VENV   generator venv python          (default <local-dir>/.venv/bin/python)
   CCLAY_ARDY_ENCODER_URL  text encoder service           (default http://127.0.0.1:9550/)
 `);
 }
@@ -1323,7 +1019,11 @@ if (process.env.COZYCLAY_BRIDGE_PORT !== undefined) {
 }
 
 const port = resolvePort(process.argv.slice(2));
-if (!HOST) die("CCLAY_ARDY_HOST is required (for example: user@ardy-host)");
+try {
+	runner = createRunner();
+} catch (err) {
+	die(err.message);
+}
 
 const server = createServer((req, res) => {
 	const started = Date.now();
@@ -1408,7 +1108,7 @@ server.on("clientError", (err, socket) => {
 server.listen(port, BIND_HOST, () => {
 	console.log(`[bridge] ARDY dev bridge listening on http://${BIND_HOST}:${port}`);
 	console.log("[bridge] dev-only sidecar: the static dist/ build does not need it; stop with Ctrl-C");
-	console.log(`[bridge] box ${HOST} (repo ${REMOTE}, generator venv ${VENV_PY}, encoder ${ENCODER_URL})`);
+	console.log(`[bridge] ${runner.mode} backend: ${runner.describe()}`);
 });
 
 server.on("error", (err) => {

--- a/tools/ardy/cclay_constrained_generate.py
+++ b/tools/ardy/cclay_constrained_generate.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: CozyClay contributors
+#
+# cclay-owned script. Source of truth lives in the CozyClay repo at
+# tools/ardy/cclay_constrained_generate.py. The local runner executes it in
+# place; a box deployment may copy it to ~/ardy/scripts/. Do not edit a
+# deployed copy.
+"""One-shot constrained text-to-motion generation for the cclay ARDY pipeline.
+
+One full ``model(...)`` sampling call over the whole clip, optionally
+conditioned on:
+
+* ``--pose-from <npz> <src-frame> <dst-frame>`` (repeatable): pins the FULL
+  BODY pose stored in an ARDY motion npz (``local_rot_mats`` +
+  ``posed_joints``) onto a clip frame via ``FullBodyConstraintSet`` — joint
+  positions, joint rotations, root X/Y/Z and heading, exactly the semantics
+  BRIDGE.md documents for pose pinning.
+* ``--root-2d FRAME X Z HEADING`` (repeatable): sparse root waypoints on the
+  X/Z ground plane via ``Root2DConstraintSet`` (HEADING in radians or the
+  literal ``none``), the same contract as cclay_sequence_generate.py.
+
+With no constraints at all this is plain text-to-motion (the local twin of
+``scripts/generate.py``); a ``--base`` flag is accepted for grammar
+compatibility with the remote script but ignored — constraint conditioning
+here needs no unconstrained first pass.
+
+The last stdout line is a single JSON object whose ``target_space`` field
+marks it as a constrained-generation report (bridge.mjs keys on that):
+    {"target_space": "skeleton_joint_center", "frames": int, "fps": int,
+     "model": str,
+     "poses": [{"dst_frame", "root_error_m", "shape_mean_error_m",
+                "shape_max_error_m"}],
+     "waypoints": [{"frame", "requested_xz", "achieved_xz",
+                    "achieved_error_m", "heading_rad"}]}
+"""
+
+import argparse
+import json
+import os
+
+import numpy as np
+import torch
+
+from ardy.model import DEFAULT_MODEL, load_model
+from ardy.model.loading import get_env_var
+from ardy.model.registry import resolve_model_name
+from ardy.motion_rep.tools import length_to_mask
+from ardy.postprocess import post_process_motion
+from ardy.skeleton import SOMASkeleton30
+from ardy.tools import seed_everything, to_numpy
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="One-shot constrained text-to-motion generation (cclay)"
+    )
+    parser.add_argument("--prompt", type=str, required=True, help="Text prompt.")
+    parser.add_argument("--duration", type=float, required=True, help="Clip length in seconds.")
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output npz path (.npz appended when missing; parent dirs created).",
+    )
+    parser.add_argument(
+        "--pose-from",
+        dest="pose_from",
+        action="append",
+        nargs=3,
+        metavar=("NPZ", "SRC_FRAME", "DST_FRAME"),
+        help="Repeatable: pin the full-body pose NPZ[SRC_FRAME] at clip frame DST_FRAME.",
+    )
+    parser.add_argument(
+        "--root-2d",
+        dest="root_2d",
+        action="append",
+        nargs=4,
+        metavar=("FRAME", "X", "Z", "HEADING"),
+        help="Repeatable: pin the root's ground position (meters) at a clip frame; HEADING radians or 'none'.",
+    )
+    parser.add_argument(
+        "--base",
+        type=str,
+        default=None,
+        help="Accepted for remote-grammar compatibility; unused locally.",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Seed for reproducible results.")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL,
+        help="Model nickname or full folder name (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--diffusion_steps",
+        type=int,
+        default=None,
+        help="Denoising steps, at most the model's num_base_steps (the default).",
+    )
+    parser.add_argument(
+        "--cfg_weight",
+        type=float,
+        nargs="+",
+        default=[2.0, 2.0],
+        help="CFG scale(s): one float (text) or two floats (text, constraint).",
+    )
+    parser.add_argument(
+        "--no-postprocess",
+        action="store_true",
+        help="Don't apply motion post-processing (foot-skate reduction).",
+    )
+    parser.add_argument(
+        "--checkpoints_dir",
+        type=str,
+        default=None,
+        help="Local dir holding released model folders (falls back to CHECKPOINTS_DIR env).",
+    )
+    return parser.parse_args(argv)
+
+
+def cclay_pick_device():
+    """cuda > mps > cpu, overridable with CCLAY_ARDY_DEVICE (cpu|mps|cuda[:N]).
+
+    The env override is how the local runner forces CPU (--cpu) without
+    relying on CUDA_VISIBLE_DEVICES, which cannot hide an Apple GPU.
+    """
+    forced = os.environ.get("CCLAY_ARDY_DEVICE", "").strip().lower()
+    if forced:
+        return forced
+    if torch.cuda.is_available():
+        return "cuda:0"
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is not None and mps_backend.is_available():
+        return "mps"
+    return "cpu"
+
+
+def cclay_mps_compat(device):
+    """Downcast float64 buffers to float32 at registration when running on MPS.
+
+    The MPS backend has no float64. ARDY's skeleton loads neutral_joints from
+    a float64 pickle and registers it as a buffer, which makes Ardy.__init__'s
+    .to("mps") fail; float32 is plenty for joint positions in meters. No-op on
+    cuda/cpu so remote-box behavior is untouched.
+    """
+    if not str(device).startswith("mps"):
+        return
+    original = torch.nn.Module.register_buffer
+    if getattr(original, "_cclay_f32", False):
+        return
+
+    def register_buffer_f32(self, name, tensor, persistent=True):
+        if tensor is not None and getattr(tensor, "dtype", None) == torch.float64:
+            tensor = tensor.float()
+        return original(self, name, tensor, persistent)
+
+    register_buffer_f32._cclay_f32 = True
+    torch.nn.Module.register_buffer = register_buffer_f32
+
+
+def cclay_progress(iterable):
+    """Print one line per sampling step so the bridge can stream progress.
+
+    The model calls this where it would call tqdm; every line lands in the
+    UI as a status event, which is the only liveness signal the operator has
+    during a minutes-long generation.
+    """
+    total = len(iterable) if hasattr(iterable, "__len__") else None
+    for index, item in enumerate(iterable):
+        if total:
+            print(f"sampling step {index + 1}/{total}", flush=True)
+        else:
+            print(f"sampling step {index + 1}", flush=True)
+        yield item
+
+
+def _default_history_frames(fps: float, gen_horizon_len: int, num_frames_per_token: int) -> int:
+    """Longest history that, with the generation horizon, fits the trained 10 s window."""
+    max_window_len = (int(10 * fps) // num_frames_per_token) * num_frames_per_token
+    return ((max_window_len - gen_horizon_len) // num_frames_per_token) * num_frames_per_token
+
+
+def _single_file_path(path: str, ext: str) -> str:
+    if not path.endswith(ext):
+        path = path.rstrip(os.sep) + ext
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    return path
+
+
+def save_motion_npz(path: str, motion_dict: dict, fps: float, text: str) -> None:
+    arrays = {k: np.asarray(v) for k, v in motion_dict.items()}
+    arrays["fps"] = np.asarray(fps)
+    arrays["text"] = np.asarray(text)
+    np.savez(path, **arrays)
+
+
+def parse_root_waypoints(raw_waypoints, num_frames: int) -> list:
+    """Same contract as cclay_sequence_generate.py, frames in clip-local range."""
+    if not raw_waypoints:
+        return []
+    waypoints = []
+    seen = set()
+    for raw_frame, raw_x, raw_z, raw_heading in raw_waypoints:
+        try:
+            frame = int(raw_frame)
+        except ValueError:
+            raise ValueError(f"--root-2d frame must be an integer, got {raw_frame!r}.")
+        if not 0 <= frame < num_frames:
+            raise ValueError(f"--root-2d frame {frame} is outside the clip (0..{num_frames - 1}).")
+        if frame in seen:
+            raise ValueError(f"duplicate --root-2d for frame {frame}; one waypoint per frame.")
+        seen.add(frame)
+        try:
+            x, z = float(raw_x), float(raw_z)
+        except ValueError:
+            raise ValueError(f"--root-2d X Z must be numbers, got {(raw_x, raw_z)!r}.")
+        if str(raw_heading).lower() == "none":
+            heading = None
+        else:
+            try:
+                heading = float(raw_heading)
+            except ValueError:
+                raise ValueError(f"--root-2d HEADING must be a number or 'none', got {raw_heading!r}.")
+        waypoints.append({"frame": frame, "xz": [x, z], "heading": heading})
+    waypoints.sort(key=lambda entry: entry["frame"])
+    if len({entry["heading"] is None for entry in waypoints}) > 1:
+        raise ValueError(
+            "--root-2d heading must be given for every waypoint or for none of them; "
+            "ARDY conditions the whole waypoint set on one heading tensor."
+        )
+    return waypoints
+
+
+def load_pose(path, skeleton, device):
+    """Pose npz -> (local_rot_mats [F,J,3,3], posed_joints [F,J,3]) tensors.
+
+    The npz stores per-joint LOCAL rotations; FullBodyConstraintSet wants
+    GLOBAL rotations and posed positions, so the caller runs skeleton.fk on
+    the selected frame — the same expansion cclay_motion_edit.py uses.
+    """
+    with np.load(path, allow_pickle=False) as data:
+        local = torch.from_numpy(np.asarray(data["local_rot_mats"])).float().to(device)
+        posed = torch.from_numpy(np.asarray(data["posed_joints"])).float().to(device)
+    return local, posed
+
+
+def measure_waypoints(waypoints: list, generated_joints, skeleton) -> list:
+    report = []
+    root_index = skeleton.root_idx
+    for entry in waypoints:
+        root = np.asarray(generated_joints[entry["frame"], root_index], dtype=np.float64)
+        achieved = [float(root[0]), float(root[2])]
+        error = float(np.linalg.norm(np.asarray(achieved) - np.asarray(entry["xz"])))
+        report.append(
+            {
+                "frame": entry["frame"],
+                "requested_xz": [round(value, 4) for value in entry["xz"]],
+                "achieved_xz": [round(value, 4) for value in achieved],
+                "achieved_error_m": round(error, 4),
+                "heading_rad": entry["heading"],
+            }
+        )
+    return report
+
+
+def main(argv=None, preloaded_model=None):
+    args = parse_args(argv)
+    device = cclay_pick_device()
+    cclay_mps_compat(device)
+    print(f"Using device: {device}")
+
+    prompt = args.prompt.strip()
+    if not prompt:
+        raise ValueError("--prompt must be non-empty.")
+    if args.duration <= 0:
+        raise ValueError(f"--duration must be > 0 seconds, got {args.duration}.")
+
+    if len(args.cfg_weight) == 1:
+        cfg_weight = float(args.cfg_weight[0])
+    elif len(args.cfg_weight) == 2:
+        cfg_weight = (float(args.cfg_weight[0]), float(args.cfg_weight[1]))
+    else:
+        raise ValueError("--cfg_weight expects one float (text) or two floats (text, constraint).")
+
+    checkpoints_dir = args.checkpoints_dir or get_env_var("CHECKPOINTS_DIR")
+    resolved_model = resolve_model_name(args.model, checkpoints_dir=checkpoints_dir)
+    model = (
+        preloaded_model
+        if preloaded_model is not None
+        else load_model(resolved_model, device=device, checkpoints_dir=checkpoints_dir)
+    )
+    model.eval()
+    skeleton = model.skeleton
+    fps = model.motion_rep.fps
+    patch = model.num_frames_per_token
+
+    num_frames = int(args.duration * fps)
+    if num_frames < 3:
+        raise ValueError(f"--duration {args.duration}s yields {num_frames} frames; the minimum is 3.")
+
+    num_base_steps = int(model.diffusion.num_base_steps)
+    diffusion_steps = args.diffusion_steps if args.diffusion_steps is not None else num_base_steps
+    if not 1 <= diffusion_steps <= num_base_steps:
+        raise ValueError(
+            f"--diffusion_steps must be between 1 and {num_base_steps}; got {diffusion_steps}."
+        )
+    history_frames = _default_history_frames(fps, model.gen_horizon_len, patch)
+
+    # --- constraints --------------------------------------------------------
+    constraint_lst = []
+    pose_targets = []  # for the report: (dst_frame, requested positions [J,3])
+    for npz_path, raw_src, raw_dst in args.pose_from or []:
+        try:
+            src_frame, dst_frame = int(raw_src), int(raw_dst)
+        except ValueError:
+            raise ValueError(f"--pose-from frames must be integers, got {(raw_src, raw_dst)!r}.")
+        if not 0 <= dst_frame < num_frames:
+            raise ValueError(f"--pose-from dst-frame {dst_frame} is outside the clip (0..{num_frames - 1}).")
+        local, posed = load_pose(npz_path, skeleton, device)
+        if not 0 <= src_frame < local.shape[0]:
+            raise ValueError(
+                f"--pose-from src-frame {src_frame} is outside {npz_path} (0..{local.shape[0] - 1})."
+            )
+        from ardy.constraints import FullBodyConstraintSet
+
+        root = posed[src_frame : src_frame + 1, skeleton.root_idx]
+        rotations, positions, _ = skeleton.fk(local[src_frame : src_frame + 1], root)
+        constraint_lst.append(
+            FullBodyConstraintSet(
+                skeleton,
+                torch.tensor([dst_frame]),
+                positions,
+                rotations,
+            )
+        )
+        pose_targets.append((dst_frame, positions[0].cpu().numpy()))
+        print(f"FullBodyConstraintSet: {npz_path}[{src_frame}] pinned at clip frame {dst_frame}")
+
+    waypoints = parse_root_waypoints(args.root_2d or [], num_frames)
+    if waypoints:
+        from ardy.constraints import Root2DConstraintSet
+
+        headings = [entry["heading"] for entry in waypoints]
+        constraint_lst.append(
+            Root2DConstraintSet(
+                skeleton,
+                frame_indices=torch.tensor([entry["frame"] for entry in waypoints]),
+                root_2d=torch.tensor(
+                    [entry["xz"] for entry in waypoints], device=device, dtype=torch.float32
+                ),
+                global_root_heading=(
+                    None
+                    if headings[0] is None
+                    else torch.tensor(headings, device=device, dtype=torch.float32)
+                ),
+            )
+        )
+        print(f"Root2DConstraintSet on clip frames {[entry['frame'] for entry in waypoints]}")
+
+    observed_motion = None
+    motion_mask = None
+    lengths = torch.tensor([num_frames], device=device)
+    if constraint_lst:
+        observed_motion, motion_mask = model.motion_rep.create_conditions_from_constraints_batched(
+            constraint_lst,
+            lengths,
+            to_normalize=True,
+            device=device,
+        )
+
+    # --- sampling -----------------------------------------------------------
+    if args.seed is not None:
+        seed_everything(args.seed)
+    print(f"Generating {num_frames} frames ({num_frames / fps:.2f}s at {fps} fps)")
+    with torch.no_grad():
+        motion = model(
+            [prompt],
+            num_frames,
+            num_denoising_steps=diffusion_steps,
+            pad_mask=length_to_mask(lengths),
+            first_heading_angle=torch.zeros(1, device=device),
+            motion_mask=motion_mask,
+            observed_motion=observed_motion,
+            cfg_weight=cfg_weight,
+            progress_bar=cclay_progress,
+            crop_history_length=history_frames,
+        )
+        output = model.motion_rep.inverse(motion, is_normalized=True)
+
+    use_postprocess = "g1" not in resolved_model.lower() and not args.no_postprocess
+    if use_postprocess:
+        corrected = post_process_motion(
+            output["local_rot_mats"],
+            output["root_positions"],
+            output["foot_contacts"],
+            skeleton,
+            constraint_lst=constraint_lst if constraint_lst else None,
+        )
+        output.update(corrected)
+
+    if isinstance(skeleton, SOMASkeleton30):
+        output = skeleton.output_to_SOMASkeleton77(output)
+
+    output = to_numpy(output)
+    motion_dict = {
+        k: (v[0] if hasattr(v, "shape") and len(v.shape) > 0 and v.shape[0] == 1 else v)
+        for k, v in output.items()
+    }
+
+    npz_path = _single_file_path(args.output, ".npz")
+    print(f"Saving the npz output to {npz_path}")
+    save_motion_npz(npz_path, motion_dict, fps, prompt)
+
+    # --- report (last stdout line, keyed on target_space by bridge.mjs) ------
+    generated_joints = np.asarray(motion_dict["posed_joints"])
+    root_index = skeleton.root_idx
+    pose_reports = []
+    for dst_frame, requested in pose_targets:
+        achieved = generated_joints[dst_frame]
+        root_error = float(np.linalg.norm(achieved[root_index] - requested[root_index]))
+        # Shape error compares body proportions with both roots removed, so a
+        # root miss is not double-counted against every joint.
+        requested_centered = requested - requested[root_index]
+        achieved_centered = achieved - achieved[root_index]
+        joint_errors = np.linalg.norm(achieved_centered - requested_centered, axis=-1)
+        pose_reports.append(
+            {
+                "dst_frame": dst_frame,
+                "root_error_m": round(root_error, 4),
+                "shape_mean_error_m": round(float(joint_errors.mean()), 4),
+                "shape_max_error_m": round(float(joint_errors.max()), 4),
+            }
+        )
+
+    report = {
+        "target_space": "skeleton_joint_center",
+        "frames": int(generated_joints.shape[0]),
+        "fps": int(fps),
+        "model": resolved_model,
+        "poses": pose_reports,
+        "waypoints": measure_waypoints(waypoints, generated_joints, skeleton),
+    }
+    print(json.dumps(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ardy/cclay_motion_edit.py
+++ b/tools/ardy/cclay_motion_edit.py
@@ -48,7 +48,7 @@ TRACK_COMMIT_CHAINS = {
 }
 
 
-def parse_args():
+def parse_args(argv=None):
     parser = argparse.ArgumentParser(description="Context-aware sparse ARDY motion edit")
     parser.add_argument("--source", required=True)
     parser.add_argument("--manifest", required=True)
@@ -57,13 +57,13 @@ def parse_args():
     parser.add_argument("--context-before", type=int, default=40)
     parser.add_argument("--context-after", type=int, default=20)
     parser.add_argument("--seed", type=int)
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 class SparseJointConstraint:
     """Constraint only the named joints; deliberately does not touch root."""
 
-        name = "cozyclay-sparse-joint"
+    name = "cozyclay-sparse-joint"
 
     def __init__(self, skeleton, frame_indices, positions, rotations, joint_names):
         import torch
@@ -101,7 +101,7 @@ class SparseJointConstraint:
 class RootTrackConstraint:
     """Root X/Y/Z and heading are a separate channel from body constraints."""
 
-        name = "cozyclay-root-track"
+    name = "cozyclay-root-track"
 
     def __init__(self, skeleton, frame_indices, positions, headings):
         self.skeleton = skeleton
@@ -138,8 +138,68 @@ def heading_from_positions(positions, skeleton):
     return torch.stack([torch.cos(angle), torch.sin(angle)], dim=-1)
 
 
-def main():
-    args = parse_args()
+def cclay_pick_device():
+    """cuda > mps > cpu, overridable with CCLAY_ARDY_DEVICE (cpu|mps|cuda[:N]).
+
+    The env override is how the local runner forces CPU (--cpu) without
+    relying on CUDA_VISIBLE_DEVICES, which cannot hide an Apple GPU.
+    """
+    import torch
+
+    forced = os.environ.get("CCLAY_ARDY_DEVICE", "").strip().lower()
+    if forced:
+        return forced
+    if torch.cuda.is_available():
+        return "cuda:0"
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is not None and mps_backend.is_available():
+        return "mps"
+    return "cpu"
+
+
+def cclay_mps_compat(device):
+    """Downcast float64 buffers to float32 at registration when running on MPS.
+
+    The MPS backend has no float64. ARDY's skeleton loads neutral_joints from
+    a float64 pickle and registers it as a buffer, which makes Ardy.__init__'s
+    .to("mps") fail; float32 is plenty for joint positions in meters. No-op on
+    cuda/cpu so remote-box behavior is untouched.
+    """
+    if not str(device).startswith("mps"):
+        return
+    import torch
+
+    original = torch.nn.Module.register_buffer
+    if getattr(original, "_cclay_f32", False):
+        return
+
+    def register_buffer_f32(self, name, tensor, persistent=True):
+        if tensor is not None and getattr(tensor, "dtype", None) == torch.float64:
+            tensor = tensor.float()
+        return original(self, name, tensor, persistent)
+
+    register_buffer_f32._cclay_f32 = True
+    torch.nn.Module.register_buffer = register_buffer_f32
+
+
+def cclay_progress(iterable):
+    """Print one line per sampling step so the bridge can stream progress.
+
+    The model calls this where it would call tqdm; every line lands in the
+    UI as a status event, which is the only liveness signal the operator has
+    during a minutes-long generation.
+    """
+    total = len(iterable) if hasattr(iterable, "__len__") else None
+    for index, item in enumerate(iterable):
+        if total:
+            print(f"sampling step {index + 1}/{total}", flush=True)
+        else:
+            print(f"sampling step {index + 1}", flush=True)
+        yield item
+
+
+def main(argv=None, preloaded_model=None):
+    args = parse_args(argv)
     import numpy as np
     import torch
     from ardy.constraints import FullBodyConstraintSet
@@ -150,10 +210,15 @@ def main():
     from ardy.motion_rep.tools import length_to_mask
     from ardy.tools import seed_everything, to_numpy
 
-    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    device = cclay_pick_device()
+    cclay_mps_compat(device)
     checkpoints_dir = get_env_var("CHECKPOINTS_DIR", None)
     resolved_model = resolve_model_name(DEFAULT_MODEL, checkpoints_dir=checkpoints_dir)
-    model = load_model(resolved_model, device=device, checkpoints_dir=checkpoints_dir)
+    model = (
+        preloaded_model
+        if preloaded_model is not None
+        else load_model(resolved_model, device=device, checkpoints_dir=checkpoints_dir)
+    )
     model.eval()
     skeleton = model.skeleton
     fps = int(model.motion_rep.fps)
@@ -327,7 +392,7 @@ def main():
             motion_mask=motion_mask,
             observed_motion=observed_motion,
             cfg_weight=2.0,
-            progress_bar=lambda iterable: iterable,
+            progress_bar=cclay_progress,
             init_history_sequence=history,
         )
         generated_motion = motion[:, history_frames:history_frames + generation_frames]

--- a/tools/ardy/cclay_sequence_generate.py
+++ b/tools/ardy/cclay_sequence_generate.py
@@ -77,7 +77,7 @@ from ardy.tools import seed_everything, to_numpy
 _SEED_STRIDE = 9973
 
 
-def parse_args():
+def parse_args(argv=None):
     parser = argparse.ArgumentParser(
         description="Segment-chained autoregressive text-to-motion generation (cclay)"
     )
@@ -180,7 +180,23 @@ def parse_args():
         default=None,
         help="Local dir holding released model folders (falls back to CHECKPOINTS_DIR env).",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def cclay_progress(iterable):
+    """Print one line per sampling step so the bridge can stream progress.
+
+    The model calls this where it would call tqdm; every line lands in the
+    UI as a status event, which is the only liveness signal the operator has
+    during a minutes-long generation.
+    """
+    total = len(iterable) if hasattr(iterable, "__len__") else None
+    for index, item in enumerate(iterable):
+        if total:
+            print(f"sampling step {index + 1}/{total}", flush=True)
+        else:
+            print(f"sampling step {index + 1}", flush=True)
+        yield item
 
 
 def _default_history_frames(fps: float, gen_horizon_len: int, num_frames_per_token: int) -> int:
@@ -319,10 +335,51 @@ def _continuity_metrics(posed_joints: np.ndarray, boundaries: list) -> dict:
     }
 
 
-def main():
-    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+def cclay_pick_device():
+    """cuda > mps > cpu, overridable with CCLAY_ARDY_DEVICE (cpu|mps|cuda[:N]).
+
+    The env override is how the local runner forces CPU (--cpu) without
+    relying on CUDA_VISIBLE_DEVICES, which cannot hide an Apple GPU.
+    """
+    forced = os.environ.get("CCLAY_ARDY_DEVICE", "").strip().lower()
+    if forced:
+        return forced
+    if torch.cuda.is_available():
+        return "cuda:0"
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is not None and mps_backend.is_available():
+        return "mps"
+    return "cpu"
+
+
+def cclay_mps_compat(device):
+    """Downcast float64 buffers to float32 at registration when running on MPS.
+
+    The MPS backend has no float64. ARDY's skeleton loads neutral_joints from
+    a float64 pickle and registers it as a buffer, which makes Ardy.__init__'s
+    .to("mps") fail; float32 is plenty for joint positions in meters. No-op on
+    cuda/cpu so remote-box behavior is untouched.
+    """
+    if not str(device).startswith("mps"):
+        return
+    original = torch.nn.Module.register_buffer
+    if getattr(original, "_cclay_f32", False):
+        return
+
+    def register_buffer_f32(self, name, tensor, persistent=True):
+        if tensor is not None and getattr(tensor, "dtype", None) == torch.float64:
+            tensor = tensor.float()
+        return original(self, name, tensor, persistent)
+
+    register_buffer_f32._cclay_f32 = True
+    torch.nn.Module.register_buffer = register_buffer_f32
+
+
+def main(argv=None, preloaded_model=None):
+    device = cclay_pick_device()
+    cclay_mps_compat(device)
     print(f"Using device: {device}")
-    args = parse_args()
+    args = parse_args(argv)
 
     segments = []
     for prompt, seconds_str in args.segment:
@@ -349,7 +406,11 @@ def main():
     # Load model (same path as scripts/generate.py)
     checkpoints_dir = args.checkpoints_dir or get_env_var("CHECKPOINTS_DIR")
     resolved_model = resolve_model_name(args.model, checkpoints_dir=checkpoints_dir)
-    model = load_model(resolved_model, device=device, checkpoints_dir=checkpoints_dir)
+    model = (
+        preloaded_model
+        if preloaded_model is not None
+        else load_model(resolved_model, device=device, checkpoints_dir=checkpoints_dir)
+    )
     print(f"Loaded model: {resolved_model}")
 
     fps = model.motion_rep.fps
@@ -478,7 +539,7 @@ def main():
                 motion_mask=seg_mask,
                 observed_motion=seg_observed,
                 cfg_weight=cfg_weight,
-                progress_bar=lambda iterable: iterable,
+                progress_bar=cclay_progress,
                 init_history_sequence=history,
                 crop_history_length=history_budget if history is None else None,
             )

--- a/tools/ardy/cclay_worker.py
+++ b/tools/ardy/cclay_worker.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: CozyClay contributors
+#
+# cclay-owned script. Source of truth lives in the CozyClay repo at
+# tools/ardy/cclay_worker.py.
+"""Persistent local generation worker for the CozyClay ARDY bridge.
+
+Loading the motion model and compiling its GPU kernels costs minutes on MPS,
+while the sampling itself takes seconds. Spawning a fresh python per request
+(the remote-box contract run-local.mjs mirrors) pays that cost every time, so
+this worker pays it ONCE: it loads the model, runs a tiny no-text warmup to
+force kernel compilation, and then serves generation jobs from the warm
+process. run-local.mjs prefers the worker and silently falls back to a direct
+spawn when it is not running, so the worker is an accelerator, never a
+dependency.
+
+Protocol (loopback TCP, one connection per job, one job at a time):
+
+    client -> worker   one JSON line
+                       {"mode": "ping"}
+                       {"mode": "single"|"sequence"|"edit", "argv": [...]}
+    worker -> client   the generator's stdout lines, verbatim, then
+                       "worker: pong"  (ping)  or  "worker: exit <code>"
+
+`argv` is exactly the CLI argument vector of the corresponding
+cclay_*_generate/edit script; the worker calls that script's main() in
+process with the cached model injected, so worker and direct-spawn runs share
+one code path and cannot drift.
+
+env:
+    CCLAY_ARDY_WORKER_PORT  listen port (default 9552, loopback only)
+    CHECKPOINTS_DIR / TEXT_ENCODER_URL / TEXT_ENCODERS_DIR as usual
+"""
+
+import importlib
+import json
+import os
+import socket
+import sys
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+MODULES = {
+    "single": "cclay_constrained_generate",
+    "sequence": "cclay_sequence_generate",
+    "edit": "cclay_motion_edit",
+}
+
+
+class _Tee:
+    """Mirror generator stdout to the job's socket AND the worker console.
+
+    A vanished client must not kill the job: the generation keeps running,
+    the npz still lands on disk, and only the socket copy is dropped.
+    """
+
+    def __init__(self, sock_file):
+        self._sock_file = sock_file
+
+    def write(self, data):
+        sys.__stdout__.write(data)
+        try:
+            self._sock_file.write(data)
+            self._sock_file.flush()
+        except OSError:
+            pass
+
+    def flush(self):
+        sys.__stdout__.flush()
+
+
+def requested_model_name(mode, argv, resolve_model_name, default_model, checkpoints_dir):
+    """The model a job's argv asks for (edit has no --model flag)."""
+    name = default_model
+    if mode != "edit":
+        for index, arg in enumerate(argv):
+            if arg == "--model" and index + 1 < len(argv):
+                name = argv[index + 1]
+    return resolve_model_name(name, checkpoints_dir=checkpoints_dir)
+
+
+def fix_text_encoder_device(model, device):
+    """Move an in-process LLM2Vec encoder onto the generation device, fast.
+
+    ARDY's load_text_encoder ends with `.to(device or "cuda"/"cpu")`, so on a
+    Mac the fallback encoder lands on CPU even when TEXT_ENCODER_DEVICE says
+    mps. On MPS the dtype matters as much as the device: bf16 matmuls are
+    emulated (a single prompt costs ~30-50 s) while fp16 is native, so fp16
+    is tried first and a canary encode guards against fp16 overflow — NaNs
+    demote back to bf16. Only the real in-process encoder has a `.model`;
+    the API client stub is left alone.
+    """
+    encoder = getattr(model, "text_encoder", None)
+    if encoder is None or not hasattr(encoder, "model") or device == "cpu":
+        return
+    import torch
+
+    for dtype in (torch.float16, torch.bfloat16):
+        try:
+            encoder.to(device=device, dtype=dtype)
+            canary, _ = encoder(["a person walks forward"])
+            if bool(torch.isfinite(canary.float()).all()):
+                print(f"worker: text encoder on {device} as {dtype}", flush=True)
+                return
+            print(f"worker: text encoder {dtype} produced non-finite values; trying next dtype", flush=True)
+        except Exception as exc:
+            print(f"worker: text encoder {dtype} on {device} failed ({exc}); trying next dtype", flush=True)
+    try:  # both GPU dtypes failed: back to the slow-but-correct CPU encoder
+        encoder.to(device="cpu", dtype=torch.bfloat16)
+        print("worker: text encoder stays on cpu", flush=True)
+    except Exception as exc:
+        print(f"worker: text encoder left as loaded ({exc})", flush=True)
+
+
+class _CachingEncoder:
+    """Per-prompt embedding cache in front of the in-process encoder.
+
+    Authoring iterates on ONE prompt (new seed, new pose pin, new waypoints),
+    so most requests re-encode text the worker has already seen. Embeddings
+    are deterministic per (model, dtype) — exactly the cache key's tag — and
+    a few KB each, so they live in memory and under ~/.cozyclay/embed-cache
+    across worker restarts. Misses are timed on the console; hits are free.
+    """
+
+    def __init__(self, inner, cache_dir, tag):
+        import os
+
+        self._inner = inner
+        self._dir = cache_dir
+        self._tag = tag
+        self._mem = {}
+        os.makedirs(cache_dir, exist_ok=True)
+
+    def _key(self, text):
+        import hashlib
+
+        return hashlib.sha256(f"{self._tag}\x00{text}".encode("utf-8")).hexdigest()
+
+    def _encode_one(self, text):
+        import os
+        import time
+
+        import numpy as np
+
+        key = self._key(text)
+        if key in self._mem:
+            return self._mem[key]
+        path = os.path.join(self._dir, f"{key}.npy")
+        if os.path.isfile(path):
+            try:
+                embedding = np.load(path)
+                self._mem[key] = embedding
+                return embedding
+            except Exception:
+                pass  # unreadable cache entry: re-encode below
+        started = time.time()
+        tensor, _ = self._inner([text])
+        embedding = tensor[0].detach().float().cpu().numpy()
+        print(f"worker: text encode took {time.time() - started:.1f}s (cache miss)", flush=True)
+        self._mem[key] = embedding
+        try:
+            np.save(path, embedding)
+        except Exception:
+            pass  # cache write failure must never fail the job
+        return embedding
+
+    def __call__(self, texts):
+        import numpy as np
+        import torch
+
+        is_string = isinstance(texts, str)
+        text_list = [texts] if is_string else list(texts)
+        stacked = np.stack([self._encode_one(text) for text in text_list])
+        device = getattr(self._inner, "_device", "cpu")
+        encoded = torch.from_numpy(stacked).to(device)
+        lengths = [1] * len(text_list)
+        if is_string:
+            return encoded[0], 1
+        return encoded, lengths
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def warmup(model, device):
+    """One throwaway sampling call so kernel compilation happens off the clock.
+
+    Zero text features skip the text encoder entirely — the warmup must not
+    drag the 16 GB Llama encoder into RAM just to compile Metal shaders.
+    """
+    import torch
+    from ardy.motion_rep.tools import length_to_mask
+
+    try:
+        frames = int(model.gen_horizon_len)
+        lengths = torch.tensor([frames], device=device)
+        with torch.no_grad():
+            model(
+                [""],
+                frames,
+                num_denoising_steps=1,
+                pad_mask=length_to_mask(lengths),
+                first_heading_angle=torch.zeros(1, device=device),
+                motion_mask=None,
+                observed_motion=None,
+                cfg_weight=2.0,
+                text_feat=torch.zeros(1, 1, 4096, device=device),
+                text_pad_mask=torch.ones(1, 1, device=device, dtype=torch.bool),
+                progress_bar=lambda iterable: iterable,
+            )
+        print("worker: warmup complete", flush=True)
+    except Exception as exc:  # non-fatal: first real job just pays the compile
+        print(f"worker: warmup skipped ({exc})", flush=True)
+
+
+def main():
+    port = int(os.environ.get("CCLAY_ARDY_WORKER_PORT", "9552"))
+
+    single = importlib.import_module(MODULES["single"])
+    device = single.cclay_pick_device()
+    single.cclay_mps_compat(device)
+
+    from ardy.model import DEFAULT_MODEL, load_model
+    from ardy.model.loading import get_env_var
+    from ardy.model.registry import resolve_model_name
+
+    checkpoints_dir = get_env_var("CHECKPOINTS_DIR", None)
+    cached_name = resolve_model_name(DEFAULT_MODEL, checkpoints_dir=checkpoints_dir)
+    print(f"worker: loading {cached_name} on {device} ...", flush=True)
+    cached_model = load_model(cached_name, device=device, checkpoints_dir=checkpoints_dir)
+    cached_model.eval()
+    fix_text_encoder_device(cached_model, device)
+    encoder = getattr(cached_model, "text_encoder", None)
+    if encoder is not None and hasattr(encoder, "model"):
+        try:
+            param = next(encoder.model.parameters())
+            tag = f"llm2vec:{param.dtype}:{param.device.type}"
+        except Exception:
+            tag = "llm2vec:unknown"
+        cache_dir = os.path.join(os.path.expanduser("~"), ".cozyclay", "embed-cache")
+        cached_model.text_encoder = _CachingEncoder(encoder, cache_dir, tag)
+        print(f"worker: embedding cache at {cache_dir} ({tag})", flush=True)
+    warmup(cached_model, device)
+
+    server = socket.create_server(("127.0.0.1", port))
+    print(f"worker: ready on 127.0.0.1:{port} (model {cached_name}, device {device})", flush=True)
+
+    while True:
+        conn, _ = server.accept()
+        with conn:
+            rfile = conn.makefile("r", encoding="utf-8")
+            wfile = conn.makefile("w", encoding="utf-8")
+            try:
+                job = json.loads(rfile.readline())
+            except (ValueError, OSError):
+                continue
+            mode = job.get("mode") if isinstance(job, dict) else None
+            if mode == "ping":
+                try:
+                    wfile.write("worker: pong\n")
+                    wfile.flush()
+                except OSError:
+                    pass
+                continue
+            argv = job.get("argv") if isinstance(job, dict) else None
+            if mode not in MODULES or not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+                try:
+                    wfile.write("worker: exit 2\n")
+                    wfile.flush()
+                except OSError:
+                    pass
+                continue
+
+            module = importlib.import_module(MODULES[mode])
+            code = 0
+            old_stdout = sys.stdout
+            sys.stdout = _Tee(wfile)
+            try:
+                wanted = requested_model_name(mode, argv, resolve_model_name, DEFAULT_MODEL, checkpoints_dir)
+                if wanted != cached_name:
+                    print(f"worker: switching model {cached_name} -> {wanted}", flush=True)
+                    cached_model = load_model(wanted, device=device, checkpoints_dir=checkpoints_dir)
+                    cached_model.eval()
+                    cached_name = wanted
+                module.main(argv, preloaded_model=cached_model)
+            except SystemExit as exit_exc:
+                code = exit_exc.code if isinstance(exit_exc.code, int) else 1
+            except Exception:
+                traceback.print_exc(file=sys.stdout)
+                code = 1
+            finally:
+                sys.stdout = old_stdout
+            try:
+                wfile.write(f"worker: exit {code}\n")
+                wfile.flush()
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ardy/run-local.mjs
+++ b/tools/ardy/run-local.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * run-local.mjs - generate an ARDY clip on THIS machine.
+ *
+ *   run-local.mjs single   [--pose-from NPZ SRC DST]... --prompt P --duration S
+ *                          [--seed N] [--root-2d F X Z H]... --output OUT.npz
+ *   run-local.mjs sequence --segment PROMPT SECONDS [--segment ...]...
+ *                          [--root-2d F X Z H]... [--seed N] --output OUT.npz
+ *   run-local.mjs edit     --source SRC.npz --manifest M.json --prompt P
+ *                          --context-before N --context-after N [--seed N]
+ *                          [--pose POSE.npz]... --output OUT.npz
+ *
+ * The local twin of run-on-box.sh / run-sequence-on-box.sh /
+ * run-edit-on-box.sh: same modes, same success marker
+ *
+ *   run-local: done - <output> (<bytes> bytes)
+ *
+ * minus every ssh/scp/temp-dir round trip — the generator scripts run in
+ * place from this repo against the ARDY checkout's venv. Device selection
+ * lives in the python side (cclay_pick_device: CCLAY_ARDY_DEVICE override,
+ * else cuda > mps > cpu). The text encoder is the bridge's lazy sidecar; a
+ * dead encoder degrades to ARDY's in-process fallback rather than failing.
+ *
+ * env (set by runners/local.mjs; usable standalone too):
+ *   CCLAY_ARDY_LOCAL_DIR    ARDY checkout       (default ~/.cozyclay/ardy)
+ *   CCLAY_ARDY_LOCAL_VENV   venv python         (default <dir>/.venv/bin/python)
+ *   TEXT_ENCODER_URL        encoder service     (default http://127.0.0.1:9550/)
+ *   TEXT_ENCODERS_DIR       encoder weights dir (default ~/.cozyclay/text-encoders)
+ *   CCLAY_ARDY_DEVICE       force a torch device (cpu|mps|cuda[:N])
+ */
+
+import { spawn } from "node:child_process";
+import { cpSync, existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { createConnection } from "node:net";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LOCAL_DIR = process.env.CCLAY_ARDY_LOCAL_DIR || join(homedir(), ".cozyclay", "ardy");
+const VENV_PY =
+	process.env.CCLAY_ARDY_LOCAL_VENV ||
+	join(LOCAL_DIR, ".venv", process.platform === "win32" ? "Scripts\\python.exe" : "bin/python");
+const WORKER_PORT = Number(process.env.CCLAY_ARDY_WORKER_PORT) || 9552;
+// A sequence job can legitimately run a long time; the watchdog only guards
+// against a worker that stopped talking entirely.
+const WORKER_SILENCE_TIMEOUT_MS = 60 * 60_000;
+
+const GENERATORS = {
+	single: join(HERE, "cclay_constrained_generate.py"),
+	sequence: join(HERE, "cclay_sequence_generate.py"),
+	edit: join(HERE, "cclay_motion_edit.py"),
+};
+
+function die(message) {
+	console.error(`run-local: ${message}`);
+	process.exit(2);
+}
+
+function usage() {
+	console.error("usage: run-local.mjs <single|sequence|edit> [flags] --output OUT.npz");
+	console.error("see the header of tools/ardy/run-local.mjs for the full grammar");
+	process.exit(2);
+}
+
+// The bridge builds these argv arrays itself, so parsing here is deliberately
+// shallow: pull out the handful of values run-local needs (--output always;
+// --cpu, --pose/--manifest for staging) and pass everything else through to
+// the python generator untouched.
+function parseArgs(argv) {
+	const passthrough = [];
+	let output = "";
+	let cpu = false;
+	const poses = [];
+	let manifest = "";
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--output") {
+			output = argv[++i] ?? "";
+			continue;
+		}
+		if (arg === "--cpu") {
+			cpu = true;
+			continue;
+		}
+		if (arg === "--pose") {
+			poses.push(argv[++i] ?? "");
+			continue;
+		}
+		if (arg === "--manifest") {
+			manifest = argv[++i] ?? "";
+			continue;
+		}
+		passthrough.push(arg);
+	}
+	if (!output) die("--output is required");
+	return { passthrough, output, cpu, poses, manifest };
+}
+
+/**
+ * Try to run the job on the persistent worker (tools/ardy/cclay_worker.py).
+ *
+ * Resolves {code} when the worker accepted and finished the job (its stdout
+ * lines have already been relayed), or null when the worker is unavailable
+ * or died mid-job — the caller falls back to a direct spawn, which is always
+ * correct because the job is idempotent (same --output, overwritten).
+ */
+function runViaWorker(mode, flagArgs) {
+	return new Promise((resolvePromise) => {
+		const sock = createConnection({ host: "127.0.0.1", port: WORKER_PORT });
+		let buffer = "";
+		let settled = false;
+		const finish = (value) => {
+			if (!settled) {
+				settled = true;
+				sock.destroy();
+				resolvePromise(value);
+			}
+		};
+		sock.setTimeout(WORKER_SILENCE_TIMEOUT_MS, () => finish(null));
+		sock.on("error", () => finish(null));
+		sock.on("close", () => finish(null));
+		sock.on("connect", () => {
+			sock.write(`${JSON.stringify({ mode, argv: flagArgs })}\n`);
+		});
+		sock.on("data", (chunk) => {
+			buffer += chunk.toString("utf8");
+			let nl;
+			while ((nl = buffer.indexOf("\n")) !== -1) {
+				const line = buffer.slice(0, nl);
+				buffer = buffer.slice(nl + 1);
+				const marker = /^worker: exit (\d+)$/.exec(line);
+				if (marker) {
+					finish({ code: Number(marker[1]) });
+					return;
+				}
+				if (line) console.log(line);
+			}
+		});
+	});
+}
+
+async function main() {
+	const [mode, ...rest] = process.argv.slice(2);
+	if (!mode || mode === "-h" || mode === "--help") usage();
+	const generator = GENERATORS[mode];
+	if (!generator) die(`unknown mode '${mode}' (expected single, sequence, or edit)`);
+	if (!existsSync(VENV_PY)) {
+		die(`venv python not found at ${VENV_PY}; run \`node tools/ardy/setup-local.mjs\` once`);
+	}
+	if (!existsSync(LOCAL_DIR)) {
+		die(`ARDY checkout not found at ${LOCAL_DIR}; run \`node tools/ardy/setup-local.mjs\` once`);
+	}
+
+	const { passthrough, output, cpu, poses, manifest } = parseArgs(rest);
+
+	const flagArgs = [...passthrough];
+	let stagingDir = null;
+	if (mode === "edit") {
+		if (!manifest) die("--manifest is required in edit mode");
+		if (poses.length === 0) die("edit mode needs at least one --pose");
+		// cclay_motion_edit.py resolves the manifest's relative pose_path
+		// entries against the manifest's own directory, expecting pose-<i>.npz
+		// siblings (the layout run-edit-on-box.sh created with scp). Stage the
+		// same layout in a fresh temp dir.
+		stagingDir = mkdtempSync(join(tmpdir(), "cozyclay-edit-"));
+		cpSync(manifest, join(stagingDir, "manifest.json"));
+		poses.forEach((posePath, index) => {
+			cpSync(posePath, join(stagingDir, `pose-${index}.npz`));
+		});
+		flagArgs.push("--manifest", join(stagingDir, "manifest.json"));
+	} else if (manifest) {
+		flagArgs.push("--manifest", manifest);
+	}
+	flagArgs.push("--output", output);
+
+	const env = { ...process.env };
+	if (cpu) env.CCLAY_ARDY_DEVICE = "cpu";
+
+	// Prefer the warm worker; a forced device (--cpu / CCLAY_ARDY_DEVICE)
+	// bypasses it because the worker's model already lives on the auto-picked
+	// device. null = worker unavailable, fall through to a direct spawn.
+	let code = null;
+	const forcedDevice = cpu || Boolean(process.env.CCLAY_ARDY_DEVICE);
+	if (!forcedDevice) {
+		const workerResult = await runViaWorker(mode, flagArgs);
+		if (workerResult) {
+			console.log("run-local: served by warm worker");
+			code = workerResult.code;
+		}
+	}
+	if (code === null) {
+		console.log(`run-local: ${mode} generation with ${basename(VENV_PY)} (${LOCAL_DIR})`);
+		const child = spawn(VENV_PY, [generator, ...flagArgs], {
+			cwd: LOCAL_DIR, // keeps any generator-relative paths (outputs/, HF cache) out of this repo
+			stdio: ["ignore", "inherit", "inherit"],
+			env,
+		});
+		code = await new Promise((resolvePromise, reject) => {
+			child.on("error", reject);
+			child.on("close", resolvePromise);
+		});
+	}
+	if (stagingDir) {
+		// Cleanup failure must never mask the real result.
+		try {
+			rmSync(stagingDir, { recursive: true, force: true });
+		} catch (err) {
+			console.error(`run-local: could not remove ${stagingDir}: ${err.message}`);
+		}
+	}
+	if (code !== 0) {
+		console.error(`run-local: generator exited with code ${code}`);
+		process.exit(code || 1);
+	}
+	let size;
+	try {
+		size = statSync(output).size;
+	} catch {
+		console.error(`run-local: generator exited 0 but ${output} does not exist`);
+		process.exit(1);
+	}
+	if (size === 0) {
+		console.error(`run-local: generator produced an empty file at ${output}`);
+		process.exit(1);
+	}
+	console.log(`run-local: done - ${output} (${size} bytes)`);
+}
+
+main().catch((err) => {
+	console.error(`run-local: ${err.stack || err}`);
+	process.exit(1);
+});

--- a/tools/ardy/runners/index.mjs
+++ b/tools/ardy/runners/index.mjs
@@ -1,0 +1,23 @@
+/**
+ * Runner selection for the ARDY bridge.
+ *
+ * Exactly one backend drives generation for the bridge's lifetime:
+ *
+ *   CCLAY_ARDY_MODE=local | remote   explicit choice
+ *   (unset)                          remote when CCLAY_ARDY_HOST is set,
+ *                                    local otherwise
+ *
+ * so an operator with a configured box keeps today's behavior untouched, and
+ * everyone else gets local generation with zero configuration.
+ */
+
+import { createLocalRunner } from "./local.mjs";
+import { createRemoteRunner } from "./remote.mjs";
+
+export function createRunner() {
+	const mode = (process.env.CCLAY_ARDY_MODE || "").trim().toLowerCase();
+	if (mode === "remote") return createRemoteRunner();
+	if (mode === "local") return createLocalRunner();
+	if (mode) throw new Error(`unknown CCLAY_ARDY_MODE "${mode}" (expected "local" or "remote")`);
+	return process.env.CCLAY_ARDY_HOST?.trim() ? createRemoteRunner() : createLocalRunner();
+}

--- a/tools/ardy/runners/local.mjs
+++ b/tools/ardy/runners/local.mjs
@@ -1,0 +1,452 @@
+/**
+ * Local runner for the ARDY bridge: generation on THIS machine.
+ *
+ * Same small interface as runners/remote.mjs, no ssh anywhere. The heavy
+ * pieces live in a per-user directory (nothing model-shaped is ever inside
+ * the CozyClay repo):
+ *
+ *   ~/.cozyclay/ardy            ARDY checkout + .venv (torch, ardy, gradio)
+ *   ~/.cozyclay/text-encoders   LLM2Vec / Llama-3-8B encoder weights
+ *   (HF cache)                  ARDY motion checkpoints, auto-downloaded by
+ *                               huggingface_hub on first use
+ *
+ * `node tools/ardy/setup-local.mjs` provisions all of it; this runner only
+ * checks and reports. Generation children are spawned through
+ * tools/ardy/run-local.mjs, which mirrors the run-*-on-box.sh contract
+ * (same modes, same "<label>: done - <path> (<bytes> bytes)" marker) minus
+ * the push/pull dance.
+ *
+ * The text encoder (Llama-3-8B, ~16 GB resident) is the one piece too heavy
+ * to keep alive unconditionally, so it is a lazy sidecar: started on the
+ * first generation that needs it, reused while warm, and shut down after an
+ * idle window to give the RAM back. ARDY's own TEXT_ENCODER_MODE=auto makes
+ * a dead encoder a graceful state (in-process fallback), never a crash.
+ */
+
+import { existsSync } from "node:fs";
+import { createConnection } from "node:net";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { killGroup, lastLine, run, track } from "./proc.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TOOLS_ARDY = join(HERE, "..");
+const RUN_LOCAL = join(TOOLS_ARDY, "run-local.mjs");
+const SETUP_HINT = "run `node tools/ardy/setup-local.mjs` once to install ARDY locally";
+
+// cuda > mps > cpu, the same order cclay_pick_device() uses in the python
+// generators, so what health reports is what generation will use.
+const DEVICE_PROBE = [
+	"import os, torch",
+	'forced = os.environ.get("CCLAY_ARDY_DEVICE", "").strip().lower()',
+	"mps = getattr(torch.backends, 'mps', None)",
+	'print(forced or ("cuda:0" if torch.cuda.is_available() else ("mps" if mps is not None and mps.is_available() else "cpu")))',
+].join("\n");
+
+const ENCODER_START_TIMEOUT_MS = 10 * 60_000; // first start reads ~16 GB of weights from disk
+const ENCODER_POLL_MS = 2000;
+const ENCODER_IDLE_DEFAULT_S = 900; // give the RAM back after 15 quiet minutes
+
+const WORKER_START_TIMEOUT_MS = 15 * 60_000; // model load + first-ever kernel compile
+const WORKER_POLL_MS = 2000;
+const WORKER_IDLE_DEFAULT_S = 3600; // the motion model is small; keep it warm longer
+
+export function createLocalRunner() {
+	const LOCAL_DIR = process.env.CCLAY_ARDY_LOCAL_DIR || join(homedir(), ".cozyclay", "ardy");
+	const VENV_PY =
+		process.env.CCLAY_ARDY_LOCAL_VENV ||
+		join(LOCAL_DIR, ".venv", process.platform === "win32" ? "Scripts\\python.exe" : "bin/python");
+	const ENCODERS_DIR = process.env.CCLAY_ARDY_ENCODERS_DIR || join(homedir(), ".cozyclay", "text-encoders");
+	const ENCODER_URL = process.env.CCLAY_ARDY_ENCODER_URL || "http://127.0.0.1:9550/";
+	const ENCODER_DEVICE = (process.env.CCLAY_ARDY_ENCODER_DEVICE || "").trim();
+	const ENCODER_IDLE_S = Number(process.env.CCLAY_ARDY_ENCODER_IDLE_S) > 0
+		? Number(process.env.CCLAY_ARDY_ENCODER_IDLE_S)
+		: ENCODER_IDLE_DEFAULT_S;
+
+	// Environment every local child (probe, encoder, generator) runs under.
+	// TEXT_ENCODER_URL/TEXT_ENCODERS_DIR are ARDY's own env contract;
+	// PYTORCH_ENABLE_MPS_FALLBACK lets the odd unsupported op fall back to CPU
+	// instead of aborting an entire generation on Apple GPUs.
+	function localEnv(extra = {}) {
+		return {
+			...process.env,
+			CCLAY_ARDY_LOCAL_DIR: LOCAL_DIR,
+			CCLAY_ARDY_LOCAL_VENV: VENV_PY,
+			CCLAY_ARDY_ENCODER_URL: ENCODER_URL,
+			TEXT_ENCODER_URL: ENCODER_URL,
+			TEXT_ENCODERS_DIR: ENCODERS_DIR,
+			PYTORCH_ENABLE_MPS_FALLBACK: "1",
+			...extra,
+		};
+	}
+
+	function requireSetup() {
+		if (!existsSync(LOCAL_DIR)) {
+			throw new Error(`local ARDY checkout not found at ${LOCAL_DIR}; ${SETUP_HINT}`);
+		}
+		if (!existsSync(VENV_PY)) {
+			throw new Error(`local ARDY venv python not found at ${VENV_PY}; ${SETUP_HINT}`);
+		}
+	}
+
+	// The device cannot change mid-session, and the probe costs a full torch
+	// import (~seconds), so the first successful answer is kept for the
+	// bridge's lifetime instead of re-spawning python on every health poll.
+	let deviceCache = null;
+
+	async function probeDevice() {
+		if (deviceCache) return deviceCache;
+		const { code, stdout, stderr } = await run([VENV_PY, "-c", DEVICE_PROBE], { timeoutMs: 60_000 });
+		if (code !== 0) {
+			throw new Error(`local device probe failed (exit ${code}): ${lastLine(stderr)}`);
+		}
+		const device = stdout.trim();
+		if (!/^(cpu|mps|cuda:\d+)$/.test(device)) {
+			throw new Error(`local device probe returned unexpected ${JSON.stringify(device)}`);
+		}
+		deviceCache = device;
+		return device;
+	}
+
+	async function encoderStatus() {
+		try {
+			const res = await fetch(ENCODER_URL, { signal: AbortSignal.timeout(5000) });
+			return res.status;
+		} catch {
+			return 0;
+		}
+	}
+
+	async function probeHealth() {
+		requireSetup();
+		const [device, encoder] = await Promise.all([probeDevice(), encoderStatus()]);
+		// A down encoder is a normal state here (it lazy-starts on the first
+		// generation), so health stays ok and the field says so instead of
+		// blocking the generate affordance the way a dead box would.
+		return { ok: true, host: "local", encoder: encoder === 200 ? 200 : "on-demand", device };
+	}
+
+	// Frame counts come from a real numpy load of each npz, one python child
+	// for the whole listing; entries that fail to load are skipped with a note
+	// on stderr, and paths are reported repo-relative (outputs/...) so the
+	// bridge-side SAFE_BASE_PATH whitelist applies unchanged.
+	const BASES_SCRIPT = [
+		"import glob, json, os, sys",
+		"import numpy as np",
+		"root = sys.argv[1]",
+		"entries = []",
+		'for pattern in ("outputs/*.npz", "outputs/omb/*.npz"):',
+		"    for path in sorted(glob.glob(os.path.join(root, pattern))):",
+		"        try:",
+		"            data = np.load(path, allow_pickle=False)",
+		'            frames = int(data["posed_joints"].shape[0])',
+		"            data.close()",
+		"        except Exception as exc:",
+		'            print("bases: skipping %s: %s" % (path, exc), file=sys.stderr)',
+		"            continue",
+		"        rel = os.path.relpath(path, root).replace(os.sep, '/')",
+		'        entries.append({"id": os.path.basename(path)[:-4], "path": rel, "frames": frames})',
+		"print(json.dumps(entries))",
+	].join("\n");
+
+	async function listBases() {
+		requireSetup();
+		const { code, stdout, stderr } = await run([VENV_PY, "-c", BASES_SCRIPT, LOCAL_DIR], { timeoutMs: 120_000 });
+		if (code !== 0) {
+			throw new Error(`local bases listing failed (exit ${code}): ${lastLine(stderr)}`);
+		}
+		let entries;
+		try {
+			entries = JSON.parse(stdout);
+		} catch (err) {
+			throw new Error(`local bases listing did not parse as JSON: ${lastLine(stderr) || err.message}`);
+		}
+		if (!Array.isArray(entries)) {
+			throw new Error("local bases listing was not an array");
+		}
+		return entries;
+	}
+
+	// --- lazy text-encoder sidecar -----------------------------------------
+
+	let encoderChild = null;
+	let encoderStarting = null;
+	let encoderIdleTimer = null;
+
+	function armIdleShutdown() {
+		if (encoderIdleTimer) clearTimeout(encoderIdleTimer);
+		encoderIdleTimer = setTimeout(() => {
+			if (encoderChild) {
+				console.log(`[bridge] text encoder idle for ${ENCODER_IDLE_S}s; shutting it down to free RAM`);
+				killGroup(encoderChild);
+				encoderChild = null;
+			}
+		}, ENCODER_IDLE_S * 1000);
+		encoderIdleTimer.unref();
+	}
+
+	async function startEncoder() {
+		const device = ENCODER_DEVICE || (await probeDevice().catch(() => "cpu"));
+		// Strip the cuda ordinal notation the generator uses; the server takes
+		// plain "cuda"/"cuda:N"/"mps"/"cpu" so cuda:0 passes through unchanged.
+		console.log(`[bridge] starting local text encoder on ${device} (first answer may take minutes while ~16 GB of weights load)`);
+		const child = spawn(
+			VENV_PY,
+			[
+				"-u", join(LOCAL_DIR, "scripts", "run_text_encoder_server.py"),
+				"--host", "127.0.0.1",
+				"--port", String(new URL(ENCODER_URL).port || 9550),
+				"--device", device,
+				// The server's default /tmp/text_encoder/ is NOT the system temp
+				// dir on macOS (/var/folders/...), and gradio refuses to serve
+				// files from outside cwd/tempdir — so put the scratch npy files
+				// where gradio provably allows them.
+				"--tmp-folder", join(tmpdir(), "cozyclay-text-encoder"),
+			],
+			{
+				cwd: LOCAL_DIR, // the server imports its sibling get_gradio_theme.py
+				detached: true,
+				stdio: ["ignore", "pipe", "pipe"],
+				env: localEnv({ GRADIO_ANALYTICS_ENABLED: "False" }),
+			}
+		);
+		track(child);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => process.stdout.write(`[encoder] ${chunk}`));
+		child.stderr.on("data", (chunk) => process.stderr.write(`[encoder] ${chunk}`));
+		child.once("close", (code) => {
+			if (encoderChild === child) encoderChild = null;
+			if (code !== 0 && code !== null) console.error(`[bridge] text encoder exited with code ${code}`);
+		});
+		encoderChild = child;
+
+		const deadline = Date.now() + ENCODER_START_TIMEOUT_MS;
+		while (Date.now() < deadline) {
+			if (encoderChild !== child) throw new Error("text encoder process exited while starting");
+			if ((await encoderStatus()) === 200) return;
+			await new Promise((resolveSleep) => setTimeout(resolveSleep, ENCODER_POLL_MS));
+		}
+		killGroup(child);
+		throw new Error(`text encoder did not answer on ${ENCODER_URL} within ${ENCODER_START_TIMEOUT_MS / 60000} minutes`);
+	}
+
+	// Resolves when the encoder answers 200. Reuses a warm encoder (its idle
+	// timer is re-armed), joins an in-flight start, or starts a fresh one.
+	async function ensureEncoder() {
+		if ((await encoderStatus()) === 200) {
+			armIdleShutdown();
+			return;
+		}
+		if (!encoderStarting) {
+			encoderStarting = startEncoder().finally(() => {
+				encoderStarting = null;
+			});
+		}
+		await encoderStarting;
+		armIdleShutdown();
+	}
+
+	// --- persistent generation worker ---------------------------------------
+	// Loading the motion model + compiling GPU kernels costs minutes on MPS;
+	// sampling costs seconds. The worker (tools/ardy/cclay_worker.py) pays the
+	// load once and serves jobs warm. run-local.mjs falls back to a direct
+	// spawn whenever the worker is missing, so this is purely an accelerator.
+
+	const WORKER_PORT = Number(process.env.CCLAY_ARDY_WORKER_PORT) || 9552;
+	const WORKER_IDLE_S = Number(process.env.CCLAY_ARDY_WORKER_IDLE_S) > 0
+		? Number(process.env.CCLAY_ARDY_WORKER_IDLE_S)
+		: WORKER_IDLE_DEFAULT_S;
+
+	let workerChild = null;
+	let workerStarting = null;
+	let workerIdleTimer = null;
+
+	function workerStatus() {
+		return new Promise((resolvePromise) => {
+			const sock = createConnection({ host: "127.0.0.1", port: WORKER_PORT });
+			let settled = false;
+			const finish = (ok) => {
+				if (!settled) {
+					settled = true;
+					sock.destroy();
+					resolvePromise(ok);
+				}
+			};
+			sock.setTimeout(3000, () => finish(false));
+			sock.on("error", () => finish(false));
+			sock.on("close", () => finish(false));
+			sock.on("connect", () => sock.write('{"mode":"ping"}\n'));
+			sock.on("data", (chunk) => finish(String(chunk).includes("worker: pong")));
+		});
+	}
+
+	function armWorkerIdleShutdown() {
+		if (workerIdleTimer) clearTimeout(workerIdleTimer);
+		workerIdleTimer = setTimeout(() => {
+			if (workerChild) {
+				console.log(`[bridge] generation worker idle for ${WORKER_IDLE_S}s; shutting it down`);
+				killGroup(workerChild);
+				workerChild = null;
+			}
+		}, WORKER_IDLE_S * 1000);
+		workerIdleTimer.unref();
+	}
+
+	async function startWorker() {
+		console.log("[bridge] starting generation worker (loads the motion model once; later requests reuse it warm)");
+		const device = ENCODER_DEVICE || (await probeDevice().catch(() => "cpu"));
+		const child = spawn(
+			VENV_PY,
+			["-u", join(TOOLS_ARDY, "cclay_worker.py")],
+			{
+				cwd: LOCAL_DIR,
+				detached: true,
+				stdio: ["ignore", "pipe", "pipe"],
+				// With no encoder service running, ARDY's auto mode loads the
+				// text encoder IN-PROCESS inside the worker — one warm process
+				// serving both models, no HTTP hop. TEXT_ENCODER_DEVICE keeps
+				// that in-process Llama off the CPU default.
+				env: localEnv({
+					CCLAY_ARDY_WORKER_PORT: String(WORKER_PORT),
+					TEXT_ENCODER_DEVICE: device,
+				}),
+			}
+		);
+		track(child);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => process.stdout.write(`[worker] ${chunk}`));
+		child.stderr.on("data", (chunk) => process.stderr.write(`[worker] ${chunk}`));
+		child.once("close", (code) => {
+			if (workerChild === child) workerChild = null;
+			if (code !== 0 && code !== null) console.error(`[bridge] generation worker exited with code ${code}`);
+		});
+		workerChild = child;
+
+		const deadline = Date.now() + WORKER_START_TIMEOUT_MS;
+		while (Date.now() < deadline) {
+			if (workerChild !== child) throw new Error("generation worker exited while starting");
+			if (await workerStatus()) return;
+			await new Promise((resolveSleep) => setTimeout(resolveSleep, WORKER_POLL_MS));
+		}
+		killGroup(child);
+		throw new Error(`generation worker did not answer on port ${WORKER_PORT} within ${WORKER_START_TIMEOUT_MS / 60000} minutes`);
+	}
+
+	// Best-effort: a broken worker must never block generation, because
+	// run-local.mjs degrades to a direct spawn on its own.
+	async function ensureWorker() {
+		if (await workerStatus()) {
+			armWorkerIdleShutdown();
+			return;
+		}
+		if (!workerStarting) {
+			workerStarting = startWorker().finally(() => {
+				workerStarting = null;
+			});
+		}
+		try {
+			await workerStarting;
+			armWorkerIdleShutdown();
+		} catch (err) {
+			console.error(`[bridge] generation worker unavailable, jobs will cold-spawn: ${err.message}`);
+		}
+	}
+
+	// Prewarm in the background at startup so even the FIRST generation of a
+	// session usually hits a warm model. Opt out with CCLAY_ARDY_PREWARM=0.
+	if (process.env.CCLAY_ARDY_PREWARM !== "0" && existsSync(VENV_PY)) {
+		ensureWorker();
+	}
+
+	// --- generation argv builders ------------------------------------------
+	// All three spawn run-local.mjs, whose stdout ends in
+	// "run-local: done - <path> (<bytes> bytes)" on success. The encoder is
+	// made ready first so the generator's TEXT_ENCODER_MODE=auto probe finds
+	// the warm service instead of cold-loading Llama in-process per request;
+	// the worker is made ready so the job skips the per-process model load.
+
+	function generatorEnv(cpu) {
+		return localEnv(cpu === true ? { CCLAY_ARDY_DEVICE: "cpu" } : {});
+	}
+
+	const DONE_RE = /^run-local: done - (.+) \((\d+) bytes\)$/;
+
+	// The worker carries its own in-process text encoder, so the separate
+	// gradio encoder service is only needed for jobs that bypass the worker
+	// (forced-CPU debugging, or the worker failing to start). Starting both
+	// would put two 16 GB Llama copies in memory on a 24 GB machine.
+	async function ensureBackends(cpu) {
+		if (cpu === true) {
+			await ensureEncoder();
+			return;
+		}
+		await ensureWorker();
+		if (await workerStatus()) return;
+		await ensureEncoder();
+	}
+
+	async function singleCommand({ poseFroms, prompt, durationS, seed, cpu, waypoints, output }) {
+		requireSetup();
+		await ensureBackends(cpu);
+		const args = [RUN_LOCAL, "single"];
+		for (const entry of poseFroms) {
+			args.push("--pose-from", entry.npz, String(entry.srcFrame), String(entry.dstFrame));
+		}
+		args.push("--prompt", prompt, "--duration", String(durationS));
+		if (Number.isInteger(seed)) args.push("--seed", String(seed));
+		for (const wp of waypoints || []) {
+			args.push("--root-2d", String(wp.frame), String(wp.x), String(wp.z), wp.heading === null ? "none" : String(wp.heading));
+		}
+		args.push("--output", output);
+		return { command: process.execPath, args, env: generatorEnv(cpu), doneRe: DONE_RE, label: "run-local" };
+	}
+
+	async function sequenceCommand({ segments, waypoints, seed, cpu, output }) {
+		requireSetup();
+		await ensureBackends(cpu);
+		const args = [RUN_LOCAL, "sequence"];
+		for (const segment of segments) {
+			args.push("--segment", segment.prompt, String(segment.durationS));
+		}
+		for (const wp of waypoints || []) {
+			args.push("--root-2d", String(wp.frame), String(wp.x), String(wp.z), wp.heading === null ? "none" : String(wp.heading));
+		}
+		if (Number.isInteger(seed)) args.push("--seed", String(seed));
+		args.push("--output", output);
+		return { command: process.execPath, args, env: generatorEnv(cpu), doneRe: DONE_RE, label: "run-local" };
+	}
+
+	async function editCommand({ source, manifest, prompt, contextBefore, contextAfter, seed, poseNpzPaths, output }) {
+		requireSetup();
+		await ensureBackends(false);
+		const args = [
+			RUN_LOCAL, "edit",
+			"--source", source,
+			"--manifest", manifest,
+			"--prompt", prompt,
+			"--context-before", String(contextBefore),
+			"--context-after", String(contextAfter),
+			"--output", output,
+		];
+		if (Number.isInteger(seed)) args.push("--seed", String(seed));
+		// The manifest references its poses as sibling pose-<i>.npz files, so
+		// run-local.mjs stages manifest + poses together in one temp dir (the
+		// local twin of run-edit-on-box.sh's scp layout).
+		for (const posePath of poseNpzPaths) args.push("--pose", posePath);
+		return { command: process.execPath, args, env: generatorEnv(false), doneRe: DONE_RE, label: "run-local" };
+	}
+
+	return {
+		mode: "local",
+		describe: () => `local ARDY at ${LOCAL_DIR} (venv ${VENV_PY}, encoder ${ENCODER_URL} lazy, weights ${ENCODERS_DIR})`,
+		probeHealth,
+		listBases,
+		singleCommand,
+		sequenceCommand,
+		editCommand,
+	};
+}

--- a/tools/ardy/runners/proc.mjs
+++ b/tools/ardy/runners/proc.mjs
@@ -1,0 +1,125 @@
+/**
+ * Shared child-process helpers for the ARDY bridge and its runners.
+ *
+ * Everything here is backend-agnostic: the same helpers drive an ssh session
+ * to a remote box and a local python process. All children spawned for
+ * generation are detached so they lead their own process group; killing the
+ * group takes down the whole tree (bash + ssh, or python + its workers), so
+ * nothing is orphaned.
+ */
+
+import { spawn } from "node:child_process";
+
+// Tracked globally so Ctrl-C can clean up in-flight children too.
+export const globalChildren = new Set();
+
+export function track(child) {
+	globalChildren.add(child);
+	child.once("close", () => globalChildren.delete(child));
+}
+
+export function killGroup(child) {
+	try {
+		process.kill(-child.pid, "SIGTERM");
+	} catch {
+		/* process group already gone */
+	}
+	// SIGKILL backup for anything that ignores SIGTERM; unref'd so it never
+	// keeps the bridge alive on its own.
+	const backup = setTimeout(() => {
+		try {
+			process.kill(-child.pid, "SIGKILL");
+		} catch {
+			/* gone */
+		}
+	}, 3000);
+	backup.unref();
+}
+
+// Run a short, non-streaming child (probes, listings) to completion.
+export function run(argv, { timeoutMs = 0 } = {}) {
+	return new Promise((resolvePromise, reject) => {
+		const child = spawn(argv[0], argv.slice(1), { stdio: ["ignore", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		let timer = null;
+		const finish = (err, code) => {
+			if (settled) return;
+			settled = true;
+			if (timer) clearTimeout(timer);
+			if (err) reject(err);
+			else resolvePromise({ code, stdout, stderr });
+		};
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.on("error", (err) => finish(err));
+		child.on("close", (code) => finish(null, code));
+		if (timeoutMs > 0) {
+			timer = setTimeout(() => {
+				try {
+					child.kill("SIGKILL");
+				} catch {
+					/* gone */
+				}
+				finish(new Error(`timed out after ${timeoutMs} ms`));
+			}, timeoutMs);
+		}
+	});
+}
+
+// Split a child's stdout/stderr into lines as they arrive; empty lines are
+// dropped. The trailing partial line is flushed on end so the generator's
+// last line is never lost.
+export function streamLines(stream, onLine) {
+	let buffer = "";
+	stream.setEncoding("utf8");
+	stream.on("data", (chunk) => {
+		buffer += chunk;
+		let idx;
+		while ((idx = buffer.indexOf("\n")) !== -1) {
+			const line = buffer.slice(0, idx).replace(/\r$/, "");
+			buffer = buffer.slice(idx + 1);
+			if (line) onLine(line);
+		}
+	});
+	stream.on("end", () => {
+		const rest = buffer.replace(/\r$/, "");
+		if (rest) onLine(rest);
+	});
+}
+
+// Resolves with the exit code; rejects when the child could not be started.
+export function runStreaming(child, onLine) {
+	return new Promise((resolvePromise, reject) => {
+		let settled = false;
+		const finish = (fn, value) => {
+			if (!settled) {
+				settled = true;
+				fn(value);
+			}
+		};
+		child.on("error", (err) => finish(reject, err));
+		child.on("close", (code) => finish(resolvePromise, code));
+		for (const [streamName, stream] of [
+			["stdout", child.stdout],
+			["stderr", child.stderr],
+		]) {
+			streamLines(stream, (line) => onLine(line, streamName));
+		}
+	});
+}
+
+export function lastLine(text) {
+	const lines = text
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+	return lines.length ? lines[lines.length - 1] : "";
+}

--- a/tools/ardy/runners/remote.mjs
+++ b/tools/ardy/runners/remote.mjs
@@ -1,0 +1,246 @@
+/**
+ * Remote (ssh) runner for the ARDY bridge.
+ *
+ * This is the original box-driven backend extracted verbatim from bridge.mjs:
+ * health and bases probes go over one ssh round trip each, reference dumps
+ * scp a python script to the box's /tmp, and generation shells out to the
+ * run-*-on-box.sh wrappers, which push inputs, run the generator remotely and
+ * pull the npz back.
+ *
+ * The runner interface (shared with runners/local.mjs) is deliberately small:
+ *
+ *   describe()                     one-line startup log
+ *   probeHealth()                  -> { ok:true, host, encoder, device } | throws
+ *   listBases()                    -> raw entries [{id, path, frames}] | throws
+ *   singleCommand(request)         -> { command, args, env, doneRe }
+ *   sequenceCommand(request)       -> { command, args, env, doneRe }
+ *   editCommand(request)           -> { command, args, env, doneRe }
+ *
+ * The bridge owns validation, caching, streaming and the motion allowlist;
+ * a runner only knows how to probe its backend and how to build the argv for
+ * one generation child whose stdout carries a `doneRe`-matching marker line
+ * (`<marker>: done - <path> (<bytes> bytes)`) on success.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { lastLine, run } from "./proc.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TOOLS_ARDY = join(HERE, "..");
+const RUN_ON_BOX = join(TOOLS_ARDY, "run-on-box.sh");
+const RUN_SEQUENCE_ON_BOX = join(TOOLS_ARDY, "run-sequence-on-box.sh");
+const RUN_EDIT_ON_BOX = join(TOOLS_ARDY, "run-edit-on-box.sh");
+
+// BatchMode: never hang on a password prompt. ConnectTimeout fails fast on a
+// dead host; ServerAlive* drops a wedged connection (same set run-on-box.sh
+// uses).
+const SSH_OPTS = [
+	"-o", "BatchMode=yes",
+	"-o", "ConnectTimeout=10",
+	"-o", "ServerAliveInterval=30",
+	"-o", "ServerAliveCountMax=240",
+];
+
+export function createRemoteRunner() {
+	// Same env var names as run-on-box.sh, so health, the bases listing and
+	// generation all talk to one operator-configured host/venv/encoder.
+	const HOST = process.env.CCLAY_ARDY_HOST?.trim() || "";
+	const REMOTE = process.env.CCLAY_ARDY_REPO || "$HOME/ardy"; // literal $HOME: the REMOTE shell expands it
+	const VENV_PY = process.env.CCLAY_ARDY_VENV || "~/ardy/.venv-cuda/bin/python"; // generator venv (tilde expands on the box)
+	const ENCODER_URL = process.env.CCLAY_ARDY_ENCODER_URL || "http://127.0.0.1:9550/";
+	// Numpy-only read paths (bases listing, reference dumps) use the CPU venv
+	// on purpose: the box's two venvs are NOT interchangeable, and this is the
+	// one the dump tooling is verified under.
+	const DUMP_PY = "~/ardy/.venv/bin/python";
+
+	if (!HOST) {
+		throw new Error("CCLAY_ARDY_HOST is required for the remote runner (for example: user@ardy-host)");
+	}
+
+	// Force the same box config onto the run-*-on-box.sh wrappers even when
+	// the bridge was started with different env values; they must not disagree.
+	function boxEnv() {
+		return {
+			...process.env,
+			CCLAY_ARDY_HOST: HOST,
+			CCLAY_ARDY_REPO: REMOTE,
+			CCLAY_ARDY_VENV: VENV_PY,
+			CCLAY_ARDY_ENCODER_URL: ENCODER_URL,
+		};
+	}
+
+	// One ssh round trip covers everything health needs: the host answering is
+	// the ssh call itself, then the encoder HTTP code and the device the
+	// generator venv would pick are read on the box with the same env the
+	// generator runs under. The device line mirrors run-on-box.sh's probe
+	// exactly, so what health reports is what the generation will use.
+	function healthRemoteCmd() {
+		return [
+			`ENC="$(curl -s -o /dev/null -w '%{http_code}' -m 10 ${ENCODER_URL})"`,
+			'[ -n "$ENC" ] || ENC="000"',
+			`DEV="$(cd ${REMOTE} && ${VENV_PY} -c 'import torch; print("cuda:0" if torch.cuda.is_available() else "cpu")')"`,
+			`printf 'encoder=%s\\ndevice=%s\\n' "$ENC" "$DEV"`,
+		].join(" && ");
+	}
+
+	async function probeHealth() {
+		const { code, stdout, stderr } = await run(
+			["ssh", ...SSH_OPTS, HOST, healthRemoteCmd()],
+			{ timeoutMs: 60_000 }
+		);
+		if (code !== 0) {
+			throw new Error(`ssh probe on ${HOST} failed (exit ${code}): ${lastLine(stderr)}`);
+		}
+		const fields = {};
+		for (const line of stdout.split("\n")) {
+			const match = /^(encoder|device)=(.*)$/.exec(line.trim());
+			if (match) fields[match[1]] = match[2];
+		}
+		if (!("encoder" in fields)) {
+			throw new Error(`encoder probe on ${HOST} produced no answer`);
+		}
+		if (fields.encoder !== "200") {
+			throw new Error(`text encoder at ${ENCODER_URL} answered ${fields.encoder}, not 200`);
+		}
+		if (!("device" in fields) || fields.device === "") {
+			const tail = lastLine(stderr);
+			throw new Error(
+				`device probe on ${HOST} produced no answer${tail ? `: ${tail}` : ""}`
+			);
+		}
+		if (!/^(cpu|cuda:\d+)$/.test(fields.device)) {
+			throw new Error(
+				`device probe on ${HOST} returned unexpected ${JSON.stringify(fields.device)}`
+			);
+		}
+		return { ok: true, host: HOST, encoder: Number(fields.encoder), device: fields.device };
+	}
+
+	// Frame counts come from a real load of each npz, in ONE ssh call: the
+	// script is fed to the box's python over a quoted heredoc (no local shell
+	// step), and entries that fail to load are skipped with a note on the box
+	// stderr instead of failing the whole listing.
+	function basesRemoteCmd() {
+		const script = [
+			"import glob, json, sys",
+			"import numpy as np",
+			"entries = []",
+			'for pattern in ("outputs/*.npz", "outputs/omb/*.npz"):',
+			"    for path in sorted(glob.glob(pattern)):",
+			"        try:",
+			'            data = np.load(path, allow_pickle=False)',
+			'            frames = int(data["posed_joints"].shape[0])',
+			"            data.close()",
+			"        except Exception as exc:",
+			'            print("bases: skipping %s: %s" % (path, exc), file=sys.stderr)',
+			"            continue",
+			'        entries.append({"id": path.rsplit("/", 1)[-1][:-4], "path": path, "frames": frames})',
+			"print(json.dumps(entries))",
+		].join("\n");
+		return `cd ${REMOTE} && ${DUMP_PY} - <<'COZYCLAY_PY_EOF'\n${script}\nCOZYCLAY_PY_EOF`;
+	}
+
+	async function listBases() {
+		const { code, stdout, stderr } = await run(
+			["ssh", ...SSH_OPTS, HOST, basesRemoteCmd()],
+			{ timeoutMs: 120_000 }
+		);
+		if (code !== 0) {
+			throw new Error(`bases listing on ${HOST} failed (exit ${code}): ${lastLine(stderr)}`);
+		}
+		let entries;
+		try {
+			entries = JSON.parse(stdout);
+		} catch (err) {
+			throw new Error(
+				`bases listing on ${HOST} did not parse as JSON: ${lastLine(stderr) || err.message}`
+			);
+		}
+		if (!Array.isArray(entries)) {
+			throw new Error(`bases listing on ${HOST} was not an array`);
+		}
+		return entries;
+	}
+
+	// --- generation argv builders -----------------------------------------
+	// Each returns what the bridge needs to spawn ONE child whose stdout ends
+	// in a done marker: pose/waypoint/free single runs, autoregressive
+	// sequence runs, and context-aware motion edits.
+
+	function singleCommand({ poseFroms, basePath, prompt, durationS, seed, cpu, waypoints, output }) {
+		const args = [RUN_ON_BOX];
+		for (const entry of poseFroms) {
+			args.push("--pose-from", entry.npz, String(entry.srcFrame), String(entry.dstFrame));
+		}
+		if (basePath) args.push("--base", basePath);
+		args.push("--prompt", prompt, "--duration", String(durationS));
+		if (Number.isInteger(seed)) args.push("--seed", String(seed));
+		if (cpu === true) args.push("--cpu");
+		for (const wp of waypoints || []) {
+			args.push("--root-2d", String(wp.frame), String(wp.x), String(wp.z), wp.heading === null ? "none" : String(wp.heading));
+		}
+		args.push("--output", output);
+		return {
+			command: "bash",
+			args,
+			env: boxEnv(),
+			doneRe: /^run-on-box: done - (.+) \((\d+) bytes\)$/,
+			label: "run-on-box",
+		};
+	}
+
+	function sequenceCommand({ segments, waypoints, seed, cpu, output }) {
+		const args = [RUN_SEQUENCE_ON_BOX];
+		for (const segment of segments) {
+			args.push("--segment", segment.prompt, String(segment.durationS));
+		}
+		// Root waypoints ride the same chained rollout (rollout-global frames):
+		// the sequence generator slices the constraint set per segment call, so
+		// a path and a prompt schedule coexist.
+		for (const wp of waypoints || []) {
+			args.push("--root-2d", String(wp.frame), String(wp.x), String(wp.z), wp.heading === null ? "none" : String(wp.heading));
+		}
+		if (Number.isInteger(seed)) args.push("--seed", String(seed));
+		if (cpu === true) args.push("--cpu");
+		args.push("--output", output);
+		return {
+			command: "bash",
+			args,
+			env: boxEnv(),
+			doneRe: /^run-sequence-on-box: done - (.+) \((\d+) bytes\)$/,
+			label: "run-sequence-on-box",
+		};
+	}
+
+	function editCommand({ source, manifest, prompt, contextBefore, contextAfter, seed, poseNpzPaths, output }) {
+		const args = [
+			RUN_EDIT_ON_BOX,
+			"--source", source,
+			"--manifest", manifest,
+			"--prompt", prompt,
+			"--context-before", String(contextBefore),
+			"--context-after", String(contextAfter),
+			"--output", output,
+		];
+		if (Number.isInteger(seed)) args.push("--seed", String(seed));
+		for (const posePath of poseNpzPaths) args.push("--pose", posePath);
+		return {
+			command: "bash",
+			args,
+			env: boxEnv(),
+			doneRe: /^run-edit-on-box: done - (.+) \((\d+) bytes\)$/,
+			label: "run-edit-on-box",
+		};
+	}
+
+	return {
+		mode: "remote",
+		describe: () => `box ${HOST} (repo ${REMOTE}, generator venv ${VENV_PY}, encoder ${ENCODER_URL})`,
+		probeHealth,
+		listBases,
+		singleCommand,
+		sequenceCommand,
+		editCommand,
+	};
+}

--- a/tools/ardy/setup-local.mjs
+++ b/tools/ardy/setup-local.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * setup-local.mjs - provision local ARDY motion generation for CozyClay.
+ *
+ *   node tools/ardy/setup-local.mjs [--skip-checkpoint] [--skip-encoder]
+ *
+ * Everything lands OUTSIDE this repo, in a per-user directory; the repo
+ * never contains model weights. All downloads come from their official
+ * sources, pinned or content-verified:
+ *
+ *   ~/.cozyclay/ardy            git clone of github.com/nv-tlabs/ardy
+ *                               (Apache-2.0) + a python venv with torch,
+ *                               ardy, gradio
+ *   HF hub cache                nvidia/ARDY-Core-RP-20FPS-Horizon40 motion
+ *                               checkpoint via huggingface_hub (NVIDIA Open
+ *                               Model License)
+ *   ~/.cozyclay/text-encoders   Llama-3-8B + LLM2Vec encoder stack from
+ *                               public, ungated mirrors, every shard
+ *                               SHA-256-verified (setup-text-encoder.py),
+ *                               then LoRA-merged in place
+ *                               (merge-text-encoder.py); ~16.4 GB, resumable
+ *
+ * Every step is idempotent: re-running verifies and fills gaps only.
+ * Overrides: CCLAY_ARDY_LOCAL_DIR, CCLAY_ARDY_ENCODERS_DIR, CCLAY_ARDY_PYTHON.
+ *
+ * torch note: `pip install torch` gives CUDA wheels on Linux and MPS wheels
+ * on Apple Silicon out of the box. On Windows, install a CUDA build first if
+ * you want GPU generation:
+ *   <venv>\Scripts\python -m pip install torch --index-url https://download.pytorch.org/whl/cu126
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ARDY_GIT_URL = "https://github.com/nv-tlabs/ardy.git";
+const ARDY_CHECKPOINT = "nvidia/ARDY-Core-RP-20FPS-Horizon40";
+const LOCAL_DIR = process.env.CCLAY_ARDY_LOCAL_DIR || join(homedir(), ".cozyclay", "ardy");
+const ENCODERS_DIR = process.env.CCLAY_ARDY_ENCODERS_DIR || join(homedir(), ".cozyclay", "text-encoders");
+const IS_WIN = process.platform === "win32";
+const VENV_DIR = join(LOCAL_DIR, ".venv");
+const VENV_PY = join(VENV_DIR, IS_WIN ? "Scripts\\python.exe" : "bin/python");
+
+const skipCheckpoint = process.argv.includes("--skip-checkpoint");
+const skipEncoder = process.argv.includes("--skip-encoder");
+
+function log(message) {
+	console.log(`setup-local: ${message}`);
+}
+
+function die(message) {
+	console.error(`setup-local: ${message}`);
+	process.exit(1);
+}
+
+// Run a step to completion with output visible; die with context on failure.
+function run(label, argv, options = {}) {
+	log(label);
+	const result = spawnSync(argv[0], argv.slice(1), { stdio: "inherit", ...options });
+	if (result.error) die(`${label} failed: ${result.error.message}`);
+	if (result.status !== 0) die(`${label} failed (exit ${result.status})`);
+}
+
+function probe(argv) {
+	const result = spawnSync(argv[0], argv.slice(1), { encoding: "utf8" });
+	return result.status === 0 ? (result.stdout || "").trim() : null;
+}
+
+// --- prerequisites ----------------------------------------------------------
+
+if (!probe(["git", "--version"])) die("git is required (https://git-scm.com)");
+if (!probe(["cmake", "--version"])) {
+	die(
+		"cmake is required to build ARDY's motion-correction extension.\n" +
+			"  macOS:  brew install cmake\n" +
+			"  Linux:  apt/dnf install cmake\n" +
+			"  Windows: winget install Kitware.CMake"
+	);
+}
+
+// Python 3.10+ — ARDY's floor. Prefer an explicit override, then the newest
+// commonly-installed minor, then the bare python3.
+function findPython() {
+	const candidates = process.env.CCLAY_ARDY_PYTHON
+		? [process.env.CCLAY_ARDY_PYTHON]
+		: ["python3.12", "python3.11", "python3.10", "python3", "python"];
+	for (const candidate of candidates) {
+		const version = probe([candidate, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"]);
+		if (!version) continue;
+		const [major, minor] = version.split(".").map(Number);
+		if (major === 3 && minor >= 10) return { python: candidate, version };
+	}
+	return null;
+}
+
+const found = findPython();
+if (!found) {
+	die(
+		"python 3.10+ not found (ARDY requires >=3.10).\n" +
+			"  install one (e.g. `brew install python@3.12` / `uv python install 3.12`)\n" +
+			"  or point CCLAY_ARDY_PYTHON at an interpreter"
+	);
+}
+log(`using ${found.python} (${found.version})`);
+
+// --- ARDY checkout + venv ----------------------------------------------------
+
+if (existsSync(join(LOCAL_DIR, "pyproject.toml"))) {
+	log(`ARDY checkout already present at ${LOCAL_DIR}`);
+} else if (existsSync(LOCAL_DIR)) {
+	die(`${LOCAL_DIR} exists but is not an ARDY checkout; move it aside or set CCLAY_ARDY_LOCAL_DIR`);
+} else {
+	run(`cloning ${ARDY_GIT_URL} -> ${LOCAL_DIR}`, ["git", "clone", "--depth", "1", ARDY_GIT_URL, LOCAL_DIR]);
+}
+
+if (existsSync(VENV_PY)) {
+	log(`venv already present at ${VENV_DIR}`);
+} else {
+	run(`creating venv at ${VENV_DIR}`, [found.python, "-m", "venv", VENV_DIR]);
+}
+
+function pipHas(module) {
+	return probe([VENV_PY, "-c", `import ${module}`]) !== null;
+}
+
+run("upgrading pip", [VENV_PY, "-m", "pip", "install", "--quiet", "--upgrade", "pip"]);
+if (pipHas("torch")) {
+	log("torch already installed");
+} else {
+	// Default wheels: CUDA on Linux, MPS on Apple Silicon, CPU on Windows
+	// (see the header for the Windows CUDA index-url).
+	run("installing torch (this downloads a large wheel)", [VENV_PY, "-m", "pip", "install", "torch"]);
+}
+if (pipHas("ardy")) {
+	log("ardy package already installed");
+} else {
+	// Core only — never [all]: the trt extra is Linux/CUDA-only and the demo
+	// extra is not needed for generation. The C++ extension builds here
+	// (cmake); it may fetch pybind11/Eigen/sse2neon from their upstreams.
+	run("installing ARDY into the venv (builds a small C++ extension)", [
+		VENV_PY, "-m", "pip", "install", "-e", LOCAL_DIR,
+	]);
+}
+if (pipHas("gradio")) {
+	log("gradio already installed");
+} else {
+	// Only the text-encoder *server* needs gradio; the generator's client side
+	// (gradio_client) is an ARDY core dependency already.
+	run("installing gradio (text-encoder service)", [VENV_PY, "-m", "pip", "install", "gradio"]);
+}
+
+// --- ARDY motion checkpoint (HF hub, auto-cached) ----------------------------
+
+if (skipCheckpoint) {
+	log("skipping motion checkpoint download (--skip-checkpoint)");
+} else {
+	run(`fetching motion checkpoint ${ARDY_CHECKPOINT} into the HF cache`, [
+		VENV_PY,
+		"-c",
+		[
+			"from huggingface_hub import snapshot_download",
+			`path = snapshot_download(repo_id=${JSON.stringify(ARDY_CHECKPOINT)})`,
+			"print('checkpoint at', path)",
+		].join("\n"),
+	]);
+}
+
+// --- text-encoder weights (public mirrors, SHA-256 pinned) -------------------
+
+if (skipEncoder) {
+	log("skipping text-encoder weights (--skip-encoder)");
+} else {
+	run(`downloading/verifying encoder stack under ${ENCODERS_DIR} (~16.4 GB, resumable)`, [
+		VENV_PY, join(HERE, "setup-text-encoder.py"), "--dest", ENCODERS_DIR,
+	]);
+	// Bake the MNTP LoRA into a full model (idempotent via MERGE_MANIFEST):
+	// transformers v5 cannot chase adapter dirs the way ARDY's loader expects.
+	run("merging MNTP LoRA into the base weights (one-time, needs RAM)", [
+		VENV_PY, join(HERE, "merge-text-encoder.py"), "--dest", ENCODERS_DIR,
+	], { cwd: LOCAL_DIR });
+}
+
+log("done. start CozyClay with `npm run dev` — the bridge auto-selects local mode");
+log(`  ARDY:     ${LOCAL_DIR}`);
+log(`  encoder:  ${ENCODERS_DIR} (lazy service on first generation)`);
+log("  remote box users: CCLAY_ARDY_HOST keeps selecting the ssh backend");


### PR DESCRIPTION
Closes #7, closes #8, closes #9.

## What

Motion generation now runs locally with zero configuration — the ssh box becomes optional. `bridge.mjs` keeps its exact HTTP contract and delegates to a runner boundary (`tools/ardy/runners/`): `remote.mjs` is the original ssh flow extracted verbatim (selected whenever `CCLAY_ARDY_HOST` is set, byte-for-byte behavior), `local.mjs` generates on this machine through a persistent warm worker. Ripping local mode back out later = deleting `runners/local.mjs`, `run-local.mjs`, `cclay_worker.py`, `cclay_constrained_generate.py`, `setup-local.mjs`.

- `npm run ardy:setup`: one-command provisioning into `~/.cozyclay/` — ARDY checkout (Apache-2.0), venv + torch, `nvidia/ARDY-Core-RP-20FPS-Horizon40` from HF, SHA-pinned ungated encoder stack via the existing setup scripts. No weights in the repo.
- Generators pick `cuda > mps > cpu` (`CCLAY_ARDY_DEVICE` override), stream `sampling step N/M` progress to the UI, and take `main(argv, preloaded_model)` so the worker can inject a warm model without forking the code path.
- Persistent worker: model loaded once, kernels prewarmed, in-process text encoder held on the GPU as fp16 (NaN-guarded bf16 fallback), per-prompt embedding disk cache. Falls back to a direct spawn when absent.
- Fixes shipped bugs: `cclay_motion_edit.py` IndentationError (#7), `npm run dev` dying without `CCLAY_ARDY_HOST`, dead `ensureReference` path removed.

## Measured (Apple M5 Pro, mps, 3 s clip)

| scenario | before | after |
|---|---|---|
| same-prompt regeneration (new seed/pins/path) | ~160 s | **0.4 s** |
| new prompt | ~160 s | 3–18 s (up to ~50 s under memory pressure) |
| session prewarm (background) | per request | once, ~90 s |

## Verified

Free / waypoint (3.5 cm error at a 2 m pin) / 2-segment sequence generation end-to-end through the bridge, decoded with the browser npz reader; `test:ardy` suite passing (verify-sequence-bridge structure assertions updated for the runner boundary; `verify-npz` still needs a box, unchanged). The motionEdit flow is implemented and now parseable but was not exercised end-to-end (needs authored IK keys from the UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)