### PR TITLE
feat: cclay launcher alias, lifted height ceilings, non-destructive ARDY prompts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,6 +35,16 @@ technical, and close to the timeline state they change.
 - Destructive rail deletion uses a red hover/focus cue and an explicit text
   label; no icon-only or right-click-only deletion.
 - Keyboard focus must remain visible.
+- Full-Body editing is direct and frame-addressed: `Cut` splits at the
+  playhead, while each resulting green segment owns a compact speed selector.
+  Speed changes redraw the segment width immediately; there is no decorative
+  transition because the new duration is the information.
+- Full-Body speed runs from `0.1×` to `4.0×` in `0.1×` steps. The current
+  segment is identified by the playhead and receives the brighter green
+  selected state. Its slider and numeric stepper stay in the fixed timeline
+  header instead of inside the segment, so a one-frame segment remains
+  editable. Outer trim handles continue to own only the complete take's
+  in/out points.
 
 ## 5. Reusable Primitives
 
@@ -42,3 +52,7 @@ technical, and close to the timeline state they change.
 - `.tl-camera-tool.active`: active/engaged action.
 - `.tl-camera-tool.danger`: destructive camera-toolbar action.
 - `.tl-camera-metric`: read-only measured camera value.
+- `.tl-motion-clip`: one cut Full-Body segment.
+- `.tl-motion-clip.selected`: segment currently under the playhead.
+- `.tl-motion-speed-editor`: fixed header slider + numeric stepper for the
+  Full-Body segment under the playhead.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ bunx cozyclay
 
 That downloads the built studio and opens it at `http://127.0.0.1:5180`. Nothing to compile, no dependency tree to install. Useful flags: `--port 5200`, `--no-open`, `--no-ardy`.
 
+A global install gives you `cclay`, the same command with less typing. Once a day the launcher checks npm for a newer release and prints a one-line notice after the studio is up; it stays quiet when you're current or offline. `cclay update` installs the latest release, and `--no-update-check` skips the check entirely.
+
 Motion generation stays off until you point it at a machine that can run it:
 
 ```bash

--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -24,6 +24,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { runMcp } from "./mcp-runtime.mjs";
 import { openBrowser } from "./open-browser.mjs";
+import { checkForUpdate, runUpdate } from "./update-check.mjs";
 
 const PKG_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const DIST = join(PKG_ROOT, "dist");
@@ -48,7 +49,7 @@ const TYPES = {
 };
 
 function parseArgs(argv) {
-	const opts = { port: 5180, host: "127.0.0.1", ardy: true, open: true, star: true };
+	const opts = { port: 5180, host: "127.0.0.1", ardy: true, open: true, star: true, updateCheck: true };
 	for (let i = 0; i < argv.length; i += 1) {
 		const arg = argv[i];
 		if (arg === "--port" || arg === "-p") opts.port = Number(argv[++i]);
@@ -58,6 +59,7 @@ function parseArgs(argv) {
 		else if (arg === "--no-ardy") opts.ardy = false;
 		else if (arg === "--no-open") opts.open = false;
 		else if (arg === "--no-star") opts.star = false;
+		else if (arg === "--no-update-check") opts.updateCheck = false;
 		else if (arg === "--help" || arg === "-h") opts.help = true;
 		else if (arg === "--version" || arg === "-v") opts.version = true;
 		else {
@@ -72,7 +74,7 @@ function parseArgs(argv) {
 	return opts;
 }
 
-const REPO_URL = "https://github.com/HaD0Yun/CozyClay";
+const REPO_URL = "https://github.com/NomaDamas/CozyClay";
 const STATE_DIR = join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "cozyclay");
 const STATE_FILE = join(STATE_DIR, "state.json");
 // Only worth asking someone who actually used the thing. A prompt three
@@ -83,10 +85,15 @@ const HELP = `cozyclay - browser-based 3D staging studio
 
   npx cozyclay              start the studio and open it
   npx cozyclay mcp          run the MCP server (for Claude, Cursor, any MCP client)
+  cclay update              install the latest cozyclay globally (npm install -g)
   npx cozyclay --port 5200  serve on another port
   npx cozyclay --no-ardy    skip the optional motion-generation sidecar
   npx cozyclay --no-open    do not open a browser
   npx cozyclay --no-star    never ask about starring the repo
+  npx cozyclay --no-update-check
+                            do not look for a newer release
+
+cclay is the same command, shorter: a global install gives you both.
 
 Motion generation needs an SSH-reachable NVIDIA machine running ARDY; point
 the sidecar at it with CCLAY_ARDY_HOST. Everything else - staging, posing,
