### PR TITLE
fix(mcp): explain the memory-only fallback when the live port is owned by a sibling session

### DIFF
--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -95,6 +95,14 @@ const state = {
 };
 
 let liveHub = null;
+/** True when another process (a sibling MCP session's child) already owns the live editor port. */
+let liveHubPortBusy = false;
+/** Explain a missing live editor, naming the sibling session that owns the port when that is the cause. */
+const noLiveEditor = (requirement) =>
+	liveHubPortBusy
+		? `${requirement} Live port ${livePort} is owned by the first MCP session of this server, so this ` +
+			"session is memory-only; reuse that first session, or restart the server and reconnect, to drive the editor."
+		: requirement;
 const motionJobs = new MotionJobRegistry();
 const liveWorkspace = new AsyncLocalStorage();
 const liveWorkspaceTools = new Set([
@@ -567,7 +575,7 @@ registerTool(
 	async () => text(
 		liveHub?.connected
 			? `Live editor connected. Workspace handles: ${liveHub.workspaceHandles.join(", ")}`
-			: "No live editor connected; using in-memory state.",
+			: noLiveEditor("No live editor connected; using in-memory state."),
 	),
 );
 
@@ -603,7 +611,7 @@ registerTool(
 		},
 	},
 	async ({ max_inline_bytes }) => {
-		if (!liveHub?.connected) return liveError(new Error("capture_frame requires a connected CozyClay editor with a renderable shot camera."));
+		if (!liveHub?.connected) return liveError(new Error(noLiveEditor("capture_frame requires a connected CozyClay editor with a renderable shot camera.")));
 		try {
 			const workspaceHandle = liveWorkspace.getStore();
 			const frame = await liveHub.command("capture_frame", {}, workspaceHandle);
@@ -1271,7 +1279,7 @@ registerTool(
 				? (rewrites.length ? `\n\nRewritten for ARDY:\n${rewrites.join("\n")}` : "\n") + dropNote + chainNote
 				: "";
 
-		if (!liveHub?.connected) return text("generate_motion requires a connected CozyClay editor so completion can be delivered over its live socket.");
+		if (!liveHub?.connected) return text(noLiveEditor("generate_motion requires a connected CozyClay editor so completion can be delivered over its live socket."));
 		try {
 			await refreshLiveDescription();
 		} catch (error) {
@@ -1482,7 +1490,7 @@ registerTool(
 		},
 	},
 	async ({ ops, atomic, stopOnError, label }) => {
-		if (!liveHub?.connected) return text("apply_batch requires a connected CozyClay editor.");
+		if (!liveHub?.connected) return text(noLiveEditor("apply_batch requires a connected CozyClay editor."));
 		try {
 			const result = await appliedLiveMutation("apply_batch", { ops, atomic, stopOnError, label });
 			const applied = Array.isArray(result?.applied) ? result.applied : [];
@@ -1844,6 +1852,7 @@ const configureLiveHub = (hub) => {
 
 if (httpFlag === -1) {
 	liveHub = await startLiveHub(livePort);
+	liveHubPortBusy = liveHub === null;
 	configureLiveHub(liveHub);
 	await server.connect(new StdioServerTransport());
 } else {

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1894,6 +1894,11 @@ if (httpFlag === -1) {
 		const child = new StdioClientTransport({
 			command: process.execPath,
 			args: [fileURLToPath(import.meta.url), "--live-port", String(livePort)],
+			// StdioClientTransport strips the environment to a safe default set, which
+			// silently discards COZYCLAY_* configuration (bridge URL, project root) in
+			// HTTP mode. The children are this same file in the same trust domain, so
+			// they get the full parent environment.
+			env: process.env,
 		});
 
 		// Splice the two transports together: the browser-facing session and the


### PR DESCRIPTION
## Problem

With `node mcp/server.mjs --http`, each MCP session runs in its own stdio child and only the first child binds the live editor port (5184). That fallback is deliberate — two clients must not silently share one scene — but it is **silent**: a later session's `live_status` says "No live editor connected; using in-memory state." even while an editor is connected and owned by a sibling session. The two situations (no editor tab open vs. port owned elsewhere) are indistinguishable, so clients waste time debugging the wrong thing.

## Fix

Keep the fallback behavior unchanged; make the reason observable.

- Track `liveHubPortBusy` when `startLiveHub` loses the bind race (EADDRINUSE).
- New `noLiveEditor()` helper appends the diagnosis to the four surfaces that report a missing live editor: `live_status`, `capture_frame`, `generate_motion`, `apply_batch`.

A memory-only session now reports:

> No live editor connected; using in-memory state. Live port 5184 is owned by the first MCP session of this server, so this session is memory-only; reuse that first session, or restart the server and reconnect, to drive the editor.

## Verification

- `npm run verify` and `npm run verify:live` pass (protocol, origin guard, live contract suites).
- Manual two-session repro against `--http 5183`: session 1 owns the hub and lists workspace handles; a second fresh session gets the new diagnostic message instead of the generic one.