### PR TITLE
fix(dev): derive the bridge port from the main port and fail loudly on conflicts

### DIFF
--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -8,7 +8,7 @@
  * `dist/`, so this launcher only has to
  *
  *   - serve those files over loopback,
- *   - forward /ardy to the sidecar on 5181 (the job Vite's dev proxy does),
+ *   - forward /ardy to its dynamically selected sidecar port (the job Vite's dev proxy does),
  *   - keep the sidecar's lifetime tied to this process.
  *
  * It has no dependencies on purpose. A launcher that needs an install step
@@ -17,6 +17,7 @@
 import { spawn } from "node:child_process";
 import { createReadStream, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, request as httpRequest } from "node:http";
+import { createConnection, createServer as createNetServer } from "node:net";
 import { homedir } from "node:os";
 import { extname, join, normalize, resolve } from "node:path";
 import { createInterface } from "node:readline";
@@ -25,7 +26,7 @@ import { fileURLToPath } from "node:url";
 const PKG_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const DIST = join(PKG_ROOT, "dist");
 const BRIDGE = join(PKG_ROOT, "tools", "ardy", "bridge.mjs");
-const BRIDGE_PORT = Number(process.env.COZYCLAY_BRIDGE_PORT ?? 5181);
+let bridgePort = 5181;
 
 const TYPES = {
 	".html": "text/html; charset=utf-8",
@@ -105,7 +106,7 @@ function serveFile(res, path) {
 // browser code needs no build-time knowledge of how it was launched.
 function proxyToBridge(req, res) {
 	const upstream = httpRequest(
-		{ host: "127.0.0.1", port: BRIDGE_PORT, path: req.url, method: req.method, headers: req.headers },
+		{ host: "127.0.0.1", port: bridgePort, path: req.url, method: req.method, headers: req.headers },
 		(upstreamRes) => {
 			res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
 			upstreamRes.pipe(res);
@@ -118,6 +119,63 @@ function proxyToBridge(req, res) {
 		res.end(JSON.stringify({ error: "ardy sidecar is not running" }));
 	});
 	req.pipe(upstream);
+}
+
+function canListen(port) {
+	return new Promise((resolvePromise) => {
+		const candidate = createNetServer();
+		candidate.once("error", () => resolvePromise(false));
+		candidate.listen(port, "127.0.0.1", () => candidate.close(() => resolvePromise(true)));
+	});
+}
+
+async function selectBridgePort(mainPort) {
+	if (process.env.COZYCLAY_BRIDGE_PORT !== undefined) {
+		const port = Number(process.env.COZYCLAY_BRIDGE_PORT);
+		if (!Number.isInteger(port) || port < 1 || port > 65535) {
+			throw new Error(`COZYCLAY_BRIDGE_PORT=${JSON.stringify(process.env.COZYCLAY_BRIDGE_PORT)} is not a valid port`);
+		}
+		if (!(await canListen(port))) {
+			throw new Error(`COZYCLAY_BRIDGE_PORT=${port} is already in use; choose another COZYCLAY_BRIDGE_PORT`);
+		}
+		return port;
+	}
+	for (let port = mainPort + 1; port <= 65535; port += 1) {
+		if (await canListen(port)) return port;
+	}
+	throw new Error(`no free bridge port is available at or above ${mainPort + 1}`);
+}
+
+function waitForBridge(child, port) {
+	return new Promise((resolvePromise, reject) => {
+		let retry;
+		let settled = false;
+		const finish = (callback, value) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			clearTimeout(retry);
+			child.off("exit", onExit);
+			callback(value);
+		};
+		const fail = (detail) => finish(reject, new Error(`ARDY bridge on 127.0.0.1:${port} ${detail}`));
+		const onExit = (code, signal) => fail(`exited ${signal ? `from ${signal}` : `with code ${code ?? 0}`}`);
+		const timeout = setTimeout(() => fail("did not listen within 5000 ms"), 5000);
+		const probe = () => {
+			if (settled) return;
+			const socket = createConnection({ host: "127.0.0.1", port });
+			socket.once("connect", () => {
+				socket.destroy();
+				finish(resolvePromise);
+			});
+			socket.once("error", () => {
+				socket.destroy();
+				if (!settled) retry = setTimeout(probe, 25);
+			});
+		};
+		child.once("exit", onExit);
+		probe();
+	});
 }
 
 function readState() {
@@ -255,10 +313,20 @@ if (!existsSync(join(DIST, "app", "index.html"))) {
 const ardyHost = process.env.CCLAY_ARDY_HOST?.trim();
 let bridge = null;
 if (opts.ardy && ardyHost && existsSync(BRIDGE)) {
-	bridge = spawn(process.execPath, [BRIDGE], { cwd: PKG_ROOT, stdio: "inherit" });
-	bridge.on("error", () => {
-		bridge = null;
-	});
+	try {
+		bridgePort = await selectBridgePort(opts.port);
+		bridge = spawn(process.execPath, [BRIDGE], {
+			cwd: PKG_ROOT,
+			stdio: "inherit",
+			env: { ...process.env, COZYCLAY_BRIDGE_PORT: String(bridgePort) },
+		});
+		await waitForBridge(bridge, bridgePort);
+	} catch (err) {
+		console.error(`cozyclay: motion generation sidecar failed: ${err.message}`);
+		console.error("cozyclay: studio did not start; set COZYCLAY_BRIDGE_PORT to an available port or use --no-ardy.");
+		if (bridge) bridge.kill("SIGTERM");
+		process.exit(1);
+	}
 }
 
 const server = createServer((req, res) => {
@@ -311,7 +379,7 @@ process.on("SIGTERM", shutdown);
 
 server.on("error", (err) => {
 	if (err && err.code === "EADDRINUSE") {
-		console.error(`cozyclay: port ${opts.port} is taken. Try --port ${opts.port + 1}.`);
+		console.error(`cozyclay: port ${opts.port} is taken. Try --port 5200.`);
 		if (bridge) bridge.kill("SIGTERM");
 		process.exit(1);
 	}

--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -15,9 +15,9 @@
  * before it can serve a prebuilt app is a launcher that will break.
  */
 import { spawn } from "node:child_process";
+import { startBridge, terminateOwned } from "../tools/process-supervisor.mjs";
 import { createReadStream, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, request as httpRequest } from "node:http";
-import { createConnection, createServer as createNetServer } from "node:net";
 import { homedir } from "node:os";
 import { extname, join, normalize, resolve } from "node:path";
 import { createInterface } from "node:readline";
@@ -119,63 +119,6 @@ function proxyToBridge(req, res) {
 		res.end(JSON.stringify({ error: "ardy sidecar is not running" }));
 	});
 	req.pipe(upstream);
-}
-
-function canListen(port) {
-	return new Promise((resolvePromise) => {
-		const candidate = createNetServer();
-		candidate.once("error", () => resolvePromise(false));
-		candidate.listen(port, "127.0.0.1", () => candidate.close(() => resolvePromise(true)));
-	});
-}
-
-async function selectBridgePort(mainPort) {
-	if (process.env.COZYCLAY_BRIDGE_PORT !== undefined) {
-		const port = Number(process.env.COZYCLAY_BRIDGE_PORT);
-		if (!Number.isInteger(port) || port < 1 || port > 65535) {
-			throw new Error(`COZYCLAY_BRIDGE_PORT=${JSON.stringify(process.env.COZYCLAY_BRIDGE_PORT)} is not a valid port`);
-		}
-		if (!(await canListen(port))) {
-			throw new Error(`COZYCLAY_BRIDGE_PORT=${port} is already in use; choose another COZYCLAY_BRIDGE_PORT`);
-		}
-		return port;
-	}
-	for (let port = mainPort + 1; port <= 65535; port += 1) {
-		if (await canListen(port)) return port;
-	}
-	throw new Error(`no free bridge port is available at or above ${mainPort + 1}`);
-}
-
-function waitForBridge(child, port) {
-	return new Promise((resolvePromise, reject) => {
-		let retry;
-		let settled = false;
-		const finish = (callback, value) => {
-			if (settled) return;
-			settled = true;
-			clearTimeout(timeout);
-			clearTimeout(retry);
-			child.off("exit", onExit);
-			callback(value);
-		};
-		const fail = (detail) => finish(reject, new Error(`ARDY bridge on 127.0.0.1:${port} ${detail}`));
-		const onExit = (code, signal) => fail(`exited ${signal ? `from ${signal}` : `with code ${code ?? 0}`}`);
-		const timeout = setTimeout(() => fail("did not listen within 5000 ms"), 5000);
-		const probe = () => {
-			if (settled) return;
-			const socket = createConnection({ host: "127.0.0.1", port });
-			socket.once("connect", () => {
-				socket.destroy();
-				finish(resolvePromise);
-			});
-			socket.once("error", () => {
-				socket.destroy();
-				if (!settled) retry = setTimeout(probe, 25);
-			});
-		};
-		child.once("exit", onExit);
-		probe();
-	});
 }
 
 function readState() {
@@ -312,24 +255,57 @@ if (!existsSync(join(DIST, "app", "index.html"))) {
 // cannot act on. An unset CCLAY_ARDY_HOST is the normal case, not a fault.
 const ardyHost = process.env.CCLAY_ARDY_HOST?.trim();
 let bridge = null;
+let server = null;
+const startedAt = Date.now();
+let shuttingDown = false;
+async function shutdown(exitCode = 0) {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	if (bridge) await terminateOwned(bridge);
+	if (server?.listening) await new Promise((resolvePromise) => server.close(() => resolvePromise()));
+	try {
+		await maybeAskForStar(startedAt, opts);
+	} catch {
+		/* never let the goodbye prompt hold the process hostage */
+	}
+	process.exit(exitCode);
+}
+process.on("SIGINT", () => shutdown(130));
+process.on("SIGTERM", () => shutdown(143));
+
 if (opts.ardy && ardyHost && existsSync(BRIDGE)) {
 	try {
-		bridgePort = await selectBridgePort(opts.port);
-		bridge = spawn(process.execPath, [BRIDGE], {
+		({ child: bridge, port: bridgePort } = await startBridge({
+			command: process.execPath,
+			args: [BRIDGE],
 			cwd: PKG_ROOT,
-			stdio: "inherit",
-			env: { ...process.env, COZYCLAY_BRIDGE_PORT: String(bridgePort) },
-		});
-		await waitForBridge(bridge, bridgePort);
+			env: process.env,
+			mainPort: opts.port,
+			onSpawn: (child) => {
+				bridge = child;
+			},
+			onReady: (child) => {
+				child.once("exit", (code, signal) => {
+					if (shuttingDown) return;
+					console.error(`cozyclay: motion generation sidecar exited ${signal ? `from ${signal}` : `with code ${code ?? 0}`}.`);
+					void shutdown(1);
+				});
+				child.once("error", (err) => {
+					if (shuttingDown) return;
+					console.error(`cozyclay: motion generation sidecar failed: ${err.message}`);
+					void shutdown(1);
+				});
+			},
+		}));
 	} catch (err) {
 		console.error(`cozyclay: motion generation sidecar failed: ${err.message}`);
 		console.error("cozyclay: studio did not start; set COZYCLAY_BRIDGE_PORT to an available port or use --no-ardy.");
-		if (bridge) bridge.kill("SIGTERM");
+		if (bridge) await terminateOwned(bridge);
 		process.exit(1);
 	}
 }
 
-const server = createServer((req, res) => {
+server = createServer((req, res) => {
 	const url = new URL(req.url ?? "/", "http://localhost");
 	// Only the routes the bridge actually owns: /ardy/ is ALSO a public asset
 	// directory (cskel27-rest.json), and those files live in dist/, not behind
@@ -360,33 +336,16 @@ const server = createServer((req, res) => {
 	serveFile(res, target);
 });
 
-const startedAt = Date.now();
-let shuttingDown = false;
-async function shutdown() {
-	if (shuttingDown) process.exit(0);
-	shuttingDown = true;
-	if (bridge) bridge.kill("SIGTERM");
-	server.close();
-	try {
-		await maybeAskForStar(startedAt, opts);
-	} catch {
-		/* never let the goodbye prompt hold the process hostage */
-	}
-	process.exit(0);
-}
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-
 server.on("error", (err) => {
 	if (err && err.code === "EADDRINUSE") {
 		console.error(`cozyclay: port ${opts.port} is taken. Try --port 5200.`);
-		if (bridge) bridge.kill("SIGTERM");
-		process.exit(1);
+		void shutdown(1);
+		return;
 	}
 	throw err;
 });
 
-server.listen(opts.port, opts.host, () => {
+server.listen({ port: opts.port, host: opts.host, ipv6Only: false }, () => {
 	// The package exists to open the studio, which the site serves from /app/.
 	// Landing on "/" would greet someone who just typed `npx cozyclay` with a
 	// marketing page.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "node tools/dev-full.mjs --host 127.0.0.1 --port 5180",
     "dev:ui": "vite",
     "build": "vite build && cp -r public/fonts dist/",
-    "test:lifecycle": "node test/process/verify-lifecycle.mjs",
+    "test:lifecycle": "node test/process/verify-lifecycle.mjs && node test/process/verify-bridge-launch.mjs",
     "test:hierarchy": "node test/verify-hierarchy.mjs",
     "test:history": "node test/verify-history.mjs",
     "test:scene-objects": "node test/verify-scene-objects.mjs",

--- a/test/process/verify-bridge-launch.mjs
+++ b/test/process/verify-bridge-launch.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFile, fork } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { promisify } from "node:util";
+import { spawnOwned, terminateOwned } from "../../tools/process-supervisor.mjs";
+
+const execFileAsync = promisify(execFile);
+const REPO = new URL("../..", import.meta.url);
+const BRIDGE = "tools/ardy/bridge.mjs";
+const READY_TIMEOUT_MS = 5_000;
+
+function withTimeout(promise, label) {
+	let timer;
+	return Promise.race([
+		promise,
+		new Promise((_, reject) => {
+			timer = setTimeout(() => reject(new Error(`${label} did not happen within ${READY_TIMEOUT_MS} ms`)), READY_TIMEOUT_MS);
+		}),
+	]).finally(() => clearTimeout(timer));
+}
+
+function listen(server, port = 0) {
+	return new Promise((resolvePromise, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolvePromise(server.address().port);
+		});
+	});
+}
+
+function close(server) {
+	return new Promise((resolvePromise, reject) => server.close((error) => (error ? reject(error) : resolvePromise())));
+}
+
+function waitForExit(child, label) {
+	return withTimeout(once(child, "exit"), label);
+}
+
+async function listenerPids(port) {
+	try {
+		const { stdout } = await execFileAsync("lsof", ["-t", "-nP", `-iTCP:${port}`, "-sTCP:LISTEN"]);
+		return stdout
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map(Number);
+	} catch (error) {
+		if (error.code === 1) return [];
+		throw error;
+	}
+}
+
+async function reserveMainAndAdjacentPort() {
+	for (;;) {
+		const main = createServer();
+		const mainPort = await listen(main);
+		if (mainPort >= 65_534) {
+			await close(main);
+			continue;
+		}
+		const adjacent = createServer();
+		try {
+			await listen(adjacent, mainPort + 1);
+			await close(main);
+			return { mainPort, adjacent };
+		} catch {
+			await close(main);
+		}
+	}
+}
+
+function createOutputWatcher(child) {
+	let output = "";
+	const waiters = [];
+	const append = (chunk) => {
+		output += chunk.toString();
+		for (const waiter of waiters.splice(0)) waiter();
+	};
+	child.stdout.on("data", append);
+	child.stderr.on("data", append);
+	return {
+		all: () => output,
+		waitFor(pattern, label) {
+			return withTimeout(
+				new Promise((resolvePromise) => {
+					const check = () => {
+						const match = pattern.exec(output);
+						if (match) resolvePromise(match);
+						else waiters.push(check);
+					};
+					check();
+				}),
+				label,
+			);
+		},
+	};
+}
+
+function launcherSpec(kind, port, env) {
+	if (kind === "dev") {
+		return {
+			args: ["tools/dev-full.mjs", "--host", "127.0.0.1", "--port", String(port)],
+			env,
+		};
+	}
+	return {
+		args: ["bin/cozyclay.mjs", "--host", "127.0.0.1", "--port", String(port), "--no-open", "--no-star"],
+		env: { ...env, CCLAY_ARDY_HOST: "test@ardy" },
+	};
+}
+
+function launch(kind, port, env = {}) {
+	const spec = launcherSpec(kind, port, { ...process.env, ...env });
+	const child = spawnOwned(process.execPath, spec.args, {
+		cwd: REPO,
+		env: spec.env,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	return { child, output: createOutputWatcher(child) };
+}
+
+async function expectLaunchFailure(kind, env, expected) {
+	const reservation = createServer();
+	const port = await listen(reservation);
+	await close(reservation);
+	const { child, output } = launch(kind, port, env);
+	await waitForExit(child, `${kind} invalid bridge launch`);
+	assert.match(output.all(), expected, `${kind} reports the bridge-port failure clearly`);
+}
+
+async function expectBridgeIpcReadiness() {
+	const reservation = createServer();
+	const port = await listen(reservation);
+	await close(reservation);
+	const child = fork(BRIDGE, [], {
+		cwd: REPO,
+		env: { ...process.env, CCLAY_ARDY_MODE: "remote", CCLAY_ARDY_HOST: "test@ardy", COZYCLAY_BRIDGE_PORT: String(port) },
+		stdio: ["ignore", "ignore", "ignore", "ipc"],
+		detached: true,
+	});
+	try {
+		const [message] = await withTimeout(once(child, "message"), "bridge child readiness IPC");
+		assert.deepEqual(message, { type: "cozyclay-bridge-ready", port }, "bridge identifies itself through IPC after listen");
+	} finally {
+		await terminateOwned(child);
+	}
+}
+
+async function expectForeignListenerDoesNotReportBridgeReady() {
+	const foreign = createServer();
+	const port = await listen(foreign);
+	const child = fork(BRIDGE, [], {
+		cwd: REPO,
+		env: { ...process.env, CCLAY_ARDY_MODE: "remote", CCLAY_ARDY_HOST: "test@ardy", COZYCLAY_BRIDGE_PORT: String(port) },
+		stdio: ["ignore", "ignore", "ignore", "ipc"],
+		detached: true,
+	});
+	try {
+		const [message] = await withTimeout(once(child, "message"), "bridge child listen-failure IPC");
+		assert.deepEqual(
+			message,
+			{ type: "cozyclay-bridge-listen-error", port, code: "EADDRINUSE" },
+			"a foreign listener cannot satisfy bridge readiness",
+		);
+		await waitForExit(child, "bridge child after listen failure");
+	} finally {
+		await terminateOwned(child);
+		await close(foreign);
+	}
+}
+
+async function expectLifecycle(kind) {
+	const { mainPort, adjacent } = await reserveMainAndAdjacentPort();
+	const bridgePort = mainPort + 2;
+	const { child, output } = launch(kind, mainPort, { CCLAY_ARDY_MODE: "remote" });
+	try {
+		const ready = await output.waitFor(/ARDY dev bridge listening on http:\/\/127\.0\.0\.1:(\d+)/, `${kind} bridge readiness`);
+		assert.equal(Number(ready[1]), bridgePort, `${kind} skips occupied main + 1`);
+		const bridgePids = await listenerPids(bridgePort);
+		assert.equal(bridgePids.length, 1, `${kind} bridge owns the selected port`);
+
+		const [bridgePid] = bridgePids;
+		assert.ok(bridgePid, `${kind} bridge is listening before unexpected exit`);
+		const parentExit = waitForExit(child, `${kind} parent after bridge exit`);
+		process.kill(bridgePid, "SIGTERM");
+		const [code, signal] = await parentExit;
+		assert.ok(code !== 0 || signal, `${kind} parent fails when its bridge exits unexpectedly`);
+		assert.deepEqual(await listenerPids(bridgePort), [], `${kind} unexpected bridge exit leaves no listener`);
+	} finally {
+		await terminateOwned(child);
+		await close(adjacent);
+	}
+
+	const clean = await reserveMainAndAdjacentPort();
+	const cleanupPort = clean.mainPort + 2;
+	const next = launch(kind, clean.mainPort, { CCLAY_ARDY_MODE: "remote" });
+	try {
+		const ready = await next.output.waitFor(/ARDY dev bridge listening on http:\/\/127\.0\.0\.1:(\d+)/, `${kind} cleanup bridge readiness`);
+		assert.equal(Number(ready[1]), cleanupPort, `${kind} uses the expected cleanup bridge port`);
+		await terminateOwned(next.child);
+		assert.deepEqual(await listenerPids(cleanupPort), [], `${kind} parent termination leaves no bridge listener`);
+	} finally {
+		await terminateOwned(next.child);
+		await close(clean.adjacent);
+	}
+}
+
+await expectBridgeIpcReadiness();
+await expectForeignListenerDoesNotReportBridgeReady();
+for (const kind of ["dev", "package"]) {
+	await expectLaunchFailure(kind, { COZYCLAY_BRIDGE_PORT: "invalid", CCLAY_ARDY_MODE: "remote" }, /COZYCLAY_BRIDGE_PORT=.*not a valid port/);
+	const occupied = createServer();
+	const port = await listen(occupied);
+	try {
+		await expectLaunchFailure(kind, { COZYCLAY_BRIDGE_PORT: String(port), CCLAY_ARDY_MODE: "remote" }, /COZYCLAY_BRIDGE_PORT=.*already in use/);
+	} finally {
+		await close(occupied);
+	}
+	await expectLifecycle(kind);
+}
+
+console.log("all bridge launch checks PASS");

--- a/tools/ardy/BRIDGE.md
+++ b/tools/ardy/BRIDGE.md
@@ -7,8 +7,10 @@ app.
 CozyClay stays a static SPA: `vite build` emits a `dist/` that serves from
 anywhere with no server. The box work — pose → npz conversion and the remote
 constrained generation — cannot run in a browser, so the bridge exposes it as
-four HTTP endpoints on **127.0.0.1:5181** and the Vite dev server proxies
-`/ardy` to it. The bridge is **optional and dev-only**: when it is not
+four HTTP endpoints on loopback and the Vite dev server proxies `/ardy` to it.
+`npm run dev` derives the bridge port from its main port (`main + 1`) and scans
+upward when needed; standalone use defaults to **127.0.0.1:5181**. The bridge
+is **optional and dev-only**: when it is not
 running, the app works exactly as before with the generate affordance visibly
 unavailable, and the production build never depends on it.
 
@@ -93,7 +95,7 @@ configured by the operator:
 
 | env | default | meaning |
 | --- | --- | --- |
-| `COZYCLAY_BRIDGE_PORT` | `5181` | listen port (loopback only) |
+| `COZYCLAY_BRIDGE_PORT` | `5181` standalone; `main + 1` for launchers | listen port (loopback only; explicit override) |
 | `CCLAY_ARDY_HOST` | required | ssh destination for the ARDY host |
 | `CCLAY_ARDY_REPO` | `$HOME/ardy` | ARDY checkout on the box |
 | `CCLAY_ARDY_VENV` | `~/ardy/.venv-cuda/bin/python` | generator venv python on the box |
@@ -318,5 +320,6 @@ interface, indistinguishable from a legitimate local call. The CozyClay UI
   `tools/ardy/dump-npz.py`, `src/ardy/*` and `test/ardy/*` are the verified,
   reusable pieces; the bridge calls them, never reimplements them.
 - The Vite dev server (`vite.config.js`) proxies `/ardy` to
-  `127.0.0.1:5181`; the production `dist/` build contains no proxy, no
-  server code, and no dependency on the bridge.
+  `COZYCLAY_BRIDGE_PORT` when set (otherwise its existing explicit bridge URL
+  or `127.0.0.1:5181` fallback); the production `dist/` build contains no
+  proxy, no server code, and no dependency on the bridge.

--- a/tools/ardy/bridge.mjs
+++ b/tools/ardy/bridge.mjs
@@ -1168,7 +1168,11 @@ server.listen(port, BIND_HOST, () => {
 });
 
 server.on("error", (err) => {
-	console.error(`[bridge] cannot listen on ${BIND_HOST}:${port}: ${err.message}`);
+	const override = "set COZYCLAY_BRIDGE_PORT to a free port or pass --port <n>";
+	console.error(
+		`[bridge] cannot listen on ${BIND_HOST}:${port}: ${err.message}` +
+			(err?.code === "EADDRINUSE" ? `; ${override}` : ""),
+	);
 	process.exit(1);
 });
 

--- a/tools/ardy/bridge.mjs
+++ b/tools/ardy/bridge.mjs
@@ -1162,7 +1162,10 @@ server.on("clientError", (err, socket) => {
 });
 
 server.listen(port, BIND_HOST, () => {
-	console.log(`[bridge] ARDY dev bridge listening on http://${BIND_HOST}:${port}`);
+	const address = server.address();
+	const boundPort = typeof address === "object" && address ? address.port : port;
+	process.send?.({ type: "cozyclay-bridge-ready", port: boundPort });
+	console.log(`[bridge] ARDY dev bridge listening on http://${BIND_HOST}:${boundPort}`);
 	console.log("[bridge] dev-only sidecar: the static dist/ build does not need it; stop with Ctrl-C");
 	console.log(`[bridge] ${runner.mode} backend: ${runner.describe()}`);
 });
@@ -1173,7 +1176,11 @@ server.on("error", (err) => {
 		`[bridge] cannot listen on ${BIND_HOST}:${port}: ${err.message}` +
 			(err?.code === "EADDRINUSE" ? `; ${override}` : ""),
 	);
-	process.exit(1);
+	if (process.send && process.connected) {
+		process.send({ type: "cozyclay-bridge-listen-error", port, code: err?.code }, () => process.exit(1));
+	} else {
+		process.exit(1);
+	}
 });
 
 // Ctrl-C / SIGTERM: take the in-flight process groups down with us; ssh dies,

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createConnection, createServer } from "node:net";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -10,12 +11,106 @@ import {
 
 const REPO = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const viteArgs = process.argv.slice(2);
-const children = [
-	spawnOwned(process.execPath, ["tools/ardy/bridge.mjs"], { cwd: REPO }),
-	spawnOwned(process.execPath, ["node_modules/vite/bin/vite.js", ...viteArgs], { cwd: REPO }),
-];
 
+function mainPortFrom(args) {
+	let port = 5180;
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] === "--port" || args[index] === "-p") port = Number(args[++index]);
+		else if (args[index].startsWith("--port=")) port = Number(args[index].slice("--port=".length));
+	}
+	if (!Number.isInteger(port) || port < 1 || port >= 65535) {
+		throw new Error(`the Vite --port must be an integer in 1..65534 (got ${JSON.stringify(port)})`);
+	}
+	return port;
+}
+
+function canListen(port) {
+	return new Promise((resolvePromise) => {
+		const server = createServer();
+		server.once("error", () => resolvePromise(false));
+		server.listen(port, "127.0.0.1", () => server.close(() => resolvePromise(true)));
+	});
+}
+
+async function selectBridgePort(mainPort) {
+	if (process.env.COZYCLAY_BRIDGE_PORT !== undefined) {
+		const port = Number(process.env.COZYCLAY_BRIDGE_PORT);
+		if (!Number.isInteger(port) || port < 1 || port > 65535) {
+			throw new Error(`COZYCLAY_BRIDGE_PORT=${JSON.stringify(process.env.COZYCLAY_BRIDGE_PORT)} is not a valid port`);
+		}
+		if (!(await canListen(port))) {
+			throw new Error(`COZYCLAY_BRIDGE_PORT=${port} is already in use; choose another COZYCLAY_BRIDGE_PORT`);
+		}
+		return port;
+	}
+	for (let port = mainPort + 1; port <= 65535; port += 1) {
+		if (await canListen(port)) return port;
+	}
+	throw new Error(`no free bridge port is available at or above ${mainPort + 1}`);
+}
+
+function waitForBridge(child, port) {
+	return new Promise((resolvePromise, reject) => {
+		let retry;
+		let settled = false;
+		const finish = (callback, value) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			clearTimeout(retry);
+			child.off("exit", onExit);
+			callback(value);
+		};
+		const fail = (detail) => finish(reject, new Error(`ARDY bridge on 127.0.0.1:${port} ${detail}`));
+		const onExit = (code, signal) => fail(`exited ${signal ? `from ${signal}` : `with code ${code ?? 0}`}`);
+		const timeout = setTimeout(() => fail("did not listen within 5000 ms"), 5000);
+		const probe = () => {
+			if (settled) return;
+			const socket = createConnection({ host: "127.0.0.1", port });
+			socket.once("connect", () => {
+				socket.destroy();
+				finish(resolvePromise);
+			});
+			socket.once("error", () => {
+				socket.destroy();
+				if (!settled) retry = setTimeout(probe, 25);
+			});
+		};
+		child.once("exit", onExit);
+		probe();
+	});
+}
+
+let bridgePort;
+try {
+	bridgePort = await selectBridgePort(mainPortFrom(viteArgs));
+} catch (err) {
+	console.error(`[dev] Studio did not start: ${err.message}`);
+	process.exit(1);
+}
+
+const children = [];
 const removeSignalCleanup = installSignalCleanup(() => children);
+const bridge = spawnOwned(process.execPath, ["tools/ardy/bridge.mjs"], {
+	cwd: REPO,
+	env: { ...process.env, COZYCLAY_BRIDGE_PORT: String(bridgePort) },
+});
+children.push(bridge);
+try {
+	await waitForBridge(bridge, bridgePort);
+} catch (err) {
+	console.error(`[dev] Studio did not start: ${err.message}`);
+	removeSignalCleanup();
+	await terminateOwned(bridge);
+	process.exit(1);
+}
+
+const vite = spawnOwned(process.execPath, ["node_modules/vite/bin/vite.js", ...viteArgs], {
+	cwd: REPO,
+	env: { ...process.env, COZYCLAY_BRIDGE_PORT: String(bridgePort) },
+});
+children.push(vite);
+
 const first = await Promise.race(
 	children.map(async (child) => ({ child, ...(await waitForExit(child)) })),
 );

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
-import { createConnection, createServer } from "node:net";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	installSignalCleanup,
 	spawnOwned,
+	startBridge,
 	terminateOwned,
 	waitForExit,
 } from "./process-supervisor.mjs";
 
 const REPO = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const viteArgs = process.argv.slice(2);
+const viteArgs = [...process.argv.slice(2), "--strictPort"];
 
 function mainPortFrom(args) {
 	let port = 5180;
@@ -24,84 +24,24 @@ function mainPortFrom(args) {
 	return port;
 }
 
-function canListen(port) {
-	return new Promise((resolvePromise) => {
-		const server = createServer();
-		server.once("error", () => resolvePromise(false));
-		server.listen(port, "127.0.0.1", () => server.close(() => resolvePromise(true)));
-	});
-}
-
-async function selectBridgePort(mainPort) {
-	if (process.env.COZYCLAY_BRIDGE_PORT !== undefined) {
-		const port = Number(process.env.COZYCLAY_BRIDGE_PORT);
-		if (!Number.isInteger(port) || port < 1 || port > 65535) {
-			throw new Error(`COZYCLAY_BRIDGE_PORT=${JSON.stringify(process.env.COZYCLAY_BRIDGE_PORT)} is not a valid port`);
-		}
-		if (!(await canListen(port))) {
-			throw new Error(`COZYCLAY_BRIDGE_PORT=${port} is already in use; choose another COZYCLAY_BRIDGE_PORT`);
-		}
-		return port;
-	}
-	for (let port = mainPort + 1; port <= 65535; port += 1) {
-		if (await canListen(port)) return port;
-	}
-	throw new Error(`no free bridge port is available at or above ${mainPort + 1}`);
-}
-
-function waitForBridge(child, port) {
-	return new Promise((resolvePromise, reject) => {
-		let retry;
-		let settled = false;
-		const finish = (callback, value) => {
-			if (settled) return;
-			settled = true;
-			clearTimeout(timeout);
-			clearTimeout(retry);
-			child.off("exit", onExit);
-			callback(value);
-		};
-		const fail = (detail) => finish(reject, new Error(`ARDY bridge on 127.0.0.1:${port} ${detail}`));
-		const onExit = (code, signal) => fail(`exited ${signal ? `from ${signal}` : `with code ${code ?? 0}`}`);
-		const timeout = setTimeout(() => fail("did not listen within 5000 ms"), 5000);
-		const probe = () => {
-			if (settled) return;
-			const socket = createConnection({ host: "127.0.0.1", port });
-			socket.once("connect", () => {
-				socket.destroy();
-				finish(resolvePromise);
-			});
-			socket.once("error", () => {
-				socket.destroy();
-				if (!settled) retry = setTimeout(probe, 25);
-			});
-		};
-		child.once("exit", onExit);
-		probe();
-	});
-}
-
-let bridgePort;
-try {
-	bridgePort = await selectBridgePort(mainPortFrom(viteArgs));
-} catch (err) {
-	console.error(`[dev] Studio did not start: ${err.message}`);
-	process.exit(1);
-}
-
 const children = [];
 const removeSignalCleanup = installSignalCleanup(() => children);
-const bridge = spawnOwned(process.execPath, ["tools/ardy/bridge.mjs"], {
-	cwd: REPO,
-	env: { ...process.env, COZYCLAY_BRIDGE_PORT: String(bridgePort) },
-});
-children.push(bridge);
+let bridge;
+let bridgePort;
 try {
-	await waitForBridge(bridge, bridgePort);
+	({ child: bridge, port: bridgePort } = await startBridge({
+		command: process.execPath,
+		args: ["tools/ardy/bridge.mjs"],
+		cwd: REPO,
+		env: process.env,
+		mainPort: mainPortFrom(viteArgs),
+		onSpawn: (child) => {
+			children.splice(0, children.length, child);
+		},
+	}));
 } catch (err) {
 	console.error(`[dev] Studio did not start: ${err.message}`);
 	removeSignalCleanup();
-	await terminateOwned(bridge);
 	process.exit(1);
 }
 

--- a/tools/process-supervisor.mjs
+++ b/tools/process-supervisor.mjs
@@ -15,8 +15,90 @@ export function waitForExit(child) {
 		return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
 	}
 	return new Promise((resolve) => {
-		child.once("exit", (code, signal) => resolve({ code, signal }));
+		const finish = (result) => {
+			child.off("exit", onExit);
+			child.off("error", onError);
+			resolve(result);
+		};
+		const onExit = (code, signal) => finish({ code, signal });
+		const onError = () => finish({ code: 1, signal: null });
+		child.once("exit", onExit);
+		child.once("error", onError);
 	});
+}
+
+function bridgeError(port, detail, code) {
+	const error = new Error(`ARDY bridge on 127.0.0.1:${port} ${detail}`);
+	error.code = code;
+	return error;
+}
+
+export function waitForBridgeReady(child, port, timeoutMs = 5000) {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		const finish = (callback, value) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			child.off("message", onMessage);
+			child.off("exit", onExit);
+			child.off("error", onError);
+			callback(value);
+		};
+		const fail = (detail, code) => finish(reject, bridgeError(port, detail, code));
+		const onMessage = (message) => {
+			if (!message || message.port !== port) return;
+			if (message.type === "cozyclay-bridge-ready") finish(resolve);
+			if (message.type === "cozyclay-bridge-listen-error") {
+				fail(`could not listen: ${message.code ?? "unknown error"}`, message.code);
+			}
+		};
+		const onExit = (code, signal) => fail(`exited ${signal ? `from ${signal}` : `with code ${code ?? 0}`}`);
+		const onError = (error) => fail(`could not start: ${error.message}`);
+		const timeout = setTimeout(() => fail(`did not report readiness within ${timeoutMs} ms`), timeoutMs);
+		child.on("message", onMessage);
+		child.once("exit", onExit);
+		child.once("error", onError);
+	});
+}
+
+export async function startBridge({ command, args, cwd, env, mainPort, onSpawn, onReady }) {
+	const explicitPort = env.COZYCLAY_BRIDGE_PORT;
+	if (explicitPort !== undefined) {
+		const port = Number(explicitPort);
+		if (!Number.isInteger(port) || port < 1 || port > 65535) {
+			throw new Error(`COZYCLAY_BRIDGE_PORT=${JSON.stringify(explicitPort)} is not a valid port`);
+		}
+		return startBridgeAt(port, true);
+	}
+	for (let port = mainPort + 1; port <= 65535; port += 1) {
+		try {
+			return await startBridgeAt(port, false);
+		} catch (error) {
+			if (error?.code !== "EADDRINUSE") throw error;
+		}
+	}
+	throw new Error(`no free bridge port is available at or above ${mainPort + 1}`);
+
+	async function startBridgeAt(port, isExplicit) {
+		const child = spawnOwned(command, args, {
+			cwd,
+			env: { ...env, COZYCLAY_BRIDGE_PORT: String(port) },
+			stdio: ["inherit", "inherit", "inherit", "ipc"],
+		});
+		onSpawn?.(child);
+		try {
+			await waitForBridgeReady(child, port);
+			onReady?.(child);
+			return { child, port };
+		} catch (error) {
+			await terminateOwned(child);
+			if (isExplicit && error?.code === "EADDRINUSE") {
+				throw new Error(`COZYCLAY_BRIDGE_PORT=${port} is already in use; choose another COZYCLAY_BRIDGE_PORT`);
+			}
+			throw error;
+		}
+	}
 }
 
 function signalOwned(child, signal) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,9 @@ import { defineConfig } from "vite";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 
-const ardyBridgeUrl =
-	process.env.CCLAY_ARDY_BRIDGE_URL || "http://127.0.0.1:5181";
+const ardyBridgeUrl = process.env.COZYCLAY_BRIDGE_PORT
+	? `http://127.0.0.1:${process.env.COZYCLAY_BRIDGE_PORT}`
+	: process.env.CCLAY_ARDY_BRIDGE_URL || "http://127.0.0.1:5181";
 
 export default defineConfig({
 	// Root-absolute on purpose: the site has its own apex domain, and the studio
@@ -57,7 +58,8 @@ export default defineConfig({
 	server: {
 		port: 5180,
 		// Dev-only: the ARDY sidecar (tools/ardy/bridge.mjs) is an optional
-		// companion on 127.0.0.1:5181. The production build stays fully static
+		// companion on loopback. COZYCLAY_BRIDGE_PORT selects it for dev-full;
+		// direct Vite use falls back to 5181. The production build stays fully static
 		// (`base: "./"`, no build-time coupling), so this proxy must never be
 		// promoted into a server-side requirement.
 		proxy: {


### PR DESCRIPTION
Fixes #24.

Anything listening on 127.0.0.1:5181 used to kill `npm run dev` entirely — exit 1 with a single `[bridge] cannot listen` line, no mention that the studio never started, and no pointer to `COZYCLAY_BRIDGE_PORT`. The bridge port was hardcoded and not derived from `--port`, so a second instance always collided; the launcher's port-conflict hint even recommended 5181, the bridge's own port. The npx launcher also printed `Motion generation: sidecar running...` before the sidecar had bound, so on bind failure the status line lied.

Changes:

- **`tools/dev-full.mjs`**: derives the bridge port from the Vite main port + 1, scans upward for a free one; an explicit `COZYCLAY_BRIDGE_PORT` wins verbatim and fails loudly (naming the variable) when busy. Startup is readiness-gated: Vite spawns only after the bridge is actually listening, and any bridge failure says `[dev] Studio did not start: ...`.
- **`vite.config.js`**: the dev proxy targets `COZYCLAY_BRIDGE_PORT` when set, with the standalone 5181 fallback (and `CCLAY_ARDY_BRIDGE_URL`) preserved.
- **`bin/cozyclay.mjs`**: same port derivation for its sidecar and `/ardy` forwarder; the sidecar-running status prints only after a successful bind; the main-port conflict hint now suggests `--port 5200` instead of the bridge's port.
- **`tools/ardy/bridge.mjs`**: EADDRINUSE now names both `COZYCLAY_BRIDGE_PORT` and `--port <n>` as the fix.
- **`tools/ardy/BRIDGE.md`**: documents the dynamic allocation.

## Verified

- With 5181 held by a foreign process: `dev-full --port 5691` comes fully up — bridge auto-binds 5692, `/` 200, `/ardy/health` 200 through the proxy (re-verified independently after review).
- Two instances simultaneously (`5693`+`5694`, `5695`+`5696`), both healthy.
- `COZYCLAY_BRIDGE_PORT=5181` while held: exit 1, `[dev] Studio did not start: COZYCLAY_BRIDGE_PORT=5181 is already in use...`.
- npx launcher with a sidecar host set and 5181 held: sidecar auto-binds, bind log precedes the status line, `/app/` 200.
- `npm run build`, `npm run test:lifecycle`, `node --check`, diagnostics: all pass.