@@ -142,7 +149,7 @@ function writeState(patch) {
 
 async function starCount() {
 	try {
-		const res = await fetch("https://api.github.com/repos/HaD0Yun/CozyClay", {
+		const res = await fetch("https://api.github.com/repos/NomaDamas/CozyClay", {
 			headers: { accept: "application/vnd.github+json" },
 			signal: AbortSignal.timeout(2500),
 		});
@@ -183,9 +190,27 @@ async function maybeAskForStar(startedAt, opts) {
 	}
 }
 
+// Read on every launch now, so it must not be able to take the launcher down:
+// the version is cosmetic here, and "0.0.0" just suppresses a bogus notice.
+function readVersion() {
+	try {
+		return JSON.parse(readFileSync(join(PKG_ROOT, "package.json"), "utf8")).version ?? "0.0.0";
+	} catch {
+		return "0.0.0";
+	}
+}
+
 const argv = process.argv.slice(2);
 if (argv[0] === "mcp") {
 	await runMcp(argv.slice(1));
+} else if (argv[0] === "update") {
+	// This branch bypasses parseArgs, so anything trailing would be swallowed
+	// and `cclay update --help` would perform an unrequested global install.
+	if (argv.length > 1) {
+		console.error(`cozyclay: update takes no arguments (got ${argv.slice(1).join(" ")})`);
+		process.exit(1);
+	}
+	runUpdate();
 } else {
 
 const opts = parseArgs(argv);
@@ -193,11 +218,14 @@ if (opts.help) {
 	console.log(HELP);
 	process.exit(0);
 }
+const version = readVersion();
 if (opts.version) {
-	const pkg = JSON.parse(await import("node:fs").then((fs) => fs.promises.readFile(join(PKG_ROOT, "package.json"), "utf8")));
-	console.log(pkg.version);
+	console.log(version);
 	process.exit(0);
 }
+// Fired before anything blocking and never awaited on the launch path: the
+// notice is worth a line of output, never a second of startup.
+const updatePending = opts.updateCheck && !process.env.CI && !process.env.COZYCLAY_NO_UPDATE_CHECK ? checkForUpdate(version, STATE_DIR) : null;
 if (!existsSync(join(DIST, "app", "index.html"))) {
 	console.error("cozyclay: this package is missing its build (dist/app/index.html).");
 	console.error("cozyclay: from a clone, run `npm install && npm run build` first.");
@@ -313,6 +341,11 @@ server.listen({ port: opts.port, host: opts.host, ipv6Only: false }, () => {
 				"set CCLAY_ARDY_HOST=user@host to turn it on. Everything else works without it.",
 		);
 	if (opts.open) openBrowser(url);
+	void updatePending?.then((latest) => {
+		// `cclay` only exists after a global install, so name the command that
+		// works from an npx run too.
+		if (latest) console.log(`cozyclay ${latest} is available (you have ${version}). Run: npm install -g cozyclay@latest`);
+	});
 });
 
 }

--- a/bin/update-check.mjs
+++ b/bin/update-check.mjs
@@ -1,0 +1,158 @@
+/**
+ * The "a newer version exists" line, and the command that acts on it.
+ *
+ * Two rules keep this from becoming the thing people disable: it never blocks
+ * the launch (fire it, print later, drop it on any error) and it never talks
+ * unless there is actually something newer. No dependencies, same as the
+ * launcher it serves.
+ */
+import { spawn } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REGISTRY_URL = "https://registry.npmjs.org/cozyclay/latest";
+const FETCH_TIMEOUT_MS = 2000;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+// Numeric dotted compare, prereleases lose to their own release. Enough to
+// answer "is the registry ahead of us"; anything more is a semver dependency.
+export function compareVersions(a, b) {
+	const parse = (v) => {
+		const s = String(v).trim();
+		const i = s.indexOf("-");
+		// split("-", 2) would *drop* everything after the second hyphen, so
+		// "1.4.0-next-rc" would compare as "next". Keep the whole tag.
+		const core = i === -1 ? s : s.slice(0, i);
+		const pre = i === -1 ? "" : s.slice(i + 1);
+		return { parts: core.split(".").map((n) => Number.parseInt(n, 10) || 0), pre };
+	};
+	const left = parse(a);
+	const right = parse(b);
+	for (let i = 0; i < Math.max(left.parts.length, right.parts.length); i += 1) {
+		const diff = (left.parts[i] ?? 0) - (right.parts[i] ?? 0);
+		if (diff !== 0) return diff < 0 ? -1 : 1;
+	}
+	if (left.pre === right.pre) return 0;
+	if (!left.pre) return 1;
+	if (!right.pre) return -1;
+	// Prerelease tags are dot-separated identifiers; numeric ones order
+	// numerically, or beta.10 would look older than beta.2.
+	const lp = left.pre.split(".");
+	const rp = right.pre.split(".");
+	for (let i = 0; i < Math.max(lp.length, rp.length); i += 1) {
+		const x = lp[i];
+		const y = rp[i];
+		if (x === undefined) return -1;
+		if (y === undefined) return 1;
+		if (/^\d+$/.test(x) && /^\d+$/.test(y)) {
+			const diff = Number(x) - Number(y);
+			if (diff !== 0) return diff < 0 ? -1 : 1;
+		} else if (x !== y) return x < y ? -1 : 1;
+	}
+	return 0;
+}
+
+function readCache(cacheFile) {
+	try {
+		return JSON.parse(readFileSync(cacheFile, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+function writeCache(cacheFile, cacheDir, latest) {
+	try {
+		mkdirSync(cacheDir, { recursive: true });
+		writeFileSync(cacheFile, JSON.stringify({ latest, checkedAt: Date.now() }, null, "\t"));
+	} catch {
+		/* a read-only home is not a reason to fail a local dev server */
+	}
+}
+
+// Returns null on any failure rather than throwing: a network error must not
+// unwind past the cache fallback in checkForUpdate.
+async function fetchLatest() {
+	let body;
+	try {
+		const res = await fetch(process.env.COZYCLAY_REGISTRY_URL || REGISTRY_URL, {
+			headers: { accept: "application/json" },
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		});
+		if (!res.ok) return null;
+		body = await res.json();
+	} catch {
+		return null;
+	}
+	if (typeof body?.version !== "string") return null;
+	// COZYCLAY_REGISTRY_URL can point anywhere, and a junk string parses as
+	// zeros further down, which reads as a downgrade. Only trust x.y.z.
+	const version = body.version.trim().replace(/^v/, "");
+	return /^\d+\.\d+\.\d+/.test(version) ? version : null;
+}
+
+/**
+ * Resolves to the newer version string, or null. Never rejects: offline,
+ * proxied, rate-limited and "npm is down" all mean "say nothing".
+ */
+export async function checkForUpdate(currentVersion, stateDir) {
+	try {
+		const cacheFile = join(stateDir, "update-check.json");
+		const cached = readCache(cacheFile);
+		let latest = cached?.latest ?? null;
+		const age = Date.now() - cached?.checkedAt;
+		// A future checkedAt (clock skew, edited cache) would otherwise look
+		// fresh forever, and the check would never run again.
+		const fresh = Number.isFinite(age) && age >= 0 && age <= CACHE_TTL_MS;
+		if (!fresh) {
+			const fetched = await fetchLatest();
+			// A dead registry must not erase a known-good cached version, or the
+			// notice silently stops working offline once the TTL lapses.
+			if (fetched) {
+				latest = fetched;
+				writeCache(cacheFile, stateDir, fetched);
+			}
+		}
+		if (!latest) return null;
+		return compareVersions(latest, currentVersion) > 0 ? latest : null;
+	} catch {
+		return null;
+	}
+}
+
+// npx/bunx runs from a temp dir, so there is no local install to upgrade in
+// place; `npm install -g` is the one command that is right either way.
+export function runUpdate() {
+	const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+	const child = spawn(npm, ["install", "-g", "cozyclay@latest"], { stdio: "inherit", shell: process.platform === "win32" });
+	child.on("error", (err) => {
+		console.error(`cozyclay: could not run npm: ${err.message}`);
+		process.exit(1);
+	});
+	child.on("exit", (code, signal) => {
+		if (signal || code !== 0) {
+			process.exit(code ?? 1);
+			return;
+		}
+		// Report what is on disk now, not what the registry says: those differ
+		// the moment a publish lands mid-update.
+		const installed = spawn(npm, ["ls", "-g", "--depth=0", "--json", "cozyclay"], {
+			stdio: ["ignore", "pipe", "ignore"],
+			shell: process.platform === "win32",
+		});
+		let out = "";
+		installed.stdout.on("data", (chunk) => {
+			out += chunk;
+		});
+		installed.on("error", () => process.exit(0));
+		installed.on("exit", () => {
+			let version = "";
+			try {
+				version = JSON.parse(out)?.dependencies?.cozyclay?.version ?? "";
+			} catch {
+				/* an unparseable `npm ls` only costs us the version in the message */
+			}
+			console.log(version ? `cozyclay ${version} installed.` : "cozyclay updated.");
+			process.exit(0);
+		});
+	});
+}

--- a/mcp/ardy-prompts.mjs
+++ b/mcp/ardy-prompts.mjs
@@ -21,11 +21,20 @@
  *
  * What that rules out, and what this module rewrites:
  *   - no subject            "runs forward"        -> "A person runs forward."
- *   - compound actions      "stands, then runs"   -> split across phases
  *   - interior states       "in astonishment"     -> dropped; ARDY animates
  *                                                    bodies, not feelings
- *   - camera/scene language "the rocket looms"    -> dropped; the prompt
+ *   - camera/scene language "the camera pushes in" -> dropped; the prompt
  *                                                    describes the BODY only
+ *
+ * What it deliberately does NOT do: rewrite a caller's composite physical
+ * description into something shorter. A phrase like "raises both arms while
+ * stepping back, then lowers them" is the caller's authored beat; splitting it
+ * on the comma or on "while"/"then" and keeping only the first fragment throws
+ * away motion the caller asked for and silently animates something else.
+ * One-action-per-phase is guidance (see PROMPT_GUIDE) that callers apply when
+ * they author phases — never a deletion this module performs on their behalf.
+ * Normalisation here is non-destructive: subject, full stop, and removal of
+ * language ARDY has no body channel for. Everything else survives verbatim.
  */
 
 /**
@@ -56,7 +65,9 @@ export const PROMPT_GUIDE = [
 	'  - One action per phase, phrased like ARDY\'s own examples: "A person walks in a circle."',
 	"  - Subject + single present-tense action + full stop. The prompt becomes ONE embedding",
 	"    (num_text_tokens=1), so two actions in one phase average together instead of playing in order.",
-	"  - Sequence = more phases, never a compound sentence.",
+	"  - Sequence = more phases, never a compound sentence. Phases are taken as written:",
+	"    a comma or a 'then'/'while'/'as'/'before' clause is NOT split or trimmed for you, so",
+	"    split sequential beats yourself instead of relying on a rewrite.",
 	`  - A block holds at most ${BLOCK_MAX_SECONDS} s. Longer beats are chained into consecutive blocks,`,
 	"    because a single long block drifts away from its prompt.",
 	"  - Describe the BODY: no emotions, no camera, no scenery, no props the model cannot infer.",
@@ -67,19 +78,30 @@ export const PROMPT_GUIDE = [
 	"    describing ONE pose is fine; sequential actions still need separate phases.",
 	'  - Good: ["A person strides forward quickly.", "A person stops abruptly.", "A person leans far back and looks straight up."]',
 	'  - Bad:  ["walks forward slowly, then stops abruptly", "staggers back in astonishment"]',
+	'  - Tested preset (backward airborne flail): "A person leaps backward with arms and legs flailing."',
+	"    Tested caveat: 'flailing' reads as ONE action, so the prompt normalises unchanged; split it",
+	'    yourself only if you want the leap and the flail as separate beats.',
 ].join("\n");
 
-/** Interior states and cinematic language ARDY has no body channel for. */
+/**
+ * Interior states and cinematic language ARDY has no body channel for.
+ *
+ * Every pattern is bounded to the offending words themselves. None of them may
+ * run to the end of a clause or sentence, because a caller's physical wording
+ * often sits on the far side of the phrase being removed ("turns while the
+ * camera pushes in and raises one arm" must keep the arm).
+ */
 const UNRENDERABLE = [
 	/\b(in|with)\s+(astonishment|awe|wonder|surprise|fear|joy|excitement|disbelief)\b/gi,
 	/\b(astonished|amazed|awestruck|terrified|delighted|confused|nervous|curious)ly?\b/gi,
-	/\b(as if|like)\s+[^,.]+/gi,
-	/\b(at|toward|towards)\s+(something|the)\s+(enormous|huge|massive|towering|giant)\b/gi,
-	/\b(the\s+)?(camera|shot|frame|rocket|spaceship|building)\b[^,.]*/gi,
+	/\b(at|toward|towards)\s+(something|the)\s+(enormous|huge|massive|towering|giant)(\s+\w+)?\b/gi,
+	// A camera/scene clause: the noun plus the verb phrase attached to it, stopping
+	// at the next clause boundary so the body action after it survives.
+	/\b(?:while|as|and)?\s*(?:the\s+)?(?:camera|shot|frame|rocket|spaceship|building)\b(?:\s+(?!and\b)\w+){0,3}/gi,
 ];
 
-/** Connectives that mean "a second action is hiding in this sentence". */
-const SPLIT_ON = /\s*,?\s*\b(?:and then|then|after that|before|while|as)\b\s*/i;
+/** A leftover connective at either end once an unrenderable clause is removed. */
+const DANGLING_CONNECTIVE = /^(?:and|then|so|while|as|before|after that)\s+|\s+(?:and|while|as|before)$/gi;
 
 const SUBJECT = /^(a|the)\s+(person|man|woman|character|figure|human)\b/i;
 
@@ -100,27 +122,24 @@ export function normalizePhase(raw) {
 	let s = tidy(String(raw ?? ""));
 	if (!s) return { text: "", notes: ["empty phrase"] };
 
+	let stripped = false;
 	for (const pattern of UNRENDERABLE) {
+		pattern.lastIndex = 0;
 		if (pattern.test(s)) {
-			s = tidy(s.replace(pattern, ""));
-			notes.push("dropped language ARDY cannot animate (emotion, camera or scenery)");
-			break;
+			pattern.lastIndex = 0;
+			s = tidy(s.replace(pattern, " "));
+			stripped = true;
 		}
 	}
-
-	// Keep the first action; a trailing clause belongs in its own phase.
-	const parts = s.split(SPLIT_ON).map(tidy).filter(Boolean);
-	if (parts.length > 1) {
-		s = parts[0];
-		notes.push(`kept the first action; "${parts.slice(1).join(" / ")}" belongs in its own phase`);
+	if (stripped) {
+		s = tidy(s.replace(DANGLING_CONNECTIVE, " "));
+		notes.push("dropped language ARDY cannot animate (emotion, camera or scenery)");
 	}
+	if (!s) return { text: "", notes: [...notes, "nothing physical left to animate"] };
 
-	// A comma usually joins two actions too ("walks forward, stops abruptly").
-	const commaParts = s.split(/\s*,\s*/).map(tidy).filter(Boolean);
-	if (commaParts.length > 1) {
-		s = commaParts[0];
-		notes.push("kept one action per prompt");
-	}
+	// Commas and "then"/"while"/"as"/"before" clauses are the caller's wording and
+	// stay put. Composite beats are their problem to split into phases; silently
+	// deleting half a prompt animates something the caller never asked for.
 
 	s = s.replace(/^(and|then|so)\s+/i, "");
 	if (!SUBJECT.test(s)) {
@@ -139,24 +158,23 @@ export function normalizePhase(raw) {
 }
 
 /**
- * Normalise a whole beat list. A phrase that carried a trailing action gets it
- * back as its own phase, so "stands up then runs" becomes two real beats
- * instead of one averaged embedding — capped so a caller cannot blow past the
- * schema's phase limit.
+ * Normalise a whole beat list. One input beat is one output phase: a beat is
+ * never split on a connective, because the caller's phase list is the sequence
+ * and re-cutting it silently changes the animation they asked for. The list is
+ * still capped so a caller cannot blow past the schema's phase limit.
+ *
+ * `sources` therefore maps 1:1 onto the inputs, and `expanded` is always false;
+ * both are kept so callers that divide a beat's duration across its pieces
+ * (server.mjs) keep working unchanged.
  */
 export function normalizePhases(phases, max = 8) {
 	const expanded = [];
 	const sources = [];
 	for (const [index, phase] of phases.entries()) {
-		const pieces = String(phase ?? "")
-			.split(SPLIT_ON)
-			.map(tidy)
-			.filter(Boolean);
-		const parts = pieces.length ? pieces : [phase];
-		expanded.push(...parts);
+		expanded.push(String(phase ?? ""));
 		// Which input each output came from, so a caller that attached a duration
-		// to a beat can split that duration across the pieces it became.
-		sources.push(...parts.map(() => index));
+		// to a beat can still line its beats up with the prompts they produced.
+		sources.push(index);
 	}
 	const capped = expanded.slice(0, max);
 	const results = capped.map((piece) => normalizePhase(piece));
@@ -164,7 +182,8 @@ export function normalizePhases(phases, max = 8) {
 		texts: results.map((r) => r.text),
 		notes: results.map((r) => r.notes),
 		sources: sources.slice(0, max),
-		expanded: expanded.length > phases.length,
+		// Kept for the callers that report it; normalisation never adds a phase now.
+		expanded: false,
 		dropped: expanded.length - capped.length,
 	};
 }

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -827,14 +827,18 @@ registerTool(
 		} catch (error) {
 			return liveError(error);
 		}
+		// Report the normalised text itself, not blocks[i]: a long beat becomes
+		// several blocks, so block indices run ahead of phase indices and quoting
+		// blocks[i] would attribute one beat's edits to another beat's wording.
 		const rewrites = normalized.notes
-			.map((notes, i) => (notes.length ? `  ${i + 1}. ${blocks[i].text}  ← ${notes.join("; ")}` : null))
+			.map((notes, i) => (notes.length ? `  ${i + 1}. ${normalized.texts[i]}  ← ${notes.join("; ")}` : null))
 			.filter(Boolean);
 		return text(
 			`${blocks.length} block(s) on the timeline (${(cursor / TIMELINE_FPS).toFixed(1)}s total):\n` +
 				blocks.map((b) => `  ${b.startFrame}-${b.endFrame}f  ${b.text}`).join("\n") +
 				(chained > 0 ? `\n  (${chained} block(s) chained to keep every block within ${BLOCK_MAX_SECONDS}s)` : "") +
 				(rewrites.length ? `\n\nRewritten for ARDY:\n${rewrites.join("\n")}` : "") +
+				(normalized.dropped > 0 ? `\n  (${normalized.dropped} beat(s) past the 8-phase limit were dropped)` : "") +
 				"\n\nGenerate them from the studio's Prompt Blocks panel, or with generate_motion.",
 		);
 	},
@@ -859,13 +863,15 @@ registerTool(
 						}),
 					]),
 				)
-				.min(2)
+				.min(1)
 				.max(8)
 				.describe(
 					"one beat per phase, in order. Write each as ARDY writes them: " +
 						'"A person walks in a circle." — subject, one action, present tense, ' +
 						"full stop. Give a plain string to share the clip evenly, or " +
-						"{ text, seconds } to hold a beat for a specific time.",
+						"{ text, seconds } to hold a beat for a specific time. A single " +
+						"complete beat is accepted and generates one clip; a sequence needs " +
+						"one phase per action, never a compound sentence.",
 				),
 			seconds: z
 				.number()
@@ -876,9 +882,9 @@ registerTool(
 			seed: z.number().int().optional().describe("generation seed"),
 			motion_url: z
 				.string()
-				.regex(/^\/ardy\/motions\/[0-9]+-[0-9a-f]{6}$/)
+				.regex(/^\/(ardy\/motions\/[0-9]+-[0-9a-f]{6}|ardy\/assembled\/[A-Za-z0-9._-]+\.npz)$/)
 				.optional()
-				.describe("reuse an already-generated clip instead of generating again"),
+				.describe("reuse an already-generated clip, or a curated clip staged under public/ardy/assembled/"),
 			drop: z
 				.object({
 					from_s: z.number().min(0).describe("clip time the plunge begins, seconds"),
@@ -905,11 +911,21 @@ registerTool(
 			return text("The ARDY bridge is not running on " + bridge + ". Start the studio with `npm run dev` (it launches the bridge) and try again.");
 		}
 
-		// Every phase is rewritten into ARDY's own sentence shape before it is
-		// ever sent; a compound beat is split into the extra phase it was hiding.
+		// Every phase is rewritten into ARDY's own sentence shape before it is ever
+		// sent. One input beat stays one phase: the caller's phase list is the
+		// sequence, so a composite beat is theirs to split, not ours to re-cut.
 		const normalized = normalizePhases(phases);
-		const prompts = normalized.texts.filter(Boolean);
-		if (prompts.length < 2) return text("Give at least two distinct motion beats.");
+		// Keep notes beside the prompt they belong to: a blank beat normalises to
+		// "" and is dropped, which would otherwise slide every later note onto the
+		// wrong prompt in the rewrite report.
+		const kept = normalized.texts
+			.map((t, i) => ({ text: t, notes: normalized.notes[i], source: normalized.sources[i] }))
+			.filter((p) => p.text);
+		const prompts = kept.map((p) => p.text);
+		// One complete beat is a legitimate clip — ARDY's own examples are single
+		// prompts ("A person walks in a circle."), so a valid one-phase request must
+		// not fail merely for being one phase. Only an empty request is refused.
+		if (prompts.length === 0) return text("Give at least one motion beat.");
 
 		// ARDY Core is 20 fps; segments must tile 0..clipFrames exactly, and each
 		// one needs at least 3 frames.
@@ -918,17 +934,17 @@ registerTool(
 		let clipFrames;
 		let chained = 0;
 		if (timed) {
-			// A beat that split into pieces shares its time between them, so an
+			// A beat that became several blocks shares its time between them, so an
 			// explicit "6 seconds of walking" stays 6 seconds however it was phrased.
-			const pieceCount = normalized.sources.reduce((acc, source) => {
-				acc[source] = (acc[source] ?? 0) + 1;
+			const pieceCount = kept.reduce((acc, piece) => {
+				acc[piece.source] = (acc[piece.source] ?? 0) + 1;
 				return acc;
 			}, {});
 			segments = [];
 			let cursor = 0;
-			for (const [i, prompt] of prompts.entries()) {
-				const whole = phaseSeconds[normalized.sources[i]] ?? seconds / phases.length;
-				const share = whole / pieceCount[normalized.sources[i]];
+			for (const { text: prompt, source } of kept) {
+				const whole = phaseSeconds[source] ?? seconds / phases.length;
+				const share = whole / pieceCount[source];
 				// The studio caps a block at BLOCK_MAX_SECONDS and refuses to generate
 				// a longer one, so a long beat becomes consecutive blocks here rather
 				// than something the UI would reject.
@@ -963,16 +979,18 @@ registerTool(
 			}
 		}
 		const clipSeconds = clipFrames / ARDY_FPS;
-		const rewrites = normalized.notes
-			.map((notes, i) => (notes.length ? `  ${i + 1}. ${prompts[i]}  ← ${notes.join("; ")}` : null))
+		const rewrites = kept
+			.map(({ text: prompt, notes }, i) => (notes.length ? `  ${i + 1}. ${prompt}  ← ${notes.join("; ")}` : null))
 			.filter(Boolean);
 		const chainNote = chained > 0 ? `\n  (${chained} block(s) chained to keep every block within ${BLOCK_MAX_SECONDS}s)` : "";
+		// A drop is reported on its own account: a caller can send nine already-perfect
+		// phases, which produces no rewrite and no chaining yet still loses the ninth
+		// to the schema's 8-phase limit, and silence there would hide a lost beat.
+		const dropNote =
+			normalized.dropped > 0 ? `\n  (${normalized.dropped} beat(s) past the 8-phase limit were dropped)` : "";
 		const promptNote =
-			rewrites.length || chainNote
-				? (rewrites.length ? `\n\nRewritten for ARDY:\n${rewrites.join("\n")}` : "\n") +
-					(normalized.expanded ? "\n  (a compound beat became its own phase)" : "") +
-					(normalized.dropped > 0 ? `\n  (${normalized.dropped} beat(s) past the 8-phase limit were dropped)` : "") +
-					chainNote
+			rewrites.length || chainNote || dropNote
+				? (rewrites.length ? `\n\nRewritten for ARDY:\n${rewrites.join("\n")}` : "\n") + dropNote + chainNote
 				: "";
 
 		const deliver = async (motionUrl, note) => {
@@ -996,7 +1014,12 @@ registerTool(
 		if (motion_url) return deliver(motion_url, "Reusing");
 		// segments run the autoregressive sequence generator, which is
 		// incompatible with pose pinning — the bridge requires posePin:false.
-		const body = { prompt: prompts.join(" "), duration: clipSeconds, segments, posePin: false };
+		// A single beat has no sequence to chain: it goes out as a plain
+		// single-prompt generation (the bridge's `segments` requires 2..64 entries).
+		const body =
+			prompts.length === 1
+				? { prompt: prompts[0], duration: clipSeconds, posePin: false }
+				: { prompt: prompts.join(" "), duration: clipSeconds, segments, posePin: false };
 		if (seed !== undefined) body.seed = seed;
 
 		const res = await fetch(`${bridge}/ardy/generate`, {

--- a/mcp/verify-prompts.mjs
+++ b/mcp/verify-prompts.mjs
@@ -4,9 +4,12 @@
  * (nv-tlabs/ardy, scripts/generate.py: "A person walks in a circle.").
  *
  * The rules under test are the ones the repository states or implies:
- * an explicit subject, exactly one action per prompt because the conditioning
- * collapses to a single text token, a closing full stop, and nothing the body
- * cannot perform (emotion, camera, scenery).
+ * an explicit subject, a closing full stop, and nothing the body cannot perform
+ * (emotion, camera, scenery).
+ *
+ * One action per prompt is guidance for whoever writes the phases, NOT a
+ * deletion the normaliser performs: a composite physical beat comes back whole,
+ * commas and "then"/"while"/"as"/"before" clauses included.
  */
 import { BLOCK_MAX_SECONDS, PROMPT_GUIDE, normalizePhase, normalizePhases, splitLongBeat } from "./ardy-prompts.mjs";
 
@@ -33,14 +36,31 @@ check("a missing full stop is closed", stop.text === "A person waves.", stop.tex
 const cased = normalizePhase("the woman walks in a circle");
 check("an existing subject is preserved", cased.text === "The woman walks in a circle.", cased.text);
 
-/* --------------------------- one action per prompt ----------------------- */
+/* ------------------------ composite beats survive ------------------------ */
+// The normaliser must never trade away wording the caller authored.
 
 const compound = normalizePhase("walks forward slowly, then stops abruptly");
-check("a compound beat keeps only its first action", compound.text === "A person walks forward slowly.", compound.text);
-check("the split is reported", compound.notes.some((n) => /own phase/.test(n)), compound.notes.join("; "));
+check(
+	"a comma + 'then' beat is kept whole",
+	compound.text === "A person walks forward slowly, then stops abruptly.",
+	compound.text,
+);
+check("keeping a beat whole reports no split", compound.notes.every((n) => !/own phase/.test(n)), compound.notes.join("; "));
 
 const comma = normalizePhase("stands up, brushes off the knees");
-check("a comma-joined pair keeps one action", comma.text === "A person stands up.", comma.text);
+check("a comma-joined pair keeps both actions", comma.text === "A person stands up, brushes off the knees.", comma.text);
+
+const simultaneous = normalizePhase("raises both arms while stepping back");
+check("a 'while' clause survives", simultaneous.text === "A person raises both arms while stepping back.", simultaneous.text);
+
+const ordered = normalizePhase("crouches low before springing straight up");
+check("a 'before' clause survives", ordered.text === "A person crouches low before springing straight up.", ordered.text);
+
+const asClause = normalizePhase("turns the head as the shoulders drop");
+check("an 'as' clause survives", asClause.text === "A person turns the head as the shoulders drop.", asClause.text);
+
+const leading = normalizePhase("then runs forward, arms swinging wide");
+check("a leading connective goes but the clause stays", leading.text === "A person runs forward, arms swinging wide.", leading.text);
 
 /* ------------------------------ unrenderable ----------------------------- */
 
@@ -53,12 +73,19 @@ check("scenery reference is dropped", !/enormous/i.test(scenery.text), scenery.t
 
 const camera = normalizePhase("turns while the camera pushes in");
 check("camera language is dropped", !/camera/i.test(camera.text), camera.text);
+check("the body action outlives the camera clause", /turns/i.test(camera.text), camera.text);
+
+const afterCamera = normalizePhase("turns while the camera pushes in and raises one arm");
+check("a body action after a camera clause survives", /raises one arm/i.test(afterCamera.text), afterCamera.text);
+check("and the camera clause is still gone", !/camera/i.test(afterCamera.text), afterCamera.text);
 
 /* -------------------------------- sequences ------------------------------ */
 
 const seq = normalizePhases(["stands up from a chair then runs forward", "trips and falls"]);
-check("a hidden action becomes its own phase", seq.texts.length === 3, seq.texts.join(" | "));
-check("expansion is reported", seq.expanded === true);
+check("one beat in, one phase out", seq.texts.length === 2, seq.texts.join(" | "));
+check("a composite beat is not re-cut", seq.texts[0] === "A person stands up from a chair then runs forward.", seq.texts[0]);
+check("no expansion is reported", seq.expanded === false);
+check("each phase still maps to its own input", seq.sources.join(",") === "0,1", seq.sources.join(","));
 check(
 	"every phase ends up in ARDY's shape",
 	seq.texts.every((t) => /^(A|The)\s+\w+.*\.$/.test(t)),
@@ -75,6 +102,7 @@ check("blank beats do not become prompts", blank.texts.filter(Boolean).length ==
 /* --------------------------------- guide --------------------------------- */
 
 check("the guide shows ARDY's own example", PROMPT_GUIDE.includes("A person walks in a circle."));
+check("the guide warns that phases are taken as written", /NOT split or trimmed for you/.test(PROMPT_GUIDE));
 check("the guide explains the single-token reason", /num_text_tokens=1/.test(PROMPT_GUIDE));
 
 if (failures > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.3.0",
 			"license": "AGPL-3.0-or-later",
 			"bin": {
-				"cozyclay": "bin/cozyclay.mjs"
+				"cozyclay": "bin/cozyclay.mjs",
+				"cclay": "bin/cozyclay.mjs"
 			},
 			"devDependencies": {
 				"@mediapipe/tasks-vision": "0.10.17",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:blocking-depth": "node test/verify-blocking-depth.mjs",
     "test:image-pose": "node test/verify-image-pose.mjs",
     "test:pwa": "node test/verify-pwa.mjs",
+    "test:update-check": "node test/verify-update-check.mjs",
     "test:localization": "node test/verify-korean-ui.mjs",
     "test:korean-ui": "node test/verify-korean-ui.mjs",
     "prepack": "npm run build",
@@ -68,7 +69,8 @@
     "vite": "^8.2.0"
   },
   "bin": {
-    "cozyclay": "bin/cozyclay.mjs"
+    "cozyclay": "bin/cozyclay.mjs",
+    "cclay": "bin/cozyclay.mjs"
   },
   "files": [
     "bin",
@@ -123,11 +125,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HaD0Yun/CozyClay.git"
+    "url": "git+https://github.com/NomaDamas/CozyClay.git"
   },
   "homepage": "https://cozyclay.org/",
   "bugs": {
-    "url": "https://github.com/HaD0Yun/CozyClay/issues"
+    "url": "https://github.com/NomaDamas/CozyClay/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:video-frames": "node test/verify-video-frames.mjs",
     "test:retime": "node test/verify-retime.mjs",
     "test:trim": "node test/verify-trim.mjs",
+    "test:motion-edit": "node test/verify-motion-edit.mjs",
     "test:footage-bridge": "node test/verify-footage-bridge.mjs",
     "test:bvh-cskel27": "node test/verify-bvh-cskel27.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:otio": "node test/verify-otio.mjs",
     "test:camera-rail-browser": "node tools/qa-browser.mjs -- node test/verify-camera-rail-browser.mjs",
     "test:pose-extract": "node test/verify-pose-extract.mjs",
+    "test:blocking-depth": "node test/verify-blocking-depth.mjs",
     "test:image-pose": "node test/verify-image-pose.mjs",
     "test:pwa": "node test/verify-pwa.mjs",
     "test:localization": "node test/verify-korean-ui.mjs",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -593,6 +593,9 @@ const Character = memo(function Character({ url, position, rot, tint, pose, scal
 					metalness: 0,
 				});
 				child.frustumCulled = false;
+				// The subject's own shadow is what plants it on the deck; a blocking
+				// frame without one leaves the figure floating over flat colour.
+				child.castShadow = true;
 			}
 		});
 		// Stamp the bind pose while the rig is still untouched: the pose effect
@@ -960,40 +963,16 @@ function ShotPathPreview({ waypoints, start, activeWaypointFrame }) {
 	);
 }
 
-/** Unity-style scene grid over the whole open stage, editor chrome only.
-    Two tiers keep it legible at any zoom: 1 m minor cells for placement and a
-    darker 10 m major line that survives wide framings where minor lines blur
-    into a wash. Both ride the gizmo layer so exports and the plan never pick
-    them up, sit a hair above the deck to dodge z-fighting, and never swallow
-    a raycast — floor clicks pass straight through to the ground plane. Warm
-    greys tuned to the clay floor (#e7e1d7). */
-function SceneGrid() {
-	const grids = useMemo(() => {
-		const make = (divisions, color, opacity, y) => {
-			const helper = new THREE.GridHelper(500, divisions, color, color);
-			helper.material.transparent = true;
-			helper.material.opacity = opacity;
-			helper.material.depthWrite = false;
-			helper.position.y = y;
-			helper.layers.set(GIZMO_LAYER);
-			helper.raycast = () => null;
-			return helper;
-		};
-		return [
-			// Value hierarchy against the bright deck (#f4f0e8): quiet 1 m cells
-			// for placement, assertive 10 m lines for structure. The gap between
-			// floor and minor keeps the tiling from reading as a repeating texture.
-			make(500, 0xa89d8a, 0.4, 0.002), // minor: 1 m cells, subtle
-			make(50, 0x6a5f4e, 0.9, 0.003), // major: 10 m lines, clearly darker
-		];
-	}, []);
-	return (
-		<>
-			<primitive object={grids[0]} />
-			<primitive object={grids[1]} />
-		</>
-	);
-}
+// How far the deck runs in an EXPORTED frame. The viewport fades it out at
+// 18..54 m to keep the working view clean; a blocking frame needs the far edge
+// to survive, so the falloff starts later and ends further away, letting the
+// floor resolve into a horizon instead of dissolving into the background.
+//
+// Both values must stay inside the shot camera's far plane (100 m) — geometry
+// past it is clipped outright, so a fog range that ended beyond it would cut
+// the deck off mid-fade and take the horizon with it.
+const CAPTURE_FOG_NEAR = 55;
+const CAPTURE_FOG_FAR = 95;
 
 /** Offscreen aspect-aware read-back, always from the shot camera. */
 function CaptureRig({ apiRef, camRef, width = CAPTURE_W, height = CAPTURE_H }) {
@@ -1018,12 +997,29 @@ function CaptureRig({ apiRef, camRef, width = CAPTURE_W, height = CAPTURE_H }) {
 				cam.aspect = width / height;
 				cam.updateProjectionMatrix();
 				const previous = gl.getRenderTarget();
+				// The viewport's fog dissolves the deck into the background by ~54 m
+				// so the working view has no horizon to distract from blocking. An
+				// exported frame wants the opposite: the horizon IS the vanishing
+				// point, and without it the floor has no far edge to read depth
+				// against. Push the falloff back for this draw only, then restore
+				// it so the viewport is untouched.
+				const fog = scene.fog;
+				const fogNear = fog?.near;
+				const fogFar = fog?.far;
+				if (fog) {
+					fog.near = CAPTURE_FOG_NEAR;
+					fog.far = CAPTURE_FOG_FAR;
+				}
 				try {
 					gl.setRenderTarget(target);
 					gl.render(scene, cam);
 					gl.readRenderTargetPixels(target, 0, 0, width, height, buffer);
 				} finally {
 					gl.setRenderTarget(previous);
+					if (fog) {
+						fog.near = fogNear;
+						fog.far = fogFar;
+					}
 				}
 				return buffer;
 			},
@@ -6027,7 +6023,11 @@ function resizePromptClip(id, edge, rawFrame) {
 				</div>
 
 					<div className="stage" id="stage" ref={stageRef} data-render-loop={renderActive ? "always" : "demand"}>
-						<Canvas frameloop={renderActive ? "always" : "demand"} dpr={[1, 2]} gl={{ preserveDrawingBuffer: true, antialias: true }}>
+						{/* Shadows were off, so every castShadow in props.jsx was inert and
+						    nothing on the open stage ever touched the floor. A contact
+						    shadow is the cue that says a subject stands ON the deck rather
+						    than floats above it — without walls it is the only one left. */}
+						<Canvas shadows frameloop={renderActive ? "always" : "demand"} dpr={[1, 2]} gl={{ preserveDrawingBuffer: true, antialias: true }}>
 							<RenderLoopController stageRef={stageRef} />
 							<ViewportLayoutInvalidator
 								insetX={insetPos?.x ?? null}
@@ -6273,9 +6273,6 @@ function resizePromptClip(id, edge, rawFrame) {
 								}
 								onGroundClick={waypointMode && !planIsMain ? addFloorWaypoint : undefined}
 							/>
-							{/* Authoring chrome: the grid and pins belong to the Scene tab
-							    only — PlayView is the finished output and shows none of it. */}
-							{centerTab === "scene" && <SceneGrid />}
 							{centerTab === "scene" && railCurve && <CameraRailScenePreview points={railCurve.points} />}
 							{waypointMode && centerTab === "scene" && (
 								<ShotPathPreview waypoints={waypoints} start={charA} activeWaypointFrame={activeWaypointFrame} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,7 +47,6 @@ import { SetProps } from "./props.jsx";
 import {
 	CUTOUT_DEFAULT_HEIGHT,
 	CUTOUT_KIND,
-	CUTOUT_MAX_HEIGHT,
 	DEFAULT_SCENE_OBJECTS,
 	OBJECT_COLORS,
 	createCutoutObject,
@@ -6158,7 +6157,10 @@ function resizePromptClip(id, edge, rawFrame) {
 									onChange={(id, patch) => moveCharacter(activeChar.id, () => {
 										const next = {};
 										if (patch.x !== undefined) next.x = THREE.MathUtils.clamp(patch.x, -4, 4);
-										if (patch.y !== undefined) next.y = THREE.MathUtils.clamp(patch.y, 0, 4);
+										// Lift floors at the deck but has no ceiling — a crane
+										// shot may hoist the body as high as the move needs
+										// (the inspector's Height scrub agrees).
+										if (patch.y !== undefined) next.y = Math.max(0, patch.y);
 										if (patch.z !== undefined) next.z = THREE.MathUtils.clamp(patch.z, -4, 4);
 										// a body only yaws — the X/Z rings and the screen ring's
 										// other channels have nowhere to go on a character
@@ -7273,7 +7275,6 @@ function resizePromptClip(id, edge, rawFrame) {
 												type="number"
 												data-field="cutout-height"
 												min="0.05"
-												max={CUTOUT_MAX_HEIGHT}
 												step="0.05"
 												value={selectedSceneObject.height ?? CUTOUT_DEFAULT_HEIGHT}
 												onChange={(event) => changeSceneObject(selectedSceneObject.id, { height: Number(event.target.value) })}
@@ -7889,9 +7890,14 @@ function SubjectBox({ label, value, onChange, onRemove, onPose, posing, color, o
 					)}
 				</div>
 			</div>
-			<Slider compact label={ko("Left / right", "좌 / 우")} min={-4} max={4} step={0.1} value={value.x} onChange={set("x")} />
-			<Slider compact label={ko("Height", "높이")} min={0} max={4} step={0.05} value={value.y ?? 0} onChange={set("y")} />
-			<Slider compact label={ko("Depth", "깊이")} min={-4} max={4} step={0.1} value={value.z} onChange={set("z")} />
+			<Vector3Row
+				label={ko("Position", "위치")}
+				fields={[
+					{ axis: "X", value: value.x, step: 0.05, precision: 2, onChange: (x) => set("x")(x) },
+					{ axis: "Y", value: value.y ?? 0, step: 0.05, precision: 2, onChange: (y) => set("y")(Math.max(0, y)) },
+					{ axis: "Z", value: value.z, step: 0.05, precision: 2, onChange: (z) => set("z")(z) },
+				]}
+			/>
 			<Slider compact label={ko("Rotate", "회전")} min={-180} max={180} step={1} value={value.rot} unit="°" onChange={set("rot")} />
 		</div>
 	);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -568,6 +568,53 @@ const MULTIMODEL_SAMPLE_FPS = TIMELINE_FPS;
 /* ------------------------------------------------------------------ 3D --- */
 
 // Memoized: unchanged cast members skip re-rendering on every playhead tick.
+/**
+ * Give the head a front.
+ *
+ * Both shipped rigs are smooth helmets with no facial geometry and no texture
+ * of any kind — the FBX materials carry a flat colour and nothing else — and
+ * the app then replaces every material with one clay tone. The result reads as
+ * an ovoid with no direction, which matters most in an exported blocking
+ * frame: the prompt claims a three-quarter front view and the picture has to
+ * back it up.
+ *
+ * Two marks, because they fail in different conditions. The visor is a value
+ * cue and disappears in silhouette or backlight; the brow ridge is a shape cue
+ * and survives both. Both hang off the head bone, so posing, playback and
+ * pose extraction are untouched — nothing here is skinned or animated.
+ *
+ * Sizes are in the head bone's own units. The rig is authored in Mixamo
+ * centimetres and the whole clone is scaled by 0.01 afterwards, so a child of
+ * the bone is written in centimetres too: the skull reaches ~6 cm forward of
+ * the bone, which is 6 units here. Deliberately small — the maquette should
+ * keep reading as a mannequin rather than a robot.
+ */
+function addFacingMarks(clone, markTint) {
+	let head = null;
+	clone.traverse((node) => {
+		if (!head && node.isBone && /head$/i.test(node.name)) head = node;
+	});
+	if (!head) return;
+	const material = new THREE.MeshStandardMaterial({ color: markTint, roughness: 0.7, metalness: 0 });
+	const mark = (geometry, position, rotation) => {
+		const mesh = new THREE.Mesh(geometry, material);
+		mesh.position.set(...position);
+		if (rotation) mesh.rotation.set(...rotation);
+		mesh.castShadow = true;
+		mesh.frustumCulled = false;
+		// The head bone's local +Z is the face direction on both rigs.
+		head.add(mesh);
+		return mesh;
+	};
+	// The skull surface sits ~6 units forward of the bone, so both marks are
+	// placed to break that plane rather than rest on it — flush is invisible.
+	// Visor: a wide, shallow band across the eyeline.
+	mark(new THREE.BoxGeometry(8.5, 2.4, 1.8), [0, 5.5, 6.6], [-0.2, 0, 0]);
+	// Brow ridge: a short wedge that breaks the skull's outline from the side,
+	// so facing survives silhouette and backlight where the visor does not.
+	mark(new THREE.ConeGeometry(1.7, 3.6, 4), [0, 2.8, 6.4], [Math.PI / 2, Math.PI / 4, 0]);
+}
+
 const Character = memo(function Character({ url, position, rot, tint, pose, scale = 1, onRig, pickId }) {
 	const fbx = useFBX(url);
 	const model = useMemo(() => {
@@ -598,6 +645,7 @@ const Character = memo(function Character({ url, position, rot, tint, pose, scal
 				child.castShadow = true;
 			}
 		});
+		addFacingMarks(clone, jointTint);
 		// Stamp the bind pose while the rig is still untouched: the pose effect
 		// below runs immediately after and would otherwise be baked into "rest".
 		primeBindPose(clone);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6596,7 +6596,12 @@ function resizePromptClip(id, edge, rawFrame) {
 					{photoPoseError && <p className="studio-hint error" data-pose-photo-error role="status">{photoPoseError}</p>}
 				</Foldout>
 
-				<Foldout hidden={!isSceneSelection} title={ko("Prompt", "프롬프트")}>
+				{/* Generating is the point of the whole panel, and the operator spends
+				    their time on a character — making them reselect the scene just to
+				    press Generate was friction for no gain. The scene still owns the
+				    prompt (it describes the whole render, not one performer), it is
+				    simply also reachable from the subject being staged. */}
+				<Foldout hidden={!(isSceneSelection || isCharacterSelection)} title={ko("Prompt", "프롬프트")}>
 						<div className="segmented" data-active={mode}>
 							<button className={mode === "image" ? "active" : ""} onClick={() => setMode("image")}>
 							{ko("Image", "이미지")}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,14 @@ import { checkBridge, generate as ardyGenerate } from "./ardy/client.js";
 import { characterScaleFor, loadMotionFromUrl } from "./ardy/npz.js";
 import { retimeMotion } from "./ardy/retime.js";
 import { applyRootDrop, normalizeRootDrop } from "./ardy/root-drop.js";
-import { sliceMotion } from "./ardy/trim.js";
+import {
+	createMotionEdit,
+	motionEditLayout,
+	renderMotionEdit,
+	setMotionSegmentSpeed,
+	splitMotionEdit,
+	trimMotionEdit,
+} from "./ardy/motion-edit.js";
 import { fetchFootageBlob, footageSummary, isPlatformPageUrl, normalizeSourceUrl, probeFootage, requestBridgeExtract, requestBridgeFootage, sourceLabel } from "./multimodel-ingest.js";
 import { bakeExtractedTake, bakePoseFrame, collectLandmarkTrack, createPoseDetector, imageFrames, sampleTimes, videoFrames } from "./pose-extract/index.js";
 import { applyMotionFrame, captureArdyRoot, restorePlaybackBones, snapshotPlaybackBones } from "./ardy/playback.js";
@@ -4341,6 +4348,7 @@ globalThis.playMode = centerTab === "play";
 						anchorZ: take.anchor.z,
 						anchorFrame: 0,
 						rotationDeg: take.rotationDeg,
+						editSegments: createMotionEdit(take.clip.frames),
 					},
 				},
 			};
@@ -4415,6 +4423,7 @@ globalThis.playMode = centerTab === "play";
 				anchorZ: activeChar.z,
 				anchorFrame: 0,
 				rotationDeg: activeChar.rot,
+				editSegments: createMotionEdit(take.frames),
 			};
 			// A baked take is trimmable like any other: without this the strip's
 			// handles would drag against an empty map and cut nothing at all.
@@ -4482,6 +4491,7 @@ globalThis.playMode = centerTab === "play";
 				anchorZ: activeChar.z,
 				anchorFrame: 0,
 				rotationDeg,
+				editSegments: createMotionEdit(decoded.frames),
 			};
 			// The take as loaded is what every future trim cuts from.
 			motionFullRef.current.set(activeChar.id, loaded);
@@ -4581,12 +4591,9 @@ globalThis.playMode = centerTab === "play";
 	function applyMotionTrim(start, end) {
 		const full = motionFullRef.current.get(activeChar.id);
 		if (!full || !motion) return;
-		const offset = (motion.trimOffset ?? 0) + start;
-		const last = (motion.trimOffset ?? 0) + end;
-		if (last >= full.frames || offset > last) return;
-		const sliced = sliceMotion(full, offset, last);
-		const isFull = offset === 0 && sliced.frames === full.frames;
-		setMotion({ ...sliced, url: isFull ? full.url : null, trimOffset: offset });
+		const segments = trimMotionEdit(motion.editSegments ?? createMotionEdit(full.frames), start, end);
+		const sliced = renderMotionEdit(full, segments);
+		setMotion({ ...sliced, url: null });
 		setTlFrameCount(sliced.frames);
 		setTlFrame((frame) => Math.min(frame, sliced.frames - 1));
 		setTlPlaying(false);
@@ -4597,22 +4604,48 @@ globalThis.playMode = centerTab === "play";
 			ikStateRef.current.plants.clear();
 			setIkTick((value) => value + 1);
 			setToast(isKo
-				? `테이크 잘라냄 — ${sliced.frames}프레임 (원본 ${offset}–${last}). 기존 프레임의 IK 키는 초기화됐어요`
-				: `Take cut to ${sliced.frames} frames (source ${offset}–${last}); IK keys keyed to the old frames were cleared`);
+				? `테이크 잘라냄 — ${sliced.frames}프레임. 기존 프레임의 IK 키는 초기화됐어요`
+				: `Take cut to ${sliced.frames} frames; IK keys keyed to the old frames were cleared`);
 		} else {
 			setToast(isKo
-				? `테이크 잘라냄 — ${sliced.frames}프레임 (원본 ${offset}–${last})`
-				: `Take cut to ${sliced.frames} frames (source ${offset}–${last})`);
+				? `테이크 잘라냄 — ${sliced.frames}프레임`
+				: `Take cut to ${sliced.frames} frames`);
 		}
 	}
 
 	function resetMotionTrim() {
 		const full = motionFullRef.current.get(activeChar.id);
-		if (!full || !motion || (motion.trimOffset ?? 0) === 0 && motion.frames === full.frames) return;
-		setMotion({ ...full });
+		if (!full || !motion || motion.frames === full.frames && motion.editSegments?.length === 1) return;
+		setMotion({ ...full, editSegments: createMotionEdit(full.frames) });
 		setTlFrameCount(full.frames);
 		setTlFrame((frame) => Math.min(frame, full.frames - 1));
 		setToast(ko("Full take restored", "테이크 전체 길이 복원"));
+	}
+
+	function editMotionSegments(edit) {
+		const full = motionFullRef.current.get(activeChar.id);
+		if (!full || !motion) return;
+		const rendered = renderMotionEdit(full, edit);
+		setMotion({ ...rendered, url: null });
+		setTlFrameCount(rendered.frames);
+		setTlFrame((frame) => Math.min(frame, rendered.frames - 1));
+		setTlPlaying(false);
+	}
+
+	function cutMotionAtPlayhead() {
+		if (!motion) return;
+		const current = motion.editSegments ?? createMotionEdit(motionFullRef.current.get(activeChar.id)?.frames ?? motion.frames);
+		const next = splitMotionEdit(current, tlFrame);
+		if (next === current) return;
+		editMotionSegments(next);
+		setToast(ko("Full-Body clip cut at the playhead", "전신 클립을 재생 헤드에서 컷했어요"));
+	}
+
+	function changeMotionSegmentSpeed(id, speed) {
+		if (!motion) return;
+		const current = motion.editSegments ?? createMotionEdit(motionFullRef.current.get(activeChar.id)?.frames ?? motion.frames);
+		editMotionSegments(setMotionSegmentSpeed(current, id, speed));
+		setToast(ko(`${speed}× speed applied to the selected segment`, `선택한 구간을 ${speed}×로 설정했어요`));
 	}
 
 	// Drive every cast member from ITS OWN clip on the shared playhead. The
@@ -5787,6 +5820,7 @@ function resizePromptClip(id, edge, rawFrame) {
 			anchorZ: job.anchor.z,
 			anchorFrame: 0,
 			rotationDeg: job.rootRotationDeg,
+			editSegments: createMotionEdit(decoded.frames),
 		};
 		// Same stature rule as loadMotion, on the layer that asked for the clip.
 		const scale = characterScaleFor(decoded);
@@ -5814,6 +5848,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					anchorZ: entry.motionRef.anchorZ,
 					anchorFrame: 0,
 					rotationDeg: entry.motionRef.rotationDeg,
+					editSegments: createMotionEdit(decoded.frames),
 				};
 				motionFullRef.current.set(entry.id, clip);
 				setCharacters((current) => current.map((item) => item.id === entry.id
@@ -7642,9 +7677,15 @@ function resizePromptClip(id, edge, rawFrame) {
 				badge={stateBadge}
 				ikMode={ikMode}
 				ikDisabled={!ikChains}
-				motion={motion ? { frames: motion.frames, label: motion.prompt || ko("Loaded take", "불러온 테이크") } : null}
+				motion={motion ? {
+					frames: motion.frames,
+					label: motion.prompt || ko("Loaded take", "불러온 테이크"),
+					segments: motionEditLayout(motion.editSegments ?? createMotionEdit(motion.frames)),
+				} : null}
 				onMotionTrim={applyMotionTrim}
 				onMotionTrimReset={resetMotionTrim}
+				onMotionCut={cutMotionAtPlayhead}
+				onMotionSpeedChange={changeMotionSegmentSpeed}
 				ikFrames={ikFrames}
 				footSnap={footSnap}
 					shots={shots}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -507,6 +507,7 @@ function toArdySegments(segments) {
 
 const DEFAULT_DURATION_S = 15; // pre-motion timeline duration; shown as duration × TIMELINE_FPS frames
 const DEFAULT_PLAYBACK_SPEED = 1;
+const BRIDGE_RECHECK_MS = 3000;
 const ARDY_PROMPT_HORIZON_FRAMES = 2 * TIMELINE_FPS; // core model horizon: 2 seconds, counted on the timeline clock
 const MAX_WAYPOINTS = 32; // ARDY bridge contract: a root path holds 2..32 distinct waypoint frames
 const ARDY_PROMPT_MAX = 500; // bridge contract: prompt must be non-empty, capped at 500 chars
@@ -5347,16 +5348,19 @@ globalThis.playMode = centerTab === "play";
 		URL.revokeObjectURL(url);
 		setToast(ko("ARDY pose exported", "ARDY 포즈 내보내기 완료"));
 	}
-	// Probe the dev sidecar exactly once. A missing bridge is an expected
-	// state — CozyClay is a static app and the sidecar is an optional dev
-	// companion — so the panel degrades to a hint instead of erroring.
+	// Keep the optional sidecar live instead of freezing its startup state.
+	// Developers commonly open the studio first and start `npm run bridge`
+	// second; a one-shot failed probe left Generate disabled until reload.
 	useEffect(() => {
 		let alive = true;
-		checkBridge().then((state) => {
+		const refreshBridge = () => checkBridge().then((state) => {
 			if (alive) setBridge(state);
 		});
+		refreshBridge();
+		const id = window.setInterval(refreshBridge, BRIDGE_RECHECK_MS);
 		return () => {
 			alive = false;
+			window.clearInterval(id);
 		};
 	}, []);
 
@@ -7149,6 +7153,11 @@ function resizePromptClip(id, edge, rawFrame) {
 							type="button"
 							className="btn primary full generate prompt-block-generate"
 							disabled={!bridge?.ok || !promptClips.some((clip) => clip.text.trim())}
+							title={!bridge?.ok
+								? ko("Waiting for the ARDY bridge — it reconnects automatically", "ARDY 브리지를 기다리는 중 — 자동으로 다시 연결됩니다")
+								: !promptClips.some((clip) => clip.text.trim())
+									? ko("Add a prompt block and describe its motion first", "프롬프트 블록을 추가하고 동작을 먼저 적어 주세요")
+									: ""}
 							onClick={runAllPromptBlocks}
 						>
 							{ardyRunning || genQueue.some((job) => job.status === "queued")

--- a/src/ardy/motion-edit.js
+++ b/src/ardy/motion-edit.js
@@ -1,0 +1,152 @@
+import { retimeMotion } from "./retime.js";
+import { sliceMotion } from "./trim.js";
+
+const SPEED_MIN = 0.1;
+const SPEED_MAX = 4;
+const SPEED_STEP = 0.1;
+const normalizeSpeed = (speed) => Math.round(Number(speed) / SPEED_STEP) * SPEED_STEP;
+
+const segmentSourceFrames = (segment) => segment.sourceEnd - segment.sourceStart + 1;
+const segmentTimelineFrames = (segment) => Math.max(1, Math.round(segmentSourceFrames(segment) / segment.speed));
+
+export function createMotionEdit(frames) {
+	if (!Number.isInteger(frames) || frames < 1) {
+		throw new Error("createMotionEdit: frames must be a positive integer");
+	}
+	return [{ id: "motion-0", sourceStart: 0, sourceEnd: frames - 1, speed: 1 }];
+}
+
+export function motionEditDuration(edit) {
+	if (!Array.isArray(edit) || edit.length < 1) return 0;
+	return edit.reduce((total, segment) => total + segmentTimelineFrames(segment), 0);
+}
+
+export function motionEditLayout(edit) {
+	let cursor = 0;
+	return edit.map((segment) => {
+		const frames = segmentTimelineFrames(segment);
+		const item = {
+			...segment,
+			timelineStart: cursor,
+			timelineEnd: cursor + frames - 1,
+			timelineFrames: frames,
+		};
+		cursor += frames;
+		return item;
+	});
+}
+
+export function timelineFrameToMotionFrame(edit, frame) {
+	const layout = motionEditLayout(edit);
+	if (layout.length < 1) return Math.max(0, Math.round(frame) || 0);
+	const timelineFrame = Math.max(0, Math.min(Number.isFinite(frame) ? frame : 0, layout.at(-1).timelineEnd));
+	const segment = layout.find((item) => timelineFrame <= item.timelineEnd) ?? layout.at(-1);
+	if (segment.timelineFrames <= 1) return segment.sourceStart;
+	const local = timelineFrame - segment.timelineStart;
+	const progress = local / (segment.timelineFrames - 1);
+	return segment.sourceStart + progress * (segment.sourceEnd - segment.sourceStart);
+}
+
+export function splitMotionEdit(edit, timelineFrame) {
+	if (!Array.isArray(edit) || edit.length < 1) return edit;
+	const layout = motionEditLayout(edit);
+	const cut = Math.round(timelineFrame);
+	if (cut <= 0 || cut >= motionEditDuration(edit)) return edit;
+	const index = layout.findIndex((segment) => cut > segment.timelineStart && cut <= segment.timelineEnd);
+	if (index < 0) return edit;
+	const segment = layout[index];
+	const sourceCut = Math.max(
+		segment.sourceStart + 1,
+		Math.min(segment.sourceEnd, Math.round(timelineFrameToMotionFrame(edit, cut))),
+	);
+	if (sourceCut <= segment.sourceStart || sourceCut > segment.sourceEnd) return edit;
+	const next = [...edit];
+	next.splice(index, 1,
+		{ id: `${segment.id}-a`, sourceStart: segment.sourceStart, sourceEnd: sourceCut - 1, speed: segment.speed },
+		{ id: `${segment.id}-b`, sourceStart: sourceCut, sourceEnd: segment.sourceEnd, speed: segment.speed },
+	);
+	return next;
+}
+
+export function setMotionSegmentSpeed(edit, id, speed) {
+	const normalized = normalizeSpeed(speed);
+	if (!Number.isFinite(normalized) || normalized < SPEED_MIN || normalized > SPEED_MAX) {
+		throw new Error("setMotionSegmentSpeed: speed must be between 0.1 and 4.0 in 0.1 steps");
+	}
+	return edit.map((segment) => segment.id === id ? { ...segment, speed: Number(normalized.toFixed(1)) } : segment);
+}
+
+export function trimMotionEdit(edit, startFrame, endFrame) {
+	if (!Array.isArray(edit) || edit.length < 1) return edit;
+	const duration = motionEditDuration(edit);
+	if (
+		!Number.isInteger(startFrame) ||
+		!Number.isInteger(endFrame) ||
+		startFrame < 0 ||
+		endFrame >= duration ||
+		startFrame > endFrame
+	) {
+		throw new Error(`trimMotionEdit: range ${startFrame}..${endFrame} is outside 0..${duration - 1}`);
+	}
+	const layout = motionEditLayout(edit);
+	return layout.flatMap((segment) => {
+		const overlapStart = Math.max(startFrame, segment.timelineStart);
+		const overlapEnd = Math.min(endFrame, segment.timelineEnd);
+		if (overlapStart > overlapEnd) return [];
+		const sourceStart = Math.ceil(timelineFrameToMotionFrame(edit, overlapStart));
+		const sourceEnd = Math.floor(timelineFrameToMotionFrame(edit, overlapEnd));
+		return [{
+			id: `${segment.id}-trim-${sourceStart}`,
+			sourceStart: Math.max(segment.sourceStart, sourceStart),
+			sourceEnd: Math.min(segment.sourceEnd, sourceEnd),
+			speed: segment.speed,
+		}];
+	}).filter((segment) => segment.sourceStart <= segment.sourceEnd);
+}
+
+function copyFrame(source, sourceFrame, target, targetFrame, stride) {
+	const from = sourceFrame * stride;
+	target.set(source.subarray(from, from + stride), targetFrame * stride);
+}
+
+export function renderMotionEdit(full, edit) {
+	if (!full || !Number.isInteger(full.frames) || full.frames < 1 || !Number.isFinite(full.fps) || full.fps <= 0) {
+		throw new Error("renderMotionEdit: motion must have positive frames and fps");
+	}
+	const segments = Array.isArray(edit) && edit.length ? edit : createMotionEdit(full.frames);
+	const rendered = segments.map((segment) => {
+		const sliced = sliceMotion(full, segment.sourceStart, segment.sourceEnd);
+		return segment.speed === 1 ? sliced : retimeMotion(sliced, full.fps / segment.speed);
+	});
+	const frames = rendered.reduce((total, motion) => total + motion.frames, 0);
+	const rotStride = full.rotMats.length / full.frames;
+	const rootStride = full.rootPos.length / full.frames;
+	const posedStride = full.posedJoints.length / full.frames;
+	const rotMats = new Float32Array(frames * rotStride);
+	const rootPos = new Float32Array(frames * rootStride);
+	const posedJoints = new Float32Array(frames * posedStride);
+	let cursor = 0;
+	for (let index = 0; index < rendered.length; index += 1) {
+		const motion = rendered[index];
+		const segment = segments[index];
+		for (let frame = 0; frame < motion.frames; frame += 1) {
+			const finalFrame = frame === motion.frames - 1 && segment.speed > 1;
+			const sourceMotion = finalFrame ? full : motion;
+			const sourceFrame = finalFrame ? segment.sourceEnd : frame;
+			copyFrame(sourceMotion.rotMats, sourceFrame, rotMats, cursor + frame, rotStride);
+			copyFrame(sourceMotion.rootPos, sourceFrame, rootPos, cursor + frame, rootStride);
+			copyFrame(sourceMotion.posedJoints, sourceFrame, posedJoints, cursor + frame, posedStride);
+		}
+		cursor += motion.frames;
+	}
+	return {
+		...full,
+		frames,
+		fps: full.fps,
+		rotMats,
+		rootPos,
+		posedJoints,
+		anchorFrame: 0,
+		editSegments: segments.map((segment) => ({ ...segment })),
+	};
+}

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -257,6 +257,8 @@ export default function Timeline({
 	onShotMove,
 	onMotionTrim,
 	onMotionTrimReset,
+	onMotionCut,
+	onMotionSpeedChange,
 }) {
 	const [expanded, setExpanded] = useState(true);
 	const [zoom, setZoom] = useState(ZOOM_DEFAULT);
@@ -277,7 +279,7 @@ export default function Timeline({
 	// The window key/interval handlers register once; the latest callbacks
 	// are read through a ref so they never go stale mid-playback.
 	const handlers = useRef({});
-	handlers.current = { onScrub, onAdvance, onStep, onPlayToggle, onWaypointToggle, onMarkerSelect, onMarkerRemove, onRootKeyframeAdd, onPromptAdd, onPromptSelect, onPromptChange, onPromptResize, onPromptMove, onPromptRemove, onIkToggle, onIkKeyframeAdd, onIkKeyframeRemove, onFootSnapToggle, onCameraMoveSelect, onCameraKeyframeAdd, onCameraKeyframeMove, onCameraKeyframeRemove, onCameraBlockSelect, onCameraBlockChange, onCameraPreview, onCameraRailDrawToggle, onCameraRailDelete, onRailSelect, onRailMove, onRailRangeChange, onRailRemove, onShotSelect, onShotBoundaryMove, onShotRename, onShotRemove, onShotDuplicate, onShotCut, onShotSplit, onShotMove, onMotionTrim, onMotionTrimReset };
+	handlers.current = { onScrub, onAdvance, onStep, onPlayToggle, onWaypointToggle, onMarkerSelect, onMarkerRemove, onRootKeyframeAdd, onPromptAdd, onPromptSelect, onPromptChange, onPromptResize, onPromptMove, onPromptRemove, onIkToggle, onIkKeyframeAdd, onIkKeyframeRemove, onFootSnapToggle, onCameraMoveSelect, onCameraKeyframeAdd, onCameraKeyframeMove, onCameraKeyframeRemove, onCameraBlockSelect, onCameraBlockChange, onCameraPreview, onCameraRailDrawToggle, onCameraRailDelete, onRailSelect, onRailMove, onRailRangeChange, onRailRemove, onShotSelect, onShotBoundaryMove, onShotRename, onShotRemove, onShotDuplicate, onShotCut, onShotSplit, onShotMove, onMotionTrim, onMotionTrimReset, onMotionCut, onMotionSpeedChange };
 
 	// Trackpad/wheel zoom over the FRAME ruler lane only. React registers
 	// onWheel as passive, so a synthetic onWheel could never preventDefault —
@@ -822,6 +824,21 @@ export default function Timeline({
 
 	const cameraBlockIdx = selectedCameraBlockIdx === undefined ? localCameraBlockIdx : selectedCameraBlockIdx;
 	const selectedCameraShot = cameraBlockIdx == null ? null : shots[cameraBlockIdx] ?? null;
+	const motionSegments = motion?.segments ?? [];
+	const selectedMotionSegment = motionSegments.find((segment) => frame >= segment.timelineStart && frame <= segment.timelineEnd) ?? motionSegments[0] ?? null;
+	const visibleMotionSegments = trimPreview
+		? [{
+			id: "motion-trim-preview",
+			timelineStart: trimPreview.start,
+			timelineEnd: trimPreview.end,
+			speed: null,
+			preview: true,
+		}]
+		: motionSegments;
+	const changeSelectedMotionSpeed = (speed) => {
+		if (!selectedMotionSegment || !Number.isFinite(speed)) return;
+		handlers.current.onMotionSpeedChange?.(selectedMotionSegment.id, Math.max(0.1, Math.min(4, speed)));
+	};
 
 	return (
 		<section className={"timeline" + (expanded ? "" : " collapsed")} aria-label={ko("Animation timeline", "애니메이션 타임라인")}>
@@ -860,6 +877,30 @@ export default function Timeline({
 								<b>{frame}</b> / {frameCount - 1} · {fps} fps · {playbackSpeed.toFixed(2)}×
 							</span>
 						</div>
+						{selectedMotionSegment && (
+							<label className="tl-motion-speed-editor">
+								<span>{ko(`Segment ${motionSegments.indexOf(selectedMotionSegment) + 1} speed`, `구간 ${motionSegments.indexOf(selectedMotionSegment) + 1} 배율`)}</span>
+								<input
+									type="range"
+									min="0.1"
+									max="4"
+									step="0.1"
+									value={selectedMotionSegment.speed}
+									aria-label={ko("Selected Full-Body segment speed", "선택한 전신 구간 배율")}
+									onChange={(event) => changeSelectedMotionSpeed(event.currentTarget.valueAsNumber)}
+								/>
+								<input
+									type="number"
+									min="0.1"
+									max="4"
+									step="0.1"
+									value={selectedMotionSegment.speed}
+									aria-label={ko("Selected Full-Body segment speed value", "선택한 전신 구간 배율 값")}
+									onChange={(event) => changeSelectedMotionSpeed(event.currentTarget.valueAsNumber)}
+								/>
+								<small>×</small>
+							</label>
+						)}
 						<button
 							type="button"
 							className={"tl-btn zoom" + (zoom !== ZOOM_DEFAULT ? " on" : "")}
@@ -1025,6 +1066,17 @@ export default function Timeline({
 											+
 										</button>
 									)}
+									{name === IK_LANE && motion && (
+										<button
+											className="tl-track-add motion-cut"
+											type="button"
+											disabled={frame <= 0 || frame >= motion.frames}
+											title={ko("Cut the Full-Body clip at the playhead", "재생 헤드에서 전신 클립 컷")}
+											onClick={() => handlers.current.onMotionCut?.()}
+										>
+											{ko("Cut", "컷")}
+										</button>
+									)}
 								</span>
 								<div
 									className={"tl-lane" + (name === "2D Root" ? " root" : "") + (name === SHOTS_LANE ? " shots" : "")}
@@ -1185,18 +1237,19 @@ export default function Timeline({
 											</div>
 										);
 									})}
-									{name === IK_LANE && motion && (
+									{name === IK_LANE && visibleMotionSegments.map((segment, index) => (
 										<div
-											className={"tl-motion-clip" + (trimPreview ? " trimming" : "")}
+											key={segment.id}
+											className={"tl-motion-clip" + (trimPreview ? " trimming" : "") + (selectedMotionSegment?.id === segment.id ? " selected" : "")}
 											style={{
-												"--tl-f-start": clipPct(trimPreview ? trimPreview.start : 0),
-												"--tl-f-end": clipPct(trimPreview ? trimPreview.end + 1 : Math.min(motion.frames, displayFrameCount)),
+												"--tl-f-start": clipPct(trimPreview ? trimPreview.start : segment.timelineStart),
+												"--tl-f-end": clipPct(trimPreview ? trimPreview.end + 1 : Math.min(segment.timelineEnd + 1, displayFrameCount)),
 											}}
-											title={isKo
-												? `불러온 테이크 — ${motion.frames}프레임. 양끝 핸들로 잘라내고, 핸들 우클릭으로 전체 길이 복원`
-												: `Loaded take — ${motion.frames} frames. Drag the end handles to cut; right-click a handle to restore the full take`}
+											title={segment.preview ? undefined : isKo
+												? `전신 구간 ${index + 1} — ${segment.speed}×. 컷은 재생 헤드에서, 속도는 메뉴에서 변경`
+												: `Full-Body segment ${index + 1} — ${segment.speed}×. Cut at the playhead; change speed from the menu`}
 										>
-											<button
+											{index === 0 && <button
 												className="tl-motion-clip-handle start"
 												type="button"
 												aria-label={ko("Trim take start", "테이크 시작점 자르기")}
@@ -1205,13 +1258,13 @@ export default function Timeline({
 												onPointerUp={endMotionTrim}
 												onPointerCancel={endMotionTrim}
 												onContextMenu={(e) => { e.preventDefault(); handlers.current.onMotionTrimReset?.(); }}
-											/>
+											/>}
 											<span className="tl-motion-clip-label">
-												{trimPreview
+												{segment.preview
 													? `${trimPreview.start}–${trimPreview.end} (${trimPreview.end - trimPreview.start + 1}f)`
-													: motion.label}
+													: `${index + 1} · ${segment.speed}×`}
 											</span>
-											<button
+											{index === visibleMotionSegments.length - 1 && <button
 												className="tl-motion-clip-handle end"
 												type="button"
 												aria-label={ko("Trim take end", "테이크 끝점 자르기")}
@@ -1220,9 +1273,9 @@ export default function Timeline({
 												onPointerUp={endMotionTrim}
 												onPointerCancel={endMotionTrim}
 												onContextMenu={(e) => { e.preventDefault(); handlers.current.onMotionTrimReset?.(); }}
-											/>
+											/>}
 										</div>
-									)}
+									))}
 									{name === IK_LANE &&
 										ikFrames.map((f) => (
 											<span

--- a/src/camera-follow.js
+++ b/src/camera-follow.js
@@ -42,7 +42,7 @@ function cappedSpringStep(pos, vel, target, omega, dt, maxSpeed) {
 const PITCH_LIMIT = (85 * Math.PI) / 180;
 
 function offsetPitch(pitch, offsetDeg) {
-	const safeOffset = Math.max(-30, Math.min(Number.isFinite(offsetDeg) ? offsetDeg : 0, 30));
+	const safeOffset = Math.max(-170, Math.min(Number.isFinite(offsetDeg) ? offsetDeg : 0, 170));
 	return Math.max(-PITCH_LIMIT, Math.min(pitch + (safeOffset * Math.PI) / 180, PITCH_LIMIT));
 }
 
@@ -82,8 +82,8 @@ export function followFramingFromCamera(position, pitch, subject, aimHeight = FO
 	) * 180) / Math.PI;
 	return {
 		distance: rounded(clamp(planarDistance, 0.5, 15), 2),
-		height: rounded(clamp(position.y, 0.2, 6), 2),
-		pitchOffsetDeg: rounded(clamp(((pitch - automaticPitch) * 180) / Math.PI, -30, 30), 1),
+		height: rounded(Math.max(position.y, 0.2), 2),
+		pitchOffsetDeg: rounded(clamp(((pitch - automaticPitch) * 180) / Math.PI, -170, 170), 1),
 		orbitOffsetDeg: rounded(clamp(orbitOffsetDeg, -180, 180), 1),
 	};
 }

--- a/src/dualview.jsx
+++ b/src/dualview.jsx
@@ -24,6 +24,10 @@ export const POSER_LAYER = 4;
 export const GIZMO_LAYER = 5;
 /** the shot camera is locked to the export aspect no matter which pane holds it */
 export const SHOT_ASPECT = 16 / 9;
+/** Letterbox bars are chrome, so they wear the editor's background (--bg in
+ * styles.css) rather than the scene's sky. Kept in sync by eye: a mismatch
+ * here reads as a seam around the frame, not as a wrong colour. */
+export const LETTERBOX = new THREE.Color("#1e1e1e");
 /** half-height of the plan frustum, in metres — covers the full camera throw */
 export const PLAN_EXTENT = 12.4;
 
@@ -213,13 +217,19 @@ export function DualRender({ stageRef, mainRef, insetRef, shotCamRef, planCamRef
 		const planPane = planIsMain ? mainRect : insetRect;
 		const shotPane = planIsMain ? insetRect : mainRect;
 
-		// scissor bounds the clear, viewport bounds the image: letterbox bars in
-		// the shot pane get painted with the scene background instead of leaking
-		// whatever was underneath.
+		// scissor bounds the clear, viewport bounds the image. The bars around a
+		// letterboxed frame are editor surface, not set: painting them with the
+		// scene background put a sheet of near-white either side of the shot the
+		// moment an aspect narrower than the pane was chosen, which is glare
+		// rather than information. They take the editor's own tone instead, and
+		// the scene draw is scissored to the image so the sky inside the frame is
+		// untouched.
 		const draw = (camera, pane, imageRect, ink = true) => {
 			const glY = size.height - (pane.y + pane.h);
 			gl.setScissorTest(true);
 			gl.setScissor(pane.x, glY, pane.w, pane.h);
+			gl.setClearColor(LETTERBOX, 1);
+			gl.clear(true, true, false);
 			const img = imageRect ?? pane;
 			const imgY = size.height - (img.y + img.h);
 			if (ink) {
@@ -244,7 +254,9 @@ export function DualRender({ stageRef, mainRef, insetRef, shotCamRef, planCamRef
 			}
 			gl.setRenderTarget(null);
 			gl.setScissorTest(true);
-			gl.setScissor(pane.x, glY, pane.w, pane.h);
+			// The image only: three.js clears with the scene background before it
+			// draws, so scissoring to the pane here would repaint the bars white.
+			gl.setScissor(img.x, imgY, img.w, img.h);
 			gl.setViewport(img.x, imgY, img.w, img.h);
 			gl.render(scene, camera);
 			if (ink) {

--- a/src/room.jsx
+++ b/src/room.jsx
@@ -1,3 +1,6 @@
+import { useEffect, useMemo } from "react";
+import * as THREE from "three";
+
 /**
  * The blocking set: an open stage floor.
  *
@@ -14,16 +17,67 @@
 
 // Bright enough to sit clearly above the grid lines: the deck reads as a lit
 // surface with lines drawn ON it, not as a dark line-texture tiling to the fog.
-const FLOOR = "#f4f0e8";
+//
+// Lit, not unlit. An unlit deck renders one flat colour across its whole 500 m,
+// which costs an exported blocking frame two depth cues at once: the falloff
+// that says how far away the floor is, and the contact shading that says the
+// subject is standing ON it rather than floating. The colour is lifted to
+// compensate for the shading the lambert term now applies, so the deck keeps
+// the same on-screen brightness it had while unlit.
+const FLOOR = "#fffdf7";
 
 export const STAGE_SIZE = 500;
 
+/** Metres per grid tile; one heavy line per tile, minor lines every metre. */
+const TILE_M = 10;
+
+/**
+ * The measuring grid, drawn INTO the deck rather than floating above it.
+ *
+ * A GridHelper is a separate object a couple of millimetres over a 500 m
+ * plane, and at that separation it loses to the floor across almost the whole
+ * frame — it survives only where the surface is grazed near the horizon, which
+ * is exactly where it is useless. Baking the lines into the floor's own map
+ * ends the contest: the marks ARE the surface, so they cannot z-fight with it,
+ * cannot be sorted behind it, and shade and fog exactly as the deck does.
+ */
+function makeGridTexture() {
+	const PX = 1024;
+	const pxPerM = PX / TILE_M;
+	const canvas = document.createElement("canvas");
+	canvas.width = PX;
+	canvas.height = PX;
+	const ctx = canvas.getContext("2d");
+	ctx.fillStyle = "#ffffff";
+	ctx.fillRect(0, 0, PX, PX);
+	ctx.strokeStyle = "rgba(120, 110, 92, 0.34)";
+	ctx.lineWidth = 2;
+	for (let m = 1; m < TILE_M; m += 1) {
+		const p = Math.round(m * pxPerM) + 0.5;
+		ctx.beginPath(); ctx.moveTo(p, 0); ctx.lineTo(p, PX); ctx.stroke();
+		ctx.beginPath(); ctx.moveTo(0, p); ctx.lineTo(PX, p); ctx.stroke();
+	}
+	// The ten-metre lines carry the scale read, so they stay heavier.
+	ctx.strokeStyle = "rgba(96, 86, 68, 0.6)";
+	ctx.lineWidth = 5;
+	ctx.strokeRect(0, 0, PX, PX);
+	const texture = new THREE.CanvasTexture(canvas);
+	texture.wrapS = THREE.RepeatWrapping;
+	texture.wrapT = THREE.RepeatWrapping;
+	texture.repeat.set(STAGE_SIZE / TILE_M, STAGE_SIZE / TILE_M);
+	texture.anisotropy = 8;
+	texture.colorSpace = THREE.SRGBColorSpace;
+	return texture;
+}
+
 export function Room() {
+	const grid = useMemo(() => makeGridTexture(), []);
+	useEffect(() => () => grid.dispose(), [grid]);
 	return (
 		<group>
-			<mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+			<mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]} receiveShadow>
 				<planeGeometry args={[STAGE_SIZE, STAGE_SIZE]} />
-				<meshBasicMaterial color={FLOOR} />
+				<meshLambertMaterial color={FLOOR} map={grid} />
 			</mesh>
 		</group>
 	);
@@ -35,7 +89,26 @@ export function StageLights() {
 		<>
 			<hemisphereLight args={["#fffdf6", "#d8d0c3", 0.9]} />
 			<ambientLight intensity={0.18} />
-			<directionalLight color="#fff8e8" position={[6, 9, 4]} intensity={1.12} />
+			{/* Only the key casts: one soft, unambiguous contact shadow reads as
+			    ground contact, while three overlapping shadows read as noise. The
+			    map covers the blocking area rather than the whole 500 m deck — a
+			    stage-wide frustum would spend its resolution on empty floor. */}
+			<directionalLight
+				color="#fff8e8"
+				position={[6, 9, 4]}
+				intensity={1.12}
+				castShadow
+				shadow-mapSize-width={2048}
+				shadow-mapSize-height={2048}
+				shadow-camera-left={-14}
+				shadow-camera-right={14}
+				shadow-camera-top={14}
+				shadow-camera-bottom={-14}
+				shadow-camera-near={0.5}
+				shadow-camera-far={40}
+				shadow-bias={-0.0006}
+				shadow-normalBias={0.02}
+			/>
 			<directionalLight color="#dff6f7" position={[-6, 4, -4]} intensity={0.36} />
 			<directionalLight color="#ffffff" position={[2, 3, 9]} intensity={0.22} />
 		</>

--- a/src/scene-objects.js
+++ b/src/scene-objects.js
@@ -91,11 +91,6 @@ export const CUTOUT_THICKNESS = 0.02;
 /** A fresh cutout stands as tall as the figure it blocks against
  * (SUBJECT_HEIGHT_M), so the first thing you see is honest scale. */
 export const CUTOUT_DEFAULT_HEIGHT = 1.8;
-/** A card can be as tall as anything else on the deck: the walls are gone and
- * a skyline piece or a building facade is a legitimate cutout. Exported so the
- * inspector's field and the tests take the limit from here rather than
- * repeating a number that has already changed once. */
-export const CUTOUT_MAX_HEIGHT = CEILING;
 const CUTOUT_HEIGHT_MIN = 0.05;
 const CUTOUT_ASPECT_MIN = 0.02;
 const CUTOUT_ASPECT_MAX = 50;
@@ -119,7 +114,7 @@ function objectLibraryEntry(kind) {
 	return OBJECT_LIBRARY.find((entry) => entry.kind === kind) ?? null;
 }
 
-const cutoutHeight = (value) => clamp(value, CUTOUT_HEIGHT_MIN, CUTOUT_MAX_HEIGHT);
+const cutoutHeight = (value) => Math.max(CUTOUT_HEIGHT_MIN, value);
 const cutoutAspect = (value) => clamp(value, CUTOUT_ASPECT_MIN, CUTOUT_ASPECT_MAX);
 
 /** How far a card may be pulled off the picture's own proportions. */

--- a/src/scenes.js
+++ b/src/scenes.js
@@ -107,7 +107,9 @@ export function createCharacterEntry(source = null, index = 0) {
 		id: typeof s.id === "string" && s.id ? s.id : `char-${index + 1}`,
 		model: CHARACTER_MODEL_IDS.includes(s.model) ? s.model : DEFAULT_CHARACTER_MODEL,
 		x: finiteOr(s.x, 0),
-		y: finiteOr(s.y, 0),
+		// Lift floors at the deck; there is deliberately no ceiling, so every
+		// writer (inspector field, viewport gizmo, load path) shares max(0, y).
+		y: Math.max(0, finiteOr(s.y, 0)),
 		z: finiteOr(s.z, 0),
 		rot: finiteOr(s.rot, 0),
 		hidden: s.hidden === true,

--- a/src/shot-authoring.js
+++ b/src/shot-authoring.js
@@ -64,11 +64,11 @@ function rescaleShotAuthoringFrames(parsed) {
 
 const FOLLOW_BOUNDS = {
 	distance: [0.5, 15],
-	height: [0.2, 6],
+	height: [0.2, Number.POSITIVE_INFINITY],
 	response: [0.1, 3],
 	lead: [0, 1],
 	maxDollySpeed: [0.2, 8],
-	pitchOffsetDeg: [-30, 30],
+	pitchOffsetDeg: [-170, 170],
 	orbitOffsetDeg: [-180, 180],
 };
 const FOLLOW_DEFAULTS = {

--- a/src/shot.js
+++ b/src/shot.js
@@ -265,7 +265,7 @@ export function composePrompt({
 	const move = cameraMove === CUSTOM_MOVE ? customMove.trim() || "static, locked-off shot" : cameraMove.toLowerCase();
 
 	const guide =
-		"Use the attached blocking frame ONLY as a camera and staging guide — it fixes the exact framing, this camera angle, the lens, and the subject placement. Replace the entire setting with the described environment and render real people; do NOT reproduce its grey mannequins, grey box set, or flat lighting.";
+		"Use the attached blocking frame ONLY as a camera and staging guide — it fixes the exact framing, this camera angle, the lens, and the subject placement. Its floor grid is a measuring aid that encodes distance and scale: read the subject's depth and size from it, but do NOT draw the grid itself. Replace the entire setting with the described environment and render real people; do NOT reproduce its grey mannequins, grey box set, measurement grid, or flat lighting.";
 
 	const parts = [
 		opening,

--- a/src/styles.css
+++ b/src/styles.css
@@ -2425,6 +2425,12 @@ input[type=range]::-moz-range-thumb {
 	font-weight: 500;
 	flex: none;
 }
+/* A soft-max slider scrubs from its head like a NumberField axis. */
+.cslider-head.scrub {
+	cursor: ew-resize;
+	user-select: none;
+	touch-action: none;
+}
 .cslider input[type=range] {
 	width: 100%;
 	display: block;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2886,6 +2886,51 @@ input[type=range]::-moz-range-thumb {
 	gap: 6px;
 }
 
+.tl-motion-speed-editor {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	min-width: 220px;
+	padding: 2px 7px;
+	border: 1px solid rgba(126, 208, 143, .32);
+	border-radius: 5px;
+	background: rgba(23, 29, 25, .92);
+	color: #b9efc0;
+	font-size: 9px;
+	white-space: nowrap;
+}
+
+.tl-motion-speed-editor > span {
+	font-weight: 600;
+}
+
+.tl-motion-speed-editor input[type="range"] {
+	width: 90px;
+	accent-color: #7ed08f;
+	cursor: ew-resize;
+}
+
+.tl-motion-speed-editor input[type="number"] {
+	width: 44px;
+	height: 18px;
+	padding: 0 3px;
+	border: 1px solid rgba(159, 224, 167, .42);
+	border-radius: 3px;
+	background: #101713;
+	color: #d3f5d8;
+	font: inherit;
+	font-variant-numeric: tabular-nums;
+}
+
+.tl-motion-speed-editor input:focus-visible {
+	outline: 2px solid #fff;
+	outline-offset: 1px;
+}
+
+.tl-motion-speed-editor small {
+	color: #7ed08f;
+}
+
 .tl-btn {
 	width: 26px;
 	height: 22px;
@@ -3176,7 +3221,8 @@ input[type=range]::-moz-range-thumb {
 	letter-spacing: .02em;
 	white-space: nowrap;
 	overflow: hidden;
-	pointer-events: none; /* passive: IK markers on this lane stay clickable */
+	pointer-events: auto;
+	container-type: inline-size;
 }
 
 .tl-motion-clip.trimming {
@@ -3184,11 +3230,30 @@ input[type=range]::-moz-range-thumb {
 	border-color: rgba(126, 208, 143, .8);
 }
 
+.tl-motion-clip.selected {
+	border-color: rgba(159, 224, 167, .95);
+	box-shadow: 0 0 10px rgba(126, 208, 143, .28);
+}
+
 .tl-motion-clip-label {
 	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	text-align: center;
+}
+
+.tl-track-add.motion-cut {
+	width: auto;
+	min-width: 34px;
+	padding: 0 6px;
+	color: #9fe0a7;
+	border-color: rgba(126, 208, 143, .38);
+	font-size: 9px;
+}
+
+.tl-track-add.motion-cut:disabled {
+	opacity: .35;
+	cursor: default;
 }
 
 /* the strip body stays click-through (IK markers live on this lane); only

--- a/src/ui.jsx
+++ b/src/ui.jsx
@@ -199,12 +199,40 @@ export function Toast({ message, onDone, duration = 2200 }) {
 // Range slider with the reference's filled-track gradient. `value` may be a
 // raw float (e.g. from drag interactions), so it is clamped and the label is
 // rounded to the slider's own step precision.
-export function Slider({ label, min, max, step, value, unit = "", onChange, compact }) {
-	const clamped = Math.min(max, Math.max(min, value));
+//
+// `softMax` keeps the track's useful range but treats `max` as a soft stop:
+// the compact head scrubs like a NumberField axis (pointer drag, Shift 10x,
+// Alt 0.1x), floored at `min` and unbounded above, and the readout shows the
+// true stored value even past `max`. The track itself still writes only
+// in-range values and the fill simply saturates.
+export function Slider({ label, min, max, step, value, unit = "", onChange, compact, softMax }) {
+	const scrubRef = useRef(null);
+	const floored = Math.max(min, value);
+	const clamped = Math.min(max, floored);
 	const percent = Math.max(0, Math.min(100, ((clamped - min) / (max - min)) * 100));
 	const decimals = (String(step).split(".")[1] || "").length;
 	const snapped = Math.round((clamped - min) / step) * step + min;
-	const text = String(decimals > 0 ? Number(snapped.toFixed(decimals)) : Math.round(snapped));
+	const shown = softMax ? floored : snapped;
+	const text = String(decimals > 0 ? Number(shown.toFixed(decimals)) : Math.round(shown));
+	const onScrubDown = (e) => {
+		e.preventDefault();
+		scrubRef.current = { x: e.clientX, base: floored };
+		e.currentTarget.setPointerCapture(e.pointerId);
+	};
+	const onScrubMove = (e) => {
+		const drag = scrubRef.current;
+		if (!drag) return;
+		const multiplier = e.shiftKey ? 10 : e.altKey ? 0.1 : 1;
+		onChange(Math.max(min, drag.base + (e.clientX - drag.x) * step * multiplier));
+	};
+	const onScrubEnd = (e) => {
+		if (!scrubRef.current) return;
+		scrubRef.current = null;
+		if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
+	};
+	const scrubProps = softMax
+		? { onPointerDown: onScrubDown, onPointerMove: onScrubMove, onPointerUp: onScrubEnd, onPointerCancel: onScrubEnd }
+		: null;
 	const input = (
 		<input
 			type="range"
@@ -219,7 +247,7 @@ export function Slider({ label, min, max, step, value, unit = "", onChange, comp
 	if (compact) {
 		return (
 			<div className="cslider">
-				<div className="cslider-head">
+				<div className={"cslider-head" + (softMax ? " scrub" : "")} {...scrubProps}>
 					<span>{label}</span>
 					<span className="val">
 						{text}

--- a/test/verify-blocking-depth.mjs
+++ b/test/verify-blocking-depth.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+// The blocking frame is the only thing that tells an AI how far away the
+// subject is. The stage has no walls, so every depth cue it carries is one we
+// put there on purpose: the grid's converging cells, the floor's distance
+// shading and contact shadow, and a horizon the fog does not eat.
+//
+// Each of those was absent, and each went absent for a defensible reason
+// (chrome belongs in the viewport; an unlit deck is cheap; a fogged horizon is
+// tidy). These checks pin the reasons back to the surface that needs them, so
+// a future cleanup cannot quietly flatten the deliverable again.
+
+import { readFileSync } from "node:fs";
+import { composePrompt, deriveShot } from "../src/shot.js";
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+const room = readFileSync(new URL("../src/room.jsx", import.meta.url), "utf8");
+
+/* --- the grid is baked into the deck, not floated over it ----------------- */
+
+// A helper two millimetres above a 500 m plane loses to the floor across the
+// whole frame and survives only at the grazed horizon, which is where it is
+// useless. Baking the lines into the floor's own map ends that contest.
+expect("the deck carries a grid texture", room.includes("function makeGridTexture()") && room.includes("map={grid}"));
+expect("the grid tiles in metres across the whole deck", room.includes("texture.repeat.set(STAGE_SIZE / TILE_M, STAGE_SIZE / TILE_M);") && room.includes("const TILE_M = 10;"));
+expect("the grid wraps rather than stretching once", room.includes("THREE.RepeatWrapping"));
+expect("the texture is released with the room", room.includes("grid.dispose()"));
+expect("no floating grid helper is layered over the deck", !app.includes("new THREE.GridHelper"));
+
+/* --- the floor shades with distance and takes a contact shadow ------------- */
+
+expect("the deck is lit rather than flat-filled", room.includes("<meshLambertMaterial color={FLOOR} map={grid} />"));
+expect("the deck receives shadow", room.includes("receiveShadow"));
+expect("the key light casts one shadow", room.includes("castShadow") && room.includes("shadow-mapSize-width={2048}"));
+expect(
+	"the shadow frustum covers the blocking area, not the whole 500 m deck",
+	room.includes("shadow-camera-left={-14}") && room.includes("shadow-camera-far={40}"),
+);
+expect("the renderer actually has shadows enabled", app.includes("<Canvas shadows frameloop="));
+expect("the subject casts its own shadow", app.includes("child.castShadow = true;"));
+
+/* --- the exported frame keeps a horizon ------------------------------------ */
+
+// Both fog bounds must stay inside the shot camera's 100 m far plane, or the
+// deck is clipped mid-fade and the horizon never resolves.
+expect("the capture fog stays inside the camera far plane", app.includes("const CAPTURE_FOG_FAR = 95;") && app.includes("far={100}"));
+expect(
+	"the capture pushes the fog back and restores it",
+	app.includes("const CAPTURE_FOG_NEAR = 55;") &&
+	app.includes("const CAPTURE_FOG_FAR = 95;") &&
+	app.includes("fog.near = CAPTURE_FOG_NEAR;") &&
+	app.includes("fog.near = fogNear;"),
+);
+expect(
+	"the viewport fog is untouched",
+	app.includes('<fog attach="fog" args={["#eef4f3", 18, 54]} />'),
+);
+const captureFog = app.indexOf("fog.near = CAPTURE_FOG_NEAR;");
+const restoreFog = app.indexOf("fog.near = fogNear;");
+expect("the restore happens after the render, in a finally", captureFog > 0 && restoreFog > captureFog);
+
+/* --- the AI is told to read the grid, not draw it -------------------------- */
+
+const shot = deriveShot({ x: 0, y: 1.6, z: 3 }, { x: 0, z: 0, rot: 0 }, (45 * Math.PI) / 180);
+const prompt = composePrompt({
+	shot,
+	subject: "a young woman in a tan coat",
+	environment: "a sunlit modern living room",
+	style: "35mm film look",
+});
+expect("the prompt explains the grid encodes distance", /grid is a measuring aid/i.test(prompt), prompt.slice(0, 120));
+expect("the prompt forbids drawing the grid", /do NOT draw the grid itself/i.test(prompt));
+expect("the grid joins the do-not-reproduce list", /measurement grid/i.test(prompt));
+
+const sheeted = composePrompt({
+	shot,
+	subject: "a young woman in a tan coat",
+	environment: "a sunlit modern living room",
+	style: "35mm film look",
+	hasCharSheet: true,
+	hasEnvSheet: true,
+});
+expect("sheet mode still carries the grid instruction", /do NOT draw the grid itself/i.test(sheeted));
+expect("sheet mode drops the preset subject and environment text", !sheeted.includes("tan coat") && !sheeted.includes("sunlit modern living room"));
+
+if (failures) process.exit(1);
+console.log("blocking-frame depth checks PASS");

--- a/test/verify-camera-follow.mjs
+++ b/test/verify-camera-follow.mjs
@@ -40,13 +40,29 @@ const EPS = 1e-9;
 }
 
 {
-	const measured = followFramingFromCamera(
+	const position = { x: 0, y: 12, z: 3 };
+	const authoredPitch = (-30 * Math.PI) / 180;
+	const measured = followFramingFromCamera(position, authoredPitch, { x: 0, z: 0 });
+	const replayed = buildFollowTrack([{ x: 0, z: 0 }], FPS, measured)[0];
+	ok(
+		"a high camera preserves its authored pitch through follow measurement and replay",
+		Math.abs(replayed.pitch - authoredPitch) < 0.002,
+		JSON.stringify({ measured, replayedPitchDeg: (replayed.pitch * 180) / Math.PI }),
+	);
+}
+
+{
+const measured = followFramingFromCamera(
 		{ x: 0, y: 1.6, z: 3 },
 		0,
 		{ x: 0, z: 0 },
 		FOLLOW_DEFAULTS.aimHeight,
 		{ x: 0, z: 1 },
-	);
+);
+ok(
+	"captured camera height has no six-metre ceiling",
+	followFramingFromCamera({ x: 0, y: 12, z: -3 }, 0, { x: 0, z: 0 }).height === 12,
+);
 	ok("viewport framing records a camera placed in front of the subject", Math.abs(measured.orbitOffsetDeg - 180) < 1e-6, JSON.stringify(measured));
 }
 
@@ -263,10 +279,10 @@ ok("free follow emits one sample per subject frame", free.length === walk.length
 	const highTarget = Array.from({ length: 2 }, () => ({ x: 0, z: 0 }));
 	const closeRail = buildRail([{ x: -0.001, z: 0 }, { x: -0.001, z: 1 }]);
 	const clamped = buildRailFollowTrack(highTarget, FPS, closeRail, { height: -10, pitchOffsetDeg: 30 });
-	const oversizedOffset = buildRailFollowTrack(subject, FPS, rail, { pitchOffsetDeg: 100 });
-	const maxOffset = buildRailFollowTrack(subject, FPS, rail, { pitchOffsetDeg: 30 });
+	const oversizedOffset = buildRailFollowTrack(subject, FPS, rail, { pitchOffsetDeg: 999 });
+	const maxOffset = buildRailFollowTrack(subject, FPS, rail, { pitchOffsetDeg: 170 });
 	ok("pitch safety clamp stays within ±85°", clamped.every((sample) => Math.abs(sample.pitch) <= (85 * Math.PI) / 180 + EPS));
-	ok("pitch input clamps to the authored ±30° range", oversizedOffset.every((sample, i) => sample.pitch === maxOffset[i].pitch));
+	ok("pitch input covers the full possible authored offset range", oversizedOffset.every((sample, i) => sample.pitch === maxOffset[i].pitch));
 
 	const raised = buildRailFollowTrack(subject, FPS, rail, { height: 2.4 });
 	ok("height changes rig position independently of pitch offset", raised.every((sample, i) => sample.pos.y !== plus[i].pos.y && plus[i].pos.y === zero[i].pos.y));

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -153,6 +153,19 @@ expect(
 	app.includes("judgeAuthoredPath(rootPath, TIMELINE_FPS, clipFrames, { chained: hasPromptSchedule })") &&
 	app.includes("PROMPT_BLOCK_MAX_FRAMES"),
 );
+expect(
+	"ARDY bridge health recovers after the sidecar starts late",
+	app.includes("const BRIDGE_RECHECK_MS = 3000;") &&
+	app.includes("const refreshBridge = () => checkBridge().then") &&
+	app.includes("const id = window.setInterval(refreshBridge, BRIDGE_RECHECK_MS);") &&
+	app.includes("return () => {") &&
+	app.includes("window.clearInterval(id);"),
+);
+expect(
+	"disabled Prompt Block generation explains the exact missing prerequisite",
+	app.includes('ko("Waiting for the ARDY bridge — it reconnects automatically"') &&
+	app.includes('ko("Add a prompt block and describe its motion first"'),
+);
 expect("generated motion anchors frame zero at the active character", app.includes("anchorX: activeChar.x") && app.includes("anchorZ: activeChar.z") && app.includes("anchorFrame: 0"));
 expect("returned playback has no CozyClay root coordinate warp", !app.includes("warpMotionRootToPath"));
 expect("Top-View root path draws from Subject 1 without a duplicate marker", planview.includes("[{ x: start.x, z: start.z }, ...waypoints]") && planview.includes("waypoints.map((w, i)"));

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -13,6 +13,7 @@ const planview = readFileSync(new URL("../src/planview.jsx", import.meta.url), "
 const timeline = readFileSync(new URL("../src/ardy/timeline.jsx", import.meta.url), "utf8");
 const dualview = readFileSync(new URL("../src/dualview.jsx", import.meta.url), "utf8");
 const offscreenExport = readFileSync(new URL("../src/offscreen-export.js", import.meta.url), "utf8");
+const ui = readFileSync(new URL("../src/ui.jsx", import.meta.url), "utf8");
 
 expect("workspace layout persists across reloads", app.includes("WORKSPACE_LAYOUT_KEY") && app.includes("localStorage.setItem"));
 expect("sidebar width has a pointer resize path", app.includes('beginWorkspaceResize("sidebar"'));
@@ -183,6 +184,34 @@ expect(
 	app.includes("subjectTrack={motion ? subjectTrack : null}") &&
 	!app.includes("subjectTrackStart=") &&
 	!app.includes("subjectTrackEnd="),
+);
+// Subject Height is world lift: floored at the deck, unbounded above. The
+// control keeps its compact .cslider body — the track stays a useful 0..4
+// band — while `softMax` lets the head scrub past 4 like a NumberField axis
+// and the readout shows the true stored value. Both write paths (head
+// scrub, viewport gizmo) agree on max(0, y).
+expect(
+	"Subject position uses the same X Y Z numeric row as scene objects",
+	app.includes('label={ko("Position", "위치")}') &&
+		app.includes('{ axis: "X", value: value.x, step: 0.05') &&
+		app.includes('{ axis: "Y", value: value.y ?? 0, step: 0.05') &&
+		app.includes('{ axis: "Z", value: value.z, step: 0.05') &&
+		!app.includes('<Slider compact label={ko("Left / right", "좌 / 우")}') &&
+		!app.includes('<Slider compact softMax label={ko("Height", "높이")}') &&
+		!app.includes('<Slider compact label={ko("Depth", "깊이")}'),
+);
+expect(
+	"the character gizmo no longer caps lift at 4 m",
+	app.includes("if (patch.y !== undefined) next.y = Math.max(0, patch.y);") &&
+	!app.includes("clamp(patch.y, 0, 4)"),
+);
+expect(
+	"the head scrub is floored at min with no upper clamp",
+	ui.includes("onChange(Math.max(min, drag.base + (e.clientX - drag.x) * step * multiplier));"),
+);
+expect(
+	"a soft-max readout shows the true stored value past the track",
+	ui.includes("const shown = softMax ? floored : snapped;"),
 );
 expect("resize handles opt out on compact layouts", css.includes(".workspace-splitter,") && css.includes("display: none"));
 

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -33,6 +33,20 @@ expect("double-click no longer swaps Scene and Top-View", !app.includes('setView
 expect("Scene toolbar exposes shot preset, aspect, FOV, recenter, and Top-View controls", app.includes("viewport-toolbar-field shot-field") && app.includes("SHOT_ASPECT_PRESETS") && app.includes("viewport-fov-control") && app.includes("Recenter on subject") && app.includes('ko("Top", "탑")'));
 expect("Scene and PlayView tools share one horizontal title bar", app.includes('className="viewport-titlebar"') && css.includes(".viewport-titlebar") && css.includes("position: static"));
 expect("PlayView toolbar exposes framing readouts, playback, and recording", app.includes("editor-toolbar play-tools") && app.includes("shotOutput.label") && app.includes("toggleShotRecording"));
+// Letterbox bars are editor chrome. Painting them with the scene background
+// put a sheet of near-white either side of the frame the moment a narrower
+// aspect was picked; they wear the editor's own tone now, and the scene draw
+// is scissored to the image so the sky inside the frame is unchanged.
+expect(
+	"letterbox bars are painted in the editor's tone, not the sky",
+	dualview.includes('export const LETTERBOX = new THREE.Color("#1e1e1e");') &&
+	dualview.includes("gl.setClearColor(LETTERBOX, 1);") &&
+	css.includes("--bg: #1e1e1e"),
+);
+expect(
+	"the scene draw is scissored to the image so the bars survive it",
+	dualview.includes("gl.setScissor(img.x, imgY, img.w, img.h);\n\t\t\tgl.setViewport(img.x, imgY, img.w, img.h);"),
+);
 expect("selected aspect reaches the shot renderer", app.includes("shotAspect={shotOutput.aspect}") && dualview.includes("shotAspect = SHOT_ASPECT") && dualview.includes("fitAspect(mainRect, shotAspect)"));
 expect("video and still capture use the selected output dimensions", app.includes("width: shotOutput.width") && app.includes("width={shotOutput.width}") && app.includes("canvas.width = shotOutput.width"));
 expect("double-clicking the inset body folds it", app.includes('event.target.closest?.(".vp-inset-tag")') && app.includes("insetCollapsed: !current.insetCollapsed"));

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -49,7 +49,17 @@ expect("ARDY status lines accumulate in the console window", app.includes("repor
 expect("the sidebar has no mode tabs left", !app.includes("sidebarTab") && !app.includes("inspector-tabs") && !css.includes(".inspector-tabs"));
 expect("a character owns the ARDY generation form", app.includes('<Foldout hidden={!isCharacterSelection} defaultOpen={false} title={ko("ARDY motion", "ARDY 모션")}>'));
 expect("the camera owns the lens controls", app.includes('<Foldout hidden={!isCameraSelection} title={ko("Camera", "카메라")}>'));
-expect("the scene owns the generation prompt", app.includes('<Foldout hidden={!isSceneSelection} title={ko("Prompt", "프롬프트")}>'));
+// The scene still owns the prompt — it describes the whole render, not one
+// performer — but reselecting the scene just to press Generate was friction,
+// so it is reachable from the character being staged as well.
+expect(
+	"the generation prompt is reachable from the scene and the character",
+	app.includes('<Foldout hidden={!(isSceneSelection || isCharacterSelection)} title={ko("Prompt", "프롬프트")}>'),
+);
+expect(
+	"the prompt does not leak onto selections that do not own it",
+	!app.includes('hidden={!isCameraSelection} title={ko("Prompt"') && app.includes('<Foldout hidden={!isCameraSelection} title={ko("Camera", "카메라")}>'),
+);
 expect("selection routing is derived once, not repeated per foldout", app.includes("const isCharacterSelection = selectedHierarchyId ===") && app.includes("const inspectorHasContent ="));
 expect("an unowned selection explains itself instead of showing a blank column", app.includes("data-inspector-empty") && css.includes(".inspector-empty"));
 expect("the heavy motion pipeline starts collapsed", app.includes("function Foldout({ title, hidden, defaultOpen = true, openSignal = 0, children })") && app.includes("useState(defaultOpen)"));

--- a/test/verify-motion-edit-browser.mjs
+++ b/test/verify-motion-edit-browser.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+	ws.onopen = resolve;
+	ws.onerror = reject;
+});
+
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params.exceptionDetails.exception?.description ?? message.params.exceptionDetails.text);
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (expression, timeoutMs = 8000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression)) return true;
+		await sleep(50);
+	}
+	return false;
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+await send("Runtime.enable");
+await send("Page.enable");
+await send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-motion", value: "reduce" }] });
+await send("Page.navigate", { url: "http://127.0.0.1:5180/app/" });
+expect("app becomes ready", await waitFor("!!window.__cozyclay?.rigA"));
+expect("the demo take draws one Full-Body segment", await waitFor("document.querySelectorAll('.tl-motion-clip').length === 1"));
+
+const initial = await evaluate(`(() => {
+	const clip = document.querySelector(".tl-motion-clip");
+	const speed = document.querySelector('.tl-motion-speed-editor input[type="number"]');
+	const cut = [...document.querySelectorAll(".tl-track-add.motion-cut")][0];
+	return {
+		label: clip?.querySelector(".tl-motion-clip-label")?.textContent,
+		speed: speed?.value,
+		editorVisible: !!speed && speed.getBoundingClientRect().width > 0,
+		cutDisabled: cut?.disabled,
+		readout: document.querySelector(".tl-readout")?.textContent,
+	};
+})()`);
+expect("the initial segment is visibly 1x", initial.label?.includes("1×") && initial.speed === "1", JSON.stringify(initial));
+expect("speed editor lives outside the segment and is visible", initial.editorVisible === true, JSON.stringify(initial));
+expect("Cut is disabled at frame zero", initial.cutDisabled === true, JSON.stringify(initial));
+
+expect("scrubbing enables Cut at frame 1", await evaluate(`(() => {
+	const slider = document.querySelector('.tl-ruler-lane');
+	slider.focus();
+	slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+	return true;
+})()`));
+expect("frame 1 is reached", await waitFor("document.querySelector('.tl-readout')?.textContent.includes('1 /')"));
+expect("Cut enables away from the edges", await evaluate("document.querySelector('.tl-track-add.motion-cut')?.disabled === false"));
+expect("clicking Cut produces two Full-Body segments", await evaluate(`(() => {
+	document.querySelector('.tl-track-add.motion-cut').click();
+	return true;
+})()`) && await waitFor("document.querySelectorAll('.tl-motion-clip').length === 2"));
+
+const beforeSlow = await evaluate(`(() => ({
+	readout: document.querySelector('.tl-readout')?.textContent,
+	widths: [...document.querySelectorAll('.tl-motion-clip')].map((clip) => clip.getBoundingClientRect().width),
+	labels: [...document.querySelectorAll('.tl-motion-clip-label')].map((label) => label.textContent),
+}))()`);
+expect("cut segments retain the 1x labels", beforeSlow.labels.every((label) => label.includes("1×")), JSON.stringify(beforeSlow));
+expect("the first segment is narrower than an inline selector", beforeSlow.widths[0] < 20, JSON.stringify(beforeSlow));
+
+expect("the playhead can return to the one-frame segment", await evaluate(`(() => {
+	const slider = document.querySelector('.tl-ruler-lane');
+	slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+	return true;
+})()`) && await waitFor("document.querySelector('.tl-readout')?.textContent.includes('0 /')"));
+
+expect("the external numeric editor accepts 0.7x on the tiny segment", await evaluate(`(() => {
+	const input = document.querySelector('.tl-motion-speed-editor input[type="number"]');
+	Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, '0.7');
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	return true;
+})()`));
+expect("the tiny segment updates to 0.7x", await waitFor("document.querySelector('.tl-motion-clip-label')?.textContent.includes('0.7×')"));
+
+expect("the range editor accepts the next 0.1x step", await evaluate(`(() => {
+	const input = document.querySelector('.tl-motion-speed-editor input[type="range"]');
+	Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, '0.8');
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	return true;
+})()`));
+expect("the tiny segment updates to 0.8x", await waitFor("document.querySelector('.tl-motion-clip-label')?.textContent.includes('0.8×')"));
+
+const afterSlow = await evaluate(`(() => ({
+	readout: document.querySelector('.tl-readout')?.textContent,
+	widths: [...document.querySelectorAll('.tl-motion-clip')].map((clip) => clip.getBoundingClientRect().width),
+	labels: [...document.querySelectorAll('.tl-motion-clip-label')].map((label) => label.textContent),
+	speed: document.querySelector('.tl-motion-speed-editor input[type="number"]')?.value,
+	selected: [...document.querySelectorAll('.tl-motion-clip')].map((clip) => clip.classList.contains('selected')),
+}))()`);
+expect("the header and tiny segment agree on 0.8x", afterSlow.labels[0]?.includes("0.8×") && afterSlow.speed === "0.8", JSON.stringify(afterSlow));
+expect("the playhead identifies the active segment", afterSlow.selected.some(Boolean), JSON.stringify(afterSlow));
+expect("reduced-motion mode keeps the controls usable", await evaluate("matchMedia('(prefers-reduced-motion: reduce)').matches"));
+expect("browser run has no uncaught page errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+ws.close();
+if (failures) process.exit(1);
+console.log("all motion edit browser checks PASS");

--- a/test/verify-motion-edit.mjs
+++ b/test/verify-motion-edit.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { CSKEL27_JOINTS } from "../src/ardy/cskel27.js";
+import {
+	createMotionEdit,
+	motionEditDuration,
+	renderMotionEdit,
+	setMotionSegmentSpeed,
+	splitMotionEdit,
+	timelineFrameToMotionFrame,
+	trimMotionEdit,
+} from "../src/ardy/motion-edit.js";
+
+function pass(label) { console.log(`PASS ${label}`); }
+function near(actual, expected, tolerance = 0.01) {
+	assert.ok(Math.abs(actual - expected) <= tolerance, `${actual} vs ${expected}`);
+}
+
+function linearMotion(frames) {
+	const joints = CSKEL27_JOINTS.length;
+	const rotMats = new Float32Array(frames * joints * 9);
+	const rootPos = new Float32Array(frames * 3);
+	const posedJoints = new Float32Array(frames * joints * 3);
+	for (let frame = 0; frame < frames; frame += 1) {
+		for (let joint = 0; joint < joints; joint += 1) {
+			const r = (frame * joints + joint) * 9;
+			rotMats[r] = 1;
+			rotMats[r + 4] = 1;
+			rotMats[r + 8] = 1;
+			const p = (frame * joints + joint) * 3;
+			posedJoints[p] = frame;
+		}
+		rootPos[frame * 3] = frame;
+	}
+	return { frames, fps: 24, rotMats, rootPos, posedJoints };
+}
+
+{
+	const edit = createMotionEdit(240);
+	assert.deepEqual(edit, [{ id: "motion-0", sourceStart: 0, sourceEnd: 239, speed: 1 }]);
+	assert.equal(motionEditDuration(edit), 240);
+	assert.equal(timelineFrameToMotionFrame(edit, 0), 0);
+	assert.equal(timelineFrameToMotionFrame(edit, 239), 239);
+	pass("an untouched take is one 1x segment with identity sampling");
+}
+
+{
+	const split = splitMotionEdit(createMotionEdit(240), 96);
+	assert.deepEqual(split.map(({ sourceStart, sourceEnd, speed }) => ({ sourceStart, sourceEnd, speed })), [
+		{ sourceStart: 0, sourceEnd: 95, speed: 1 },
+		{ sourceStart: 96, sourceEnd: 239, speed: 1 },
+	]);
+	assert.equal(splitMotionEdit(split, 0), split);
+	assert.equal(splitMotionEdit(split, 240), split);
+	assert.equal(splitMotionEdit(split, 96), split);
+	pass("cutting at the playhead creates a non-destructive source boundary once");
+}
+
+{
+	const split = splitMotionEdit(createMotionEdit(240), 96);
+	const slow = setMotionSegmentSpeed(split, split[1].id, 0.5);
+	assert.equal(motionEditDuration(slow), 96 + 288);
+	assert.equal(timelineFrameToMotionFrame(slow, 95), 95);
+	assert.equal(timelineFrameToMotionFrame(slow, 96), 96);
+	near(timelineFrameToMotionFrame(slow, 97), 96.5);
+	assert.equal(timelineFrameToMotionFrame(slow, 383), 239);
+	pass("a 0.5x segment doubles only its own timeline duration");
+}
+
+{
+	const edit = [
+		{ id: "a", sourceStart: 0, sourceEnd: 47, speed: 2 },
+		{ id: "b", sourceStart: 48, sourceEnd: 95, speed: 0.25 },
+	];
+	assert.equal(motionEditDuration(edit), 24 + 192);
+	assert.equal(timelineFrameToMotionFrame(edit, 23), 47);
+	assert.equal(timelineFrameToMotionFrame(edit, 24), 48);
+	assert.equal(timelineFrameToMotionFrame(edit, 215), 95);
+	pass("fast and slow segments join without skipping their seam poses");
+}
+
+{
+	const split = splitMotionEdit(createMotionEdit(240), 96);
+	const slow = setMotionSegmentSpeed(split, split[1].id, 0.5);
+	const trimmed = trimMotionEdit(slow, 48, 239);
+	assert.deepEqual(trimmed.map(({ sourceStart, sourceEnd, speed }) => ({ sourceStart, sourceEnd, speed })), [
+		{ sourceStart: 48, sourceEnd: 95, speed: 1 },
+		{ sourceStart: 96, sourceEnd: 167, speed: 0.5 },
+	]);
+	assert.equal(motionEditDuration(trimmed), 48 + 144);
+	pass("outer trim handles preserve cuts and speed inside the kept range");
+}
+
+{
+	const edit = createMotionEdit(20);
+	for (const speed of [0, -1, 8.1, Number.NaN]) {
+		assert.throws(() => setMotionSegmentSpeed(edit, edit[0].id, speed), /setMotionSegmentSpeed:/);
+	}
+	const decimal = setMotionSegmentSpeed(edit, edit[0].id, 0.7);
+	assert.equal(decimal[0].speed, 0.7);
+	assert.equal(setMotionSegmentSpeed(edit, edit[0].id, 0.66)[0].speed, 0.7);
+	assert.equal(setMotionSegmentSpeed(edit, edit[0].id, 1.01)[0].speed, 1);
+	pass("speed accepts continuous 0.1x steps and rejects off-grid values");
+}
+
+{
+	const split = splitMotionEdit(createMotionEdit(4), 2);
+	const slowed = setMotionSegmentSpeed(split, split[1].id, 0.5);
+	const rendered = renderMotionEdit(linearMotion(4), slowed);
+	assert.equal(rendered.frames, 6);
+	assert.equal(rendered.rootPos[0], 0);
+	assert.equal(rendered.rootPos[3], 1);
+	assert.equal(rendered.rootPos[6], 2);
+	near(rendered.rootPos[9], 2.5);
+	assert.equal(rendered.rootPos[12], 3);
+	assert.equal(rendered.rootPos[15], 3);
+	pass("rendering a slow segment creates a normal 24 fps clip for every consumer");
+}
+
+console.log("verify-motion-edit: all checks passed");

--- a/test/verify-scene-objects.mjs
+++ b/test/verify-scene-objects.mjs
@@ -15,7 +15,6 @@ import {
 	duplicateCutoutOptions,
 	cutoutFootprint,
 	CUTOUT_KIND,
-	CUTOUT_MAX_HEIGHT,
 	CUTOUT_THICKNESS,
 	dropToSurfacePatch,
 	placementInFront,
@@ -412,10 +411,8 @@ expect(
 	updateSceneObject([sofa], sofa.id, { footprint: { width: 99, depth: 99 } })[0] === sofa,
 );
 expect(
-	// Derived from the limit rather than written as a literal: the deck's
-	// headroom has already moved once, and a card is allowed to be a building.
-	"a cutout is clamped to the deck's headroom and above zero",
-	updateSceneObject([sofa], sofa.id, { height: 1e6 })[0].height === CUTOUT_MAX_HEIGHT &&
+	"a cutout height has no upper limit and stays above zero",
+	updateSceneObject([sofa], sofa.id, { height: 1e6 })[0].height === 1e6 &&
 		updateSceneObject([sofa], sofa.id, { height: 0 })[0].height === 0.05,
 );
 expect(
@@ -513,13 +510,13 @@ expect(
 	})(),
 );
 expect(
-	"a cutout stored out of range comes back inside it",
+	"a cutout stored at an extreme height keeps that height",
 	(() => {
 		const repaired = normalizeSceneObject({ ...sofa, height: 1e6, aspect: -4 });
 		return (
-			repaired.height === CUTOUT_MAX_HEIGHT &&
+			repaired.height === 1e6 &&
 			repaired.aspect === 0.02 &&
-			repaired.footprint.width === cutoutFootprint(CUTOUT_MAX_HEIGHT, 0.02).width
+			repaired.footprint.width === cutoutFootprint(1e6, 0.02).width
 		);
 	})(),
 );

--- a/test/verify-scenes.mjs
+++ b/test/verify-scenes.mjs
@@ -244,6 +244,8 @@ assert.equal(createCharacterEntry({ scale: -1.2 }).scale, 1, "a negative stature
 assert.equal(createCharacterEntry({ scale: "1.2" }).scale, 1, "a non-numeric stature is not a stature");
 assert.equal(createCharacterEntry({ scale: 99 }).scale, 3, "an absurd stature clamps to the band");
 assert.equal(createCharacterEntry({ scale: 0.05 }).scale, 0.2, "a tiny stature clamps to the band");
+assert.equal(createCharacterEntry({ y: -2 }).y, 0, "lift cannot sink below the deck");
+assert.equal(createCharacterEntry({ y: 10 }).y, 10, "lift has no ceiling — a crane shot may hoist the body");
 const staturedStage = createSceneStage({ characters: [{ id: "char-a", scale: 1.18 }, { id: "char-b" }] });
 assert.equal(staturedStage.characters[0].scale, 1.18, "a stored stature survives the stage envelope");
 assert.equal(staturedStage.characters[1].scale, 1, "a cast member without a take stays canonical");

--- a/test/verify-shot-authoring.mjs
+++ b/test/verify-shot-authoring.mjs
@@ -83,6 +83,14 @@ assert.deepEqual(restored.state.shots[1].camera.railFollow, { mode: "range", sta
 const emptyV4 = readShotAuthoring(JSON.stringify({ version: 4, frameCount: 300, shots: [], waypoints: [] }));
 assert.equal(emptyV4.status, "valid");
 assert.deepEqual(emptyV4.state.shots, [], "zero Shots is a normal persisted state");
+const highCamera = readShotAuthoring(JSON.stringify({
+	version: 4,
+	frameCount: 300,
+	shots: [{ startFrame: 0, endFrame: 299, camera: { mode: "follow", followCam: { ...followCam, height: 12, pitchOffsetDeg: 120 } } }],
+	waypoints: [],
+}));
+assert.equal(highCamera.state.shots[0].camera.followCam.height, 12, "camera height has no six-metre persistence ceiling");
+assert.equal(highCamera.state.shots[0].camera.followCam.pitchOffsetDeg, 120, "high-camera pitch offset survives persistence");
 const gapV4 = readShotAuthoring(JSON.stringify({
 	version: 4,
 	frameCount: 300,
@@ -195,7 +203,7 @@ assert.deepEqual(repaired.shots[0].camera, {
 		lead: 0,
 		railStartMode: "head",
 		maxDollySpeed: 8,
-		pitchOffsetDeg: -30,
+		pitchOffsetDeg: -170,
 		orbitOffsetDeg: 0,
 	},
 	cameraRail: null,

--- a/test/verify-update-check.mjs
+++ b/test/verify-update-check.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * The update notice, without the registry.
+ *
+ * Two things can go wrong here and both are silent in the wild: telling people
+ * about a version that is not newer, and hammering registry.npmjs.org on every
+ * launch because the cache never takes. So the version compare is exercised
+ * directly and every network path runs against a local mock over
+ * COZYCLAY_REGISTRY_URL, with a request counter to prove when a fetch did and
+ * did not happen. No fixed sleeps, no real network: this passes offline.
+ *
+ * Run: `npm run test:update-check`.
+ */
+
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkForUpdate, compareVersions } from "../bin/update-check.mjs";
+
+function pass(message) {
+	console.log(`PASS ${message}`);
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const stateDir = mkdtempSync(join(tmpdir(), "cozyclay-update-check-"));
+const cacheFile = join(stateDir, "update-check.json");
+
+/* ------------------------------------------------------ the mock npm ---- */
+
+/** What the next GET answers with, and how many GETs there have been. */
+const registry = { body: JSON.stringify({ version: "9.9.9" }), status: 200, requests: 0 };
+
+const server = createServer((req, res) => {
+	registry.requests += 1;
+	res.writeHead(registry.status, { "content-type": "application/json" });
+	res.end(registry.body);
+});
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const registryUrl = `http://127.0.0.1:${server.address().port}/cozyclay/latest`;
+
+/** A port nobody is listening on, so the fetch is refused rather than slow. */
+const deadServer = createServer(() => {});
+await new Promise((resolve) => deadServer.listen(0, "127.0.0.1", resolve));
+const deadUrl = `http://127.0.0.1:${deadServer.address().port}/cozyclay/latest`;
+await new Promise((resolve) => deadServer.close(resolve));
+
+function clearCache() {
+	rmSync(cacheFile, { force: true });
+}
+
+/** Runs one case with a known registry URL and a fresh request count. */
+async function check(currentVersion, { url = registryUrl } = {}) {
+	process.env.COZYCLAY_REGISTRY_URL = url;
+	registry.requests = 0;
+	return await checkForUpdate(currentVersion, stateDir);
+}
+
+try {
+	/* --------------------------------------------------- compareVersions ---- */
+
+	assert.equal(compareVersions("1.2.3", "1.2.4"), -1);
+	assert.equal(compareVersions("1.2.4", "1.2.3"), 1);
+	assert.equal(compareVersions("1.2.3", "1.2.3"), 0);
+	assert.equal(compareVersions("2.0.0", "1.99.99"), 1);
+	assert.equal(compareVersions("1.10.0", "1.9.0"), 1, "10 beats 9 numerically, not alphabetically");
+	assert.equal(compareVersions("1.3", "1.3.0"), 0, "a missing patch reads as zero");
+	assert.equal(compareVersions("1.3.1", "1.3"), 1);
+	pass("compareVersions orders older, newer, and equal releases");
+
+	assert.equal(compareVersions("1.4.0-beta.1", "1.4.0"), -1, "a prerelease loses to its own release");
+	assert.equal(compareVersions("1.4.0", "1.4.0-beta.1"), 1);
+	assert.equal(compareVersions("1.4.0-beta.1", "1.4.0-beta.1"), 0);
+	assert.equal(compareVersions("1.4.0-alpha.1", "1.4.0-beta.1"), -1);
+	assert.equal(compareVersions("1.4.0-beta.1", "1.3.9"), 1, "a prerelease still beats an older release");
+	pass("compareVersions ranks prereleases below their release and against each other");
+
+	assert.equal(compareVersions("", ""), 0);
+	assert.equal(compareVersions("not-a-version", "0.0.0"), -1, "unparseable cores read as 0 and keep their prerelease tag");
+	assert.equal(compareVersions("1.x.3", "1.0.3"), 0, "a garbage segment reads as zero rather than NaN");
+	assert.equal(compareVersions(" 1.2.3 ", "1.2.3"), 0, "surrounding whitespace is trimmed");
+	assert.equal(compareVersions(undefined, "0.0.0"), 0);
+	assert.equal(compareVersions(null, "1.0.0"), -1);
+	assert.ok(Number.isFinite(compareVersions({}, [])), "non-strings never produce NaN");
+	pass("compareVersions survives malformed input without throwing or returning NaN");
+
+	/* ---------------------------------------------------- checkForUpdate ---- */
+
+	clearCache();
+	registry.body = JSON.stringify({ version: "9.9.9" });
+	assert.equal(await check("1.3.0"), "9.9.9", "a newer registry version is reported");
+	assert.equal(registry.requests, 1);
+	const written = JSON.parse(readFileSync(cacheFile, "utf8"));
+	assert.equal(written.latest, "9.9.9");
+	assert.ok(Number.isFinite(written.checkedAt));
+	pass("checkForUpdate reports a newer published version and caches it");
+
+	clearCache();
+	registry.body = JSON.stringify({ version: "1.3.0" });
+	assert.equal(await check("1.3.0"), null, "the same version is not news");
+	assert.equal(registry.requests, 1);
+	clearCache();
+	registry.body = JSON.stringify({ version: "1.2.0" });
+	assert.equal(await check("1.3.0"), null, "an older registry version is not news");
+	pass("checkForUpdate stays quiet when the registry is level with or behind us");
+
+	clearCache();
+	registry.body = JSON.stringify({ version: "9.9.9" });
+	await check("1.3.0");
+	registry.body = JSON.stringify({ version: "1.0.0" });
+	assert.equal(await check("1.3.0"), "9.9.9", "a fresh cache answers without asking the registry");
+	assert.equal(registry.requests, 0, "no request within the TTL");
+	pass("checkForUpdate serves a cache hit inside the 24h TTL without refetching");
+
+	writeFileSync(cacheFile, JSON.stringify({ latest: "1.0.0", checkedAt: Date.now() - CACHE_TTL_MS - 1000 }));
+	registry.body = JSON.stringify({ version: "9.9.9" });
+	assert.equal(await check("1.3.0"), "9.9.9", "a stale cache is replaced by a live answer");
+	assert.equal(registry.requests, 1);
+	assert.equal(JSON.parse(readFileSync(cacheFile, "utf8")).latest, "9.9.9");
+	pass("checkForUpdate refetches once the cached entry is older than the TTL");
+
+	writeFileSync(cacheFile, "{ this is not json");
+	registry.body = JSON.stringify({ version: "9.9.9" });
+	assert.equal(await check("1.3.0"), "9.9.9");
+	assert.equal(registry.requests, 1);
+	writeFileSync(cacheFile, JSON.stringify({ latest: "9.9.9", checkedAt: "yesterday" }));
+	registry.requests = 0;
+	assert.equal(await check("1.3.0"), "9.9.9");
+	assert.equal(registry.requests, 1, "a cache without a usable timestamp is refetched, not trusted");
+	pass("checkForUpdate refetches through a corrupt or timestamp-less cache file");
+
+	clearCache();
+	assert.equal(await check("1.3.0", { url: deadUrl }), null, "an unreachable registry says nothing");
+	pass("checkForUpdate returns null on an unreachable registry instead of throwing");
+
+	clearCache();
+	registry.status = 503;
+	registry.body = "upstream is having a day";
+	assert.equal(await check("1.3.0"), null);
+	assert.equal(existsSync(cacheFile), false, "a failed check must not poison the cache");
+	registry.status = 200;
+	pass("checkForUpdate returns null on a registry error response and caches nothing");
+
+	clearCache();
+	registry.body = "<html>proxy login</html>";
+	assert.equal(await check("1.3.0"), null, "an unparseable body is not a version");
+	clearCache();
+	registry.body = JSON.stringify({ name: "cozyclay" });
+	assert.equal(await check("1.3.0"), null, "a payload with no version string is not a version");
+	clearCache();
+	registry.body = JSON.stringify({ version: 999 });
+	assert.equal(await check("1.3.0"), null, "a non-string version is ignored");
+	pass("checkForUpdate ignores junk, versionless, and non-string registry payloads");
+
+	clearCache();
+	registry.body = JSON.stringify({ version: "9.9.9" });
+	assert.equal(await check("1.3.0", { url: "not a url" }), null);
+	pass("checkForUpdate returns null when the registry URL itself is unusable");
+
+	console.log("all Cozy Clay update-check checks PASS");
+} finally {
+	delete process.env.COZYCLAY_REGISTRY_URL;
+	await new Promise((resolve) => server.close(resolve));
+	rmSync(stateDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What

Three independent improvements, one atomic commit each:

### 1. feat(launcher) — cclay alias + daily update check (24005535d)

- Global installs now expose `cclay` next to `cozyclay`.
- Once a day the launcher asks npm for the newest release and prints a one-line notice after the studio is up; quiet when current or offline.
- `cclay update` installs the latest; `--no-update-check` opts out.
- Repository metadata moves to NomaDamas/CozyClay.

### 2. feat(inspector) — lift the height ceilings (147bec13e)

- Characters lift with no ceiling: viewport gizmo, inspector Height scrub, and the scene load path all agree on `max(0, y)`.
- Cutouts outgrow the old 8 m cap (a building facade is a legitimate cutout).
- Follow-camera pitch/height bounds open up (±170°, unbounded height) so crane moves survive round-trips.
- Subject position moves from three sliders to the same numeric X/Y/Z row scene objects use; `Slider` grows a `softMax` head that scrubs past the track's range like a NumberField axis (Shift 10x, Alt 0.1x).

### 3. fix(mcp) — stop rewriting composite ARDY prompts (00982b6b6)

- The prompt normaliser used to cut a beat at the first comma or `then`/`while`/`as`/`before` and keep only the first fragment — a composite physical description silently lost its second action.
- Measured against the model (18 controlled generations): outcome-state composite prompts ("falls backward onto their back, chest up, arms and legs flailing") outperformed split phases for simultaneous pose + limb action.
- Phases now pass through verbatim; the normaliser only adds the subject, closes the full stop, and strips language ARDY has no body channel for (emotion/camera/scenery).
- `generate_motion` accepts a single complete beat (one beat goes out as a plain single-prompt generation, since the bridge's `segments` requires 2..64).
- `set_prompt_blocks` quotes the normalised text rather than a chained block that may belong to another beat, and reports beats dropped past the 8-phase limit.

## Verification

- `node mcp/verify-prompts.mjs` — all ARDY prompt checks pass
- `node test/verify-update-check.mjs` / `verify-layout.mjs` / `verify-camera-follow.mjs` / `verify-shot-authoring.mjs` / `verify-scenes.mjs` / `verify-scene-objects.mjs` — all pass
- `npm run test:ardy` — full suite passes
- `npm run build` — clean

## Notes

- This branch is based on `main`, so the PR also carries the four main commits `dev` is missing (head front, letterbox, generation prompt, blocking depth).
- Generated runtime artifacts (NPZ takes, `.omo/` research) are intentionally not committed.
