### PR TITLE
fix(timeline): pass the shot id, not the block index, to camera preview

### DIFF
--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -988,7 +988,7 @@ export default function Timeline({
 							railDraw={railDraw}
 							railLength={cameraRailLength}
 							onChange={(patch) => handlers.current.onCameraBlockChange?.(patch)}
-							onPreview={() => handlers.current.onCameraPreview?.(cameraBlockIdx)}
+							onPreview={() => handlers.current.onCameraPreview?.(selectedCameraShot.id)}
 							onRailDrawToggle={() => handlers.current.onCameraRailDrawToggle?.()}
 							onRailDelete={() => handlers.current.onCameraRailDelete?.()}
 						/>


### PR DESCRIPTION
## Problem

`timeline.jsx` wires the camera block editor's preview button as
`onPreview={() => handlers.current.onCameraPreview?.(cameraBlockIdx)}`, but `cameraBlockIdx` is an **array index** (`shots[cameraBlockIdx]`, line 830). The App-side handler `previewCameraShot(shotId)` resolves it with `shots.find((entry) => entry.id === shotId)`.

Shot ids are stable string ids (`createShot` → `createStableItemId("shot")`), never numbers, so the lookup fails for **every** shot and each click throws an unhandled `Unknown shots ID: <n>` error in the viewport. Every sibling callback on the same editor (`onCameraBlockSelect`, `onRailSelect`, ...) already passes `shot.id`.

## Fix

Pass `selectedCameraShot.id` — non-null inside the `{selectedCameraShot && (...)}` guard — matching the id convention of every other shot callback.

## Verification

- `node test/verify-timeline-camera.mjs` passes (existing suite; it does not cover this button).
- Live repro: clicking the camera block preview button threw `Unknown shots ID: 1` repeatedly in the dev editor; after the fix (HMR) the same click starts shot preview playback with no error.