### PR TITLE
docs(mcp): add the missing npm install step to the verify instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ See [`tools/ardy/README.md`](tools/ardy/README.md) for details. This workflow is
 | `npm run test:theme` / `test:appearance` / `test:layout` | UI theme, appearance, layout |
 | `npm run test:lifecycle` | Dev-server process lifecycle |
 | `npm run test:ardy` | ARDY conversion, playback, and IK pipeline |
-| `cd mcp && npm run verify` | MCP server over real stdio — all 420 framing combinations |
-| `cd mcp && npm run verify:live` | Live-control protocol against a fake editor |
+| `cd mcp && npm install && npm run verify` | MCP server over real stdio — all 420 framing combinations |
+| `cd mcp && npm run verify:live` | Live-control protocol against a fake editor (same `npm install` first) |
 | `npm run build` | Production build |
 
 Ad-hoc browser QA, while a dev server is available:


### PR DESCRIPTION
Fixes #25.

The Validate table's `cd mcp && npm run verify` crashes on a fresh clone with `ERR_MODULE_NOT_FOUND`: `mcp/` is its own npm tree and the root `npm install` does not populate it. The row now reads `cd mcp && npm install && npm run verify`, and the `verify:live` row notes it needs the same install. `mcp/README.md` already documented the install step, so it is untouched.

Verified on a fresh worktree: the documented command as now written ends with `420 framing combinations checked / all checks passed`.
