### PR TITLE
fix(camera): let drawn rails complete their move

### DIFF
--- a/src/camera-follow.js
+++ b/src/camera-follow.js
@@ -29,11 +29,13 @@ function springStep(pos, vel, target, omega, dt) {
 	return [pos + nextVel * dt, nextVel];
 }
 
-/** scalar spring whose speed limit is applied before position integration */
+/** scalar forward spring whose speed limit is applied before position integration */
 function cappedSpringStep(pos, vel, target, omega, dt, maxSpeed) {
 	const acc = omega * omega * (target - pos) - 2 * omega * vel;
 	const cap = Math.max(0, Number.isFinite(maxSpeed) ? maxSpeed : 0);
-	const nextVel = Math.max(-cap, Math.min(vel + acc * dt, cap));
+	// Rail targets never move backward; discard incompatible spring velocity
+	// before integration so the authored arc remains a forward-only invariant.
+	const nextVel = Math.max(0, Math.min(vel + acc * dt, cap));
 	return [pos + nextVel * dt, nextVel];
 }
 

--- a/src/camera-follow.js
+++ b/src/camera-follow.js
@@ -334,20 +334,24 @@ function nearestS(rail, point) {
 }
 
 /**
- * Rail follow: the camera lives ON the drawn rail; each frame the grip finds
- * the nearby arc position whose distance to the subject is closest to
- * `distance` and spring-pushes toward it (speed-capped — a dolly has mass).
- * The operator aims exactly as in the free follow. Local search only: the
- * dolly never teleports across the stage to a globally better spot.
+ * Rail follow: the camera lives ON the drawn rail and traverses the authored
+ * arc over the clip. `distance` remains a soft framing preference: nearby
+ * arc positions can refine the timed target, but they can never make the
+ * dolly stop at the first point that happens to match the preference.
+ * The operator aims exactly as in the free follow. The timed target and its
+ * local distance correction are both speed-capped, so the dolly never
+ * teleports across the stage.
  */
 export function buildRailFollowTrack(subject, fps, rail, params = {}) {
-	const p = { ...FOLLOW_DEFAULTS, searchWindow: 2.5, backtrackPenalty: 1.0, ...params };
+	const p = { ...FOLLOW_DEFAULTS, searchWindow: 2.5, distanceInfluence: 0.35, ...params };
 	if (!subject || subject.length === 0 || !rail || rail.length < 1e-6) return [];
 	const dt = 1 / Math.max(fps, 1);
 	const vels = smoothedVelocities(subject, fps);
 	const omega = omegaFor(p.response);
 	const aimOmega = omegaFor(p.aimResponse);
 	const step = Math.max(rail.length / Math.max(rail.points.length - 1, 1), 1e-3);
+	const authoredSpeed = subject.length > 1 ? rail.length / ((subject.length - 1) * dt) : 0;
+	const progressLead = (2 * authoredSpeed) / omega;
 
 	const distanceErrorAt = (s, subj) => {
 		const rp = railPoint(rail, s);
@@ -373,7 +377,9 @@ export function buildRailFollowTrack(subject, fps, rail, params = {}) {
 	};
 
 	// Head mode honours the authored start mark exactly. Nearest preserves the
-	// legacy auto-placement option by searching the whole rail once.
+	// legacy auto-placement option by searching the whole rail once. Once the
+	// clip starts, authored progress is the primary target; distance only
+	// nudges that target locally and can never reverse the dolly.
 	let s = p.railStartMode === "nearest"
 		? bestSNear(nearestS(rail, subject[0]), subject[0], rail.length, 0)
 		: 0;
@@ -387,7 +393,17 @@ export function buildRailFollowTrack(subject, fps, rail, params = {}) {
 	const track = [];
 	for (let f = 0; f < subject.length; f += 1) {
 		if (f > 0) {
-			const sTarget = bestSNear(s, subject[f], p.searchWindow, p.backtrackPenalty);
+			const progress = f / Math.max(subject.length - 1, 1);
+			const authoredS = rail.length * progress;
+			const distanceS = bestSNear(authoredS, subject[f], p.searchWindow, 0);
+			// Distance influence fades to zero at both authored endpoints, so
+			// it refines the middle of the move without shifting its marks.
+			const correctionEnvelope = Math.sin(Math.PI * progress) ** 2;
+			const correction = (distanceS - authoredS) * clamp(p.distanceInfluence, 0, 1) * correctionEnvelope;
+			// A critically damped spring trails a constant-speed target by
+			// 2v/omega. Lead the authored target by that exact amount so the
+			// dolly reaches the end mark instead of stopping one spring-lag shy.
+			const sTarget = Math.max(s, Math.min(rail.length, authoredS + progressLead + correction));
 			[s, sVel] = cappedSpringStep(s, sVel, sTarget, omega, dt, p.maxDollySpeed);
 			s = Math.max(0, Math.min(s, rail.length));
 			[py, vy] = springStep(py, vy, p.height, omega, dt);

--- a/test/verify-camera-follow.mjs
+++ b/test/verify-camera-follow.mjs
@@ -155,12 +155,27 @@ ok("free follow emits one sample per subject frame", free.length === walk.length
 {
 	// A rail that pulls away from a stationary subject must keep traversing.
 	// Distance is a framing preference, not permission to stop the authored move.
-	const stationary = Array.from({ length: 120 }, () => ({ x: 0, z: 0 }));
+	const stationary = Array.from({ length: 180 }, () => ({ x: 0, z: 0 }));
 	const rail = buildRail([{ x: 1, z: 0 }, { x: 8, z: 0 }]);
-	const track = buildRailFollowTrack(stationary, FPS, rail);
-	ok("pull-out rail reaches the authored far end", track.at(-1).s > rail.length - 0.2, `s ${track.at(-1).s.toFixed(3)} / ${rail.length.toFixed(3)}`);
-	ok("pull-out rail keeps progressing after distance is reached", track[80].s > track[40].s + 1, `${track[40].s.toFixed(3)} -> ${track[80].s.toFixed(3)}`);
-	ok("pull-out rail never travels backward", track.every((sample, i) => i === 0 || sample.s >= track[i - 1].s - EPS));
+	for (const maxDollySpeed of [FOLLOW_DEFAULTS.maxDollySpeed, 1]) {
+		const track = buildRailFollowTrack(stationary, FPS, rail, { response: 0.1, maxDollySpeed });
+		const sSteps = track.slice(1).map((sample, i) => sample.s - track[i].s);
+		ok(
+			`response 0.1 pull-out reaches the authored far end at ${maxDollySpeed} m/s`,
+			track.at(-1).s > rail.length - 0.2,
+			`s ${track.at(-1).s.toFixed(3)} / ${rail.length.toFixed(3)}`,
+		);
+		ok(
+			`response 0.1 pull-out never travels backward at ${maxDollySpeed} m/s`,
+			Math.min(...sSteps) >= -EPS,
+			`min Δs ${Math.min(...sSteps).toFixed(6)}`,
+		);
+		ok(
+			`response 0.1 pull-out respects the ${maxDollySpeed} m/s cap`,
+			Math.max(...sSteps) <= maxDollySpeed / FPS + EPS,
+			`max Δs ${(Math.max(...sSteps) * FPS).toFixed(6)} m/s`,
+		);
+	}
 }
 
 {

--- a/test/verify-camera-follow.mjs
+++ b/test/verify-camera-follow.mjs
@@ -136,22 +136,31 @@ ok("free follow emits one sample per subject frame", free.length === walk.length
 }
 
 {
-	// rail alongside a straight walk: dolly pushes parallel, holds distance
+	// rail alongside a straight walk: dolly follows the authored arc
 	const walkLong = straightWalk(10);
 	const rail = buildRail([{ x: -2.5, z: -2 }, { x: -2.5, z: 16 }]);
 	const track = buildRailFollowTrack(walkLong, FPS, rail);
 	ok("rail follow emits one sample per subject frame", track.length === walkLong.length);
 	const onRail = track.every((s) => Math.abs(s.pos.x - -2.5) < 1e-6);
 	ok("the camera never leaves the rail", onRail);
-	const late = track.slice(80);
-	const errs = late.map((s, i) => Math.abs(dist(s.pos, walkLong[80 + i]) - FOLLOW_DEFAULTS.distance));
-	ok("rail follow holds distance where the rail allows it (±0.5 m)", Math.max(...errs) < 0.5, `max err ${Math.max(...errs).toFixed(3)}`);
+	ok("rail follow advances through the authored rail", track.at(-1).s > rail.length - 0.2, `s ${track.at(-1).s.toFixed(3)} / ${rail.length.toFixed(3)}`);
 	const sSteps = track.slice(1).map((s, i) => s.s - track[i].s);
 	ok(
 		"the dolly respects its speed cap",
 		Math.max(...sSteps.map(Math.abs)) <= 4 / FPS + 1e-6,
 		`${(Math.max(...sSteps.map(Math.abs)) * FPS).toFixed(2)} m/s`,
 	);
+}
+
+{
+	// A rail that pulls away from a stationary subject must keep traversing.
+	// Distance is a framing preference, not permission to stop the authored move.
+	const stationary = Array.from({ length: 120 }, () => ({ x: 0, z: 0 }));
+	const rail = buildRail([{ x: 1, z: 0 }, { x: 8, z: 0 }]);
+	const track = buildRailFollowTrack(stationary, FPS, rail);
+	ok("pull-out rail reaches the authored far end", track.at(-1).s > rail.length - 0.2, `s ${track.at(-1).s.toFixed(3)} / ${rail.length.toFixed(3)}`);
+	ok("pull-out rail keeps progressing after distance is reached", track[80].s > track[40].s + 1, `${track[40].s.toFixed(3)} -> ${track[80].s.toFixed(3)}`);
+	ok("pull-out rail never travels backward", track.every((sample, i) => i === 0 || sample.s >= track[i - 1].s - EPS));
 }
 
 {


### PR DESCRIPTION
## Summary
- make authored rail progress the primary Rail Follow target
- keep the configured distance as a soft, middle-of-shot correction
- preserve speed caps and prevent backward travel while ensuring the dolly reaches the authored end

## Verification
- `node test/verify-camera-follow.mjs`
- `node test/verify-camera-rail-schedule.mjs`
- `npm run build`
- Chrome/CDP QA: Draw Rail entered drawing mode; a pull-out rail reached the far end, continued after the preferred distance, and never reversed

## Notes
- Build retains the existing Vite warning about the unresolved Inter font path and large minified chunks.
- `npm ci` reports one existing high-severity audit finding; no dependency files changed.