### PR TITLE
feat(camera): split the editor view from the recording camera

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -900,6 +900,56 @@ function FollowCamRig({ enabled, frame, scene, shot, camRef, look, isInterrupted
 }
 
 /**
+ * Applies the shot camera's yaw/pitch from its look ref every frame. Before
+ * the camera split, FlyControls owned the shot camera and performed this
+ * apply as a side effect of flying; with the fly controls bound to the
+ * editor camera, the recording camera still needs its aim (ShotRig, follow,
+ * frame-selection) reflected in its actual rotation — the preview and the
+ * capture read the camera object, not the ref.
+ */
+function ShotLookApplier({ camRef, look }) {
+	useFrame(() => {
+		const cam = camRef.current;
+		if (!cam) return;
+		if (cam.rotation.order !== "YXZ") cam.rotation.order = "YXZ";
+		if (cam.rotation.x !== look.current.pitch || cam.rotation.y !== look.current.yaw || cam.rotation.z !== 0) {
+			cam.rotation.set(look.current.pitch, look.current.yaw, 0);
+		}
+	});
+	return null;
+}
+
+/**
+ * Seeds the editor camera once, inside the Canvas root — App-level effects
+ * run before R3F mounts its children, so the ref is still null there. The
+ * seed frames both the subject and the shot camera: the first editor frame
+ * must read as "the set with the camera in it".
+ */
+function EditorCamSeed({ camRef, lookRef, shotCamRef, subject }) {
+	const seeded = useRef(false);
+	const invalidate = useThree((state) => state.invalidate);
+	useEffect(() => {
+		if (seeded.current) return;
+		const cam = camRef.current;
+		if (!cam) return;
+		seeded.current = true;
+		const shot = shotCamRef.current;
+		const target = {
+			x: ((subject?.x ?? 0) + (shot?.position.x ?? 1)) / 2,
+			y: 1.1,
+			z: ((subject?.z ?? 0) + (shot?.position.z ?? 2.4)) / 2,
+		};
+		cam.position.set(target.x + 3.2, 2.9, target.z + 4.2);
+		const angles = aimAt(cam.position, target);
+		lookRef.current = { yaw: angles.yaw, pitch: angles.pitch };
+		cam.rotation.order = "YXZ";
+		cam.rotation.set(angles.pitch, angles.yaw, 0);
+		invalidate();
+	});
+	return null;
+}
+
+/**
  * The shot camera drawn as an object in the editor view: a body and a short
  * frustum wireframe on GIZMO_LAYER, synced from the live camera every frame.
  * Preview, capture and PlayView draws all drop GIZMO_LAYER, so the ghost can
@@ -936,15 +986,20 @@ function ShotCameraGhost({ camRef, fovDeg, aspect, visible, selected }) {
 	if (!visible) return null;
 	return (
 		<group ref={groupRef}>
-			<mesh userData={{ shotCameraPick: true }}>
-				<boxGeometry args={[0.22, 0.16, 0.34]} />
-				<meshBasicMaterial color={selected ? "#ffb454" : "#46536a"} />
+			<mesh userData={{ shotCameraPick: true }} position={[0, 0, 0.06]}>
+				<boxGeometry args={[0.15, 0.11, 0.2]} />
+				<meshBasicMaterial color={selected ? "#ffb454" : "#3b6ea5"} />
+			</mesh>
+			{/* the lens: a short cone opening toward the view direction */}
+			<mesh userData={{ shotCameraPick: true }} rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, -0.075]}>
+				<coneGeometry args={[0.052, 0.09, 20, 1, true]} />
+				<meshBasicMaterial color={selected ? "#e09a3e" : "#2f5a8a"} side={THREE.DoubleSide} />
 			</mesh>
 			<lineSegments key={`${fovDeg}:${aspect}`}>
 				<bufferGeometry>
 					<bufferAttribute attach="attributes-position" array={frustum} count={frustum.length / 3} itemSize={3} />
 				</bufferGeometry>
-				<lineBasicMaterial color={selected ? "#ffb454" : "#8a97ad"} transparent opacity={0.9} />
+				<lineBasicMaterial color={selected ? "#ffb454" : "#6f9cc9"} transparent opacity={0.85} />
 			</lineSegments>
 		</group>
 	);
@@ -1417,6 +1472,14 @@ globalThis.playMode = centerTab === "play";
 	// controls the shot camera itself — the pre-split single-view behaviour —
 	// for framing by flying.
 	const [lookThroughShot, setLookThroughShot] = useState(false);
+	useEffect(() => {
+		if (!lookThroughShot) return undefined;
+		const onKey = (event) => {
+			if (event.key === "Escape") setLookThroughShot(false);
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [lookThroughShot]);
 	useEffect(() => {
 		// The player always starts the finished piece from frame 0; auto-play
 		// only exists once there is a motion to play.
@@ -3930,17 +3993,6 @@ globalThis.playMode = centerTab === "play";
 	// follow, rail and capture never touch it — that is the whole split.
 	const editorCamRef = useRef(null);
 	const editorLook = useRef({ yaw: 0, pitch: 0 });
-	// Seed once: a 3/4 overview aimed at the subject, so the first frame of
-	// the editor view reads as "the set with the camera in it".
-	useEffect(() => {
-		const cam = editorCamRef.current;
-		if (!cam) return;
-		const angles = aimAt(cam.position, { x: charA.x, y: 1.0, z: charA.z });
-		editorLook.current = { yaw: angles.yaw, pitch: angles.pitch };
-		cam.rotation.order = "YXZ";
-		cam.rotation.set(angles.pitch, angles.yaw, 0);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	/* The shot camera as a manipulable object in the editor view: the proxy
 	 * mirrors the live camera, gizmo patches write straight back to it and
@@ -6787,6 +6839,8 @@ function resizePromptClip(id, edge, rawFrame) {
 								onGroundClick={waypointMode && !planIsMain ? addFloorWaypoint : undefined}
 							/>
 							{centerTab === "scene" && railCurve && <CameraRailScenePreview points={railCurve.points} />}
+							<EditorCamSeed camRef={editorCamRef} lookRef={editorLook} shotCamRef={shotCamRef} subject={charA} />
+							<ShotLookApplier camRef={shotCamRef} look={look} />
 							<ShotCameraGhost
 								camRef={shotCamRef}
 								fovDeg={fovDeg}
@@ -6879,25 +6933,34 @@ function resizePromptClip(id, edge, rawFrame) {
 							style={{ "--shot-aspect": shotOutput.aspect }}
 						>
 							<span className="vp-inset-tag vp-shot-preview-tag">
-								{ko("Shot preview", "샷 프리뷰")}
+								<span className="vp-rec-dot" aria-hidden="true" />
+								{ko("Shot", "샷")}
 								<button
 									type="button"
 									className="vp-look-through"
-									title={ko("Fly the shot camera itself to frame the shot", "샷 카메라를 직접 조종해 프레이밍")}
+									aria-label={ko("Look through the shot camera", "샷 카메라 시점으로 보기")}
+									title={ko("Fly the shot camera itself (Esc returns)", "샷 카메라를 직접 조종 (Esc로 복귀)")}
 									onClick={() => setLookThroughShot(true)}
 								>
-									{ko("Look through", "시점 들어가기")}
+									<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+										<path d="M15 3h6v6" />
+										<path d="M21 3l-8 8" />
+										<path d="M9 21H3v-6" />
+										<path d="M3 21l8-8" />
+									</svg>
 								</button>
 							</span>
 						</div>
 						{lookThroughShot && !playMode && !ikMode && (
 							<button
 								type="button"
-								className="vp-look-through-exit"
-								title={ko("Return to the editor view", "에디터 시점으로 돌아가기")}
+								className="vp-inset-tag vp-look-through-exit"
+								title={ko("Return to the editor view (Esc)", "에디터 시점으로 돌아가기 (Esc)")}
 								onClick={() => setLookThroughShot(false)}
 							>
-								{ko("◉ Shot camera — exit", "◉ 샷 카메라 시점 — 나가기")}
+								<span className="vp-rec-dot" aria-hidden="true" />
+								{ko("Shot camera", "샷 카메라")}
+								<span className="vp-exit-hint">{ko("Esc · exit", "Esc · 나가기")}</span>
 							</button>
 						)}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -899,6 +899,57 @@ function FollowCamRig({ enabled, frame, scene, shot, camRef, look, isInterrupted
 	return null;
 }
 
+/**
+ * The shot camera drawn as an object in the editor view: a body and a short
+ * frustum wireframe on GIZMO_LAYER, synced from the live camera every frame.
+ * Preview, capture and PlayView draws all drop GIZMO_LAYER, so the ghost can
+ * never reach a recorded frame.
+ */
+function ShotCameraGhost({ camRef, fovDeg, aspect, visible, selected }) {
+	const groupRef = useRef(null);
+	const invalidate = useThree((state) => state.invalidate);
+	const frustum = useMemo(() => {
+		const depth = 0.62;
+		const h = Math.tan(THREE.MathUtils.degToRad(fovDeg) / 2) * depth;
+		const w = h * aspect;
+		const corners = [[-w, h], [w, h], [w, -h], [-w, -h]];
+		const points = [];
+		for (const [x, y] of corners) points.push(0, 0, 0, x, y, -depth);
+		for (let i = 0; i < 4; i++) {
+			const [ax, ay] = corners[i];
+			const [bx, by] = corners[(i + 1) % 4];
+			points.push(ax, ay, -depth, bx, by, -depth);
+		}
+		return new Float32Array(points);
+	}, [fovDeg, aspect]);
+	useEffect(() => {
+		groupRef.current?.traverse((node) => node.layers?.set(GIZMO_LAYER));
+		invalidate();
+	}, [visible, frustum, selected, invalidate]);
+	useFrame(() => {
+		const cam = camRef.current;
+		const group = groupRef.current;
+		if (!cam || !group) return;
+		group.position.copy(cam.position);
+		group.quaternion.copy(cam.quaternion);
+	});
+	if (!visible) return null;
+	return (
+		<group ref={groupRef}>
+			<mesh userData={{ shotCameraPick: true }}>
+				<boxGeometry args={[0.22, 0.16, 0.34]} />
+				<meshBasicMaterial color={selected ? "#ffb454" : "#46536a"} />
+			</mesh>
+			<lineSegments key={`${fovDeg}:${aspect}`}>
+				<bufferGeometry>
+					<bufferAttribute attach="attributes-position" array={frustum} count={frustum.length / 3} itemSize={3} />
+				</bufferGeometry>
+				<lineBasicMaterial color={selected ? "#ffb454" : "#8a97ad"} transparent opacity={0.9} />
+			</lineSegments>
+		</group>
+	);
+}
+
 function RenderLoopController({ stageRef }) {
 	const frameloop = useThree((state) => state.frameloop);
 	const setFrameloop = useThree((state) => state.setFrameloop);
@@ -1361,6 +1412,11 @@ globalThis.playMode = centerTab === "play";
 	// their hands. Follow/Rail only take it back through an explicit Preview or
 	// timeline Play, avoiding the snap-back that used to happen on pointer-up.
 	const manualCameraOverrideRef = useRef(false);
+	// Split cameras: the EDITOR camera is the user's own eye and never
+	// records; the shot camera keeps the framing. Look-through hands the fly
+	// controls the shot camera itself — the pre-split single-view behaviour —
+	// for framing by flying.
+	const [lookThroughShot, setLookThroughShot] = useState(false);
 	useEffect(() => {
 		// The player always starts the finished piece from frame 0; auto-play
 		// only exists once there is a motion to play.
@@ -1372,6 +1428,10 @@ globalThis.playMode = centerTab === "play";
 	const stageRef = useRef();
 	const mainPaneRef = useRef();
 	const insetPaneRef = useRef();
+	// The shot preview pane: the recording camera's framed output, rendered
+	// like an exported frame (no editing chrome) while the editor camera owns
+	// the main pane.
+	const shotPreviewRef = useRef();
 	// User-dragged inset position (px, stage-relative). null = the CSS default
 	// (top-right); double-clicking the tag snaps back to it.
 	const [insetPos, setInsetPos] = useState(null);
@@ -1699,7 +1759,7 @@ globalThis.playMode = centerTab === "play";
 			window.removeEventListener("pointercancel", onUp);
 			setAssetDrag(null);
 			const host = mainPaneRef.current;
-			const cam = shotCamRef.current;
+			const cam = (lookThroughShot ? shotCamRef : editorCamRef).current;
 			if (!host || !cam) return;
 			const rect = host.getBoundingClientRect();
 			if (up.clientX < rect.left || up.clientX > rect.right || up.clientY < rect.top || up.clientY > rect.bottom) return;
@@ -2027,9 +2087,10 @@ globalThis.playMode = centerTab === "play";
 	/** `at` overrides the floor point: the Assets-shelf drop already knows
 	 * where the pointer hit, everyone else gets in-front-of-camera. */
 	function addSceneObject(kind, at) {
-		const camera = shotCamRef.current;
+		const camera = (lookThroughShot ? shotCamRef : editorCamRef).current;
+		const paneYaw = (lookThroughShot ? look : editorLook).current.yaw;
 		const placement = at ?? (camera
-			? placementInFront({ x: camera.position.x, z: camera.position.z }, look.current.yaw)
+			? placementInFront({ x: camera.position.x, z: camera.position.z }, paneYaw)
 			: {});
 		const object = createSceneObject(kind, sceneObjects, placement);
 		if (!object) return;
@@ -2060,9 +2121,9 @@ globalThis.playMode = centerTab === "play";
 		if (!file) return;
 		try {
 			const asset = await rememberAsset(await importImageFile(file));
-			const camera = shotCamRef.current;
+			const camera = (lookThroughShot ? shotCamRef : editorCamRef).current;
 			const placement = camera
-				? placementInFront({ x: camera.position.x, z: camera.position.z }, look.current.yaw)
+				? placementInFront({ x: camera.position.x, z: camera.position.z }, (lookThroughShot ? look : editorLook).current.yaw)
 				: {};
 			const object = createCutoutObject(
 				{ assetId: asset.id, aspect: assetAspect(asset) ?? 1, height: CUTOUT_DEFAULT_HEIGHT, name: cutoutNameFromFile(asset.name) },
@@ -2195,7 +2256,8 @@ globalThis.playMode = centerTab === "play";
 	 * the current view direction, the way Unity's F key does. Defaults to the
 	 * selection; the hierarchy context menu passes a specific row's id. */
 	function frameSelection(id = selectedSceneObjectId) {
-		const camera = shotCamRef.current;
+		const camera = (lookThroughShot ? shotCamRef : editorCamRef).current;
+		const paneLook = lookThroughShot ? look : editorLook;
 		const object = sceneObjects.find((item) => item.id === id) ?? null;
 		if (!camera || !object) return;
 		const size = objectSize(object);
@@ -2206,11 +2268,13 @@ globalThis.playMode = centerTab === "play";
 		};
 		const reach = Math.max(size.width, size.height, size.depth, 0.5);
 		const distance = reach * 2.4 + 0.6;
-		const back = forwardFrom(look.current.yaw, look.current.pitch).multiplyScalar(-distance);
+		const back = forwardFrom(paneLook.current.yaw, paneLook.current.pitch).multiplyScalar(-distance);
 		camera.position.set(target.x + back.x, Math.max(target.y + back.y, 0.3), target.z + back.z);
 		const angles = aimAt(camera.position, target);
-		look.current.yaw = angles.yaw;
-		look.current.pitch = angles.pitch;
+		paneLook.current.yaw = angles.yaw;
+		paneLook.current.pitch = angles.pitch;
+		camera.rotation.order = "YXZ";
+		camera.rotation.set(angles.pitch, angles.yaw, 0);
 	}
 
 	/** In-place rename commit from the hierarchy (F2 / Return / rename on
@@ -3862,6 +3926,54 @@ globalThis.playMode = centerTab === "play";
 	// the framing and shows in the inset. Two separate screens by design.
 	const poserCamRef = useRef(null);
 	const poserLook = useRef({ yaw: 0, pitch: 0 });
+	// The editor camera: the free working view the operator flies. Playback,
+	// follow, rail and capture never touch it — that is the whole split.
+	const editorCamRef = useRef(null);
+	const editorLook = useRef({ yaw: 0, pitch: 0 });
+	// Seed once: a 3/4 overview aimed at the subject, so the first frame of
+	// the editor view reads as "the set with the camera in it".
+	useEffect(() => {
+		const cam = editorCamRef.current;
+		if (!cam) return;
+		const angles = aimAt(cam.position, { x: charA.x, y: 1.0, z: charA.z });
+		editorLook.current = { yaw: angles.yaw, pitch: angles.pitch };
+		cam.rotation.order = "YXZ";
+		cam.rotation.set(angles.pitch, angles.yaw, 0);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	/* The shot camera as a manipulable object in the editor view: the proxy
+	 * mirrors the live camera, gizmo patches write straight back to it and
+	 * commit manual framing — the same contract as dragging its plan puck. */
+	const shotCameraSelected = selectedHierarchyId === "camera";
+	const cameraGizmoObject = useMemo(() => {
+		if (lookThroughShot || ikMode || !shotCameraSelected) return null;
+		return {
+			id: "__shotcam__",
+			x: cameraPos.x,
+			y: Math.max(0, cameraPos.y - 0.12),
+			z: cameraPos.z,
+			height: 0.24,
+			footprint: { width: 0.34, depth: 0.34 },
+			rotY: THREE.MathUtils.radToDeg(look.current.yaw),
+			scaleX: 1,
+			scaleY: 1,
+			scaleZ: 1,
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [cameraPos, lookThroughShot, ikMode, shotCameraSelected]);
+	function changeShotCameraFromGizmo(_id, patch) {
+		const cam = shotCamRef.current;
+		if (!cam) return;
+		if (patch.x !== undefined) cam.position.x = THREE.MathUtils.clamp(patch.x, -30, 30);
+		if (patch.y !== undefined) cam.position.y = Math.max(0.12, patch.y + 0.12);
+		if (patch.z !== undefined) cam.position.z = THREE.MathUtils.clamp(patch.z, -30, 30);
+		if (patch.rotY !== undefined) look.current.yaw = THREE.MathUtils.degToRad(patch.rotY);
+		cam.rotation.order = "YXZ";
+		cam.rotation.set(look.current.pitch, look.current.yaw, 0);
+		commitManualCameraFraming();
+	}
+
 
 	const shot = useMemo(
 		() => deriveShot(cameraPos, charA, (fovDeg * Math.PI) / 180, SUBJECT_HEIGHT_M, filmback),
@@ -5146,14 +5258,17 @@ globalThis.playMode = centerTab === "play";
 			committedIkEdits, waypoints,
 			// the camera the main view renders through (poser in IK mode) — QA
 			// projections must use this one, not the frozen shot camera
-			activeCam: ikMode ? poserCamRef.current : shotCamRef.current,
+			activeCam: ikMode ? poserCamRef.current : lookThroughShot ? shotCamRef.current : editorCamRef.current,
 			shotCam: shotCamRef.current,
 			poserCam: poserCamRef.current,
 			planCam: planCamRef.current,
+			editorCam: editorCamRef.current,
+			lookThroughShot,
+			setLookThrough: (value) => setLookThroughShot(!!value),
 			charA,
 			insetPane: insetPaneRef.current,
 		};
-	}, [activeRig, motion, tlFrame, ikMode, ikChains, ikFocus, ikTick, charA, committedIkEdits, waypoints]);
+	}, [activeRig, motion, tlFrame, ikMode, ikChains, ikFocus, ikTick, charA, committedIkEdits, waypoints, lookThroughShot]);
 	// QA hook (plan §6.5): exposes history depth and the present === objects
 	// invariant so the browser suite can assert undo entry counts directly.
 	// Reads live store state at call time; re-registered after every render.
@@ -6434,11 +6549,22 @@ function resizePromptClip(id, edge, rawFrame) {
 
 							<PerspectiveCamera
 								ref={shotCamRef}
-								makeDefault={!ikMode}
+								makeDefault={!ikMode && lookThroughShot}
 								fov={fovDeg}
 								near={0.1}
 								far={100}
 								position={[0.97, 1.62, 2.39]}
+							/>
+							{/* the EDITOR camera: the user's working eye. Fixed lens — the
+							    shot's focal length belongs to the recording, not to the
+							    operator's own view of the set. */}
+							<PerspectiveCamera
+								ref={editorCamRef}
+								makeDefault={!ikMode && !lookThroughShot}
+								fov={55}
+								near={0.1}
+								far={100}
+								position={[3.6, 2.7, 5.4]}
 							/>
 							{/* the poser camera is the default (event/raycast) camera in
 							    IK mode so handle hit-testing matches what you see */}
@@ -6485,8 +6611,8 @@ function resizePromptClip(id, edge, rawFrame) {
 									snap={snapEnabled}
 									enabled={!planIsMain && !posing && !ikMode && !playMode && !!characterGizmoObject}
 									paneRef={mainPaneRef}
-									camRef={shotCamRef}
-									shotAspect={shotOutput.aspect}
+									camRef={lookThroughShot ? shotCamRef : editorCamRef}
+									shotAspect={lookThroughShot ? shotOutput.aspect : null}
 									onChange={(id, patch) => moveCharacter(activeChar.id, () => {
 										const next = {};
 										if (patch.x !== undefined) next.x = THREE.MathUtils.clamp(patch.x, -4, 4);
@@ -6546,7 +6672,7 @@ function resizePromptClip(id, edge, rawFrame) {
 								scene={playbackScene}
 								camRef={shotCamRef}
 								look={look}
-								isInterrupted={() => flyingRef.current || manualCameraOverrideRef.current}
+								isInterrupted={() => (lookThroughShot && flyingRef.current) || manualCameraOverrideRef.current}
 								onDone={(finalFov) => {
 									setMovePlaying(false);
 									setFovDeg(Math.round(finalFov * 10) / 10);
@@ -6559,7 +6685,7 @@ function resizePromptClip(id, edge, rawFrame) {
 								shot={activeShot}
 								camRef={shotCamRef}
 								look={look}
-								isInterrupted={() => flyingRef.current || manualCameraOverrideRef.current}
+								isInterrupted={() => (lookThroughShot && flyingRef.current) || manualCameraOverrideRef.current}
 							/>
 							{/* Camera stays live in IK mode but drives the POSER camera,
 							    never the shot camera: the handle layer only consumes
@@ -6567,8 +6693,8 @@ function resizePromptClip(id, edge, rawFrame) {
 							    and the wheel dollies without wrecking the framing. */}
 							<FlyControls
 								enabled={!posing && !playMode}
-								camRef={ikMode ? poserCamRef : shotCamRef}
-								look={ikMode ? poserLook : look}
+								camRef={ikMode ? poserCamRef : lookThroughShot ? shotCamRef : editorCamRef}
+								look={ikMode ? poserLook : lookThroughShot ? look : editorLook}
 								getPivot={() => {
 									if (!selectedSceneObject) return null;
 									const size = objectSize(selectedSceneObject);
@@ -6577,7 +6703,7 @@ function resizePromptClip(id, edge, rawFrame) {
 								onFlyStateChange={(flying) => {
 									flyingRef.current = flying;
 								}}
-								onCameraChange={commitManualCameraFraming}
+								onCameraChange={lookThroughShot && !ikMode ? commitManualCameraFraming : undefined}
 							/>
 							<PoseHandles
 								root={posedRig()}
@@ -6638,25 +6764,36 @@ function resizePromptClip(id, edge, rawFrame) {
 							    the plan owns the big pane (the pucks are the handles there)
 							    and while posing/IK owns the pointer. */}
 							<ObjectGizmo
-								object={selectedSceneObject}
+								object={cameraGizmoObject ?? selectedSceneObject}
 								objects={sceneObjects}
-								mode={gizmoMode}
+								mode={cameraGizmoObject ? (gizmoMode === "scale" ? "move" : gizmoMode) : gizmoMode}
 								snap={snapEnabled}
 								enabled={!planIsMain && !posing && !ikMode && !playMode}
 								paneRef={mainPaneRef}
-								camRef={shotCamRef}
-								shotAspect={shotOutput.aspect}
-								onChange={changeSceneObject}
-								onDragStart={beginSceneTransaction}
-								onDragEnd={endSceneTransaction}
+								camRef={lookThroughShot ? shotCamRef : editorCamRef}
+								shotAspect={lookThroughShot ? shotOutput.aspect : null}
+								onChange={(id, patch) => (id === "__shotcam__" ? changeShotCameraFromGizmo(id, patch) : changeSceneObject(id, patch))}
+								onDragStart={(...args) => {
+									if (!cameraGizmoObject) beginSceneTransaction(...args);
+								}}
+								onDragEnd={(...args) => {
+									if (!cameraGizmoObject) endSceneTransaction(...args);
+								}}
 								onSelect={(id) =>
 									selectHierarchy(
-										id?.startsWith("char:") ? charKeyToHierarchyId(id) : id ? `object:${id}` : "props",
+										id === "__shotcam__" ? "camera" : id?.startsWith("char:") ? charKeyToHierarchyId(id) : id ? `object:${id}` : "props",
 									)
 								}
 								onGroundClick={waypointMode && !planIsMain ? addFloorWaypoint : undefined}
 							/>
 							{centerTab === "scene" && railCurve && <CameraRailScenePreview points={railCurve.points} />}
+							<ShotCameraGhost
+								camRef={shotCamRef}
+								fovDeg={fovDeg}
+								aspect={shotOutput.aspect}
+								visible={centerTab === "scene" && !lookThroughShot && !ikMode && !posing}
+								selected={shotCameraSelected}
+							/>
 							{waypointMode && centerTab === "scene" && (
 								<ShotPathPreview waypoints={waypoints} start={charA} activeWaypointId={activeWaypointId} />
 							)}
@@ -6671,12 +6808,15 @@ function resizePromptClip(id, edge, rawFrame) {
 								stageRef={stageRef}
 								mainRef={mainPaneRef}
 								insetRef={insetPaneRef}
+								shotPreviewRef={shotPreviewRef}
 								shotCamRef={shotCamRef}
 								planCamRef={planCamRef}
 								poserCamRef={poserCamRef}
+								editorCamRef={editorCamRef}
 								ikMode={ikMode}
 								planIsMain={planIsMain}
 								playMode={playMode}
+								lookThrough={lookThroughShot}
 								insetCollapsed={workspaceLayout.insetCollapsed}
 								planZoom={workspaceLayout.planZoom}
 								shotAspect={shotOutput.aspect}
@@ -6732,13 +6872,42 @@ function resizePromptClip(id, edge, rawFrame) {
 							)}
 						</div>
 
-						<div className="film-frame" hidden={playMode}>
+						<div
+							ref={shotPreviewRef}
+							hidden={playMode || ikMode || lookThroughShot}
+							className="vp-pane vp-shot-preview"
+							style={{ "--shot-aspect": shotOutput.aspect }}
+						>
+							<span className="vp-inset-tag vp-shot-preview-tag">
+								{ko("Shot preview", "샷 프리뷰")}
+								<button
+									type="button"
+									className="vp-look-through"
+									title={ko("Fly the shot camera itself to frame the shot", "샷 카메라를 직접 조종해 프레이밍")}
+									onClick={() => setLookThroughShot(true)}
+								>
+									{ko("Look through", "시점 들어가기")}
+								</button>
+							</span>
+						</div>
+						{lookThroughShot && !playMode && !ikMode && (
+							<button
+								type="button"
+								className="vp-look-through-exit"
+								title={ko("Return to the editor view", "에디터 시점으로 돌아가기")}
+								onClick={() => setLookThroughShot(false)}
+							>
+								{ko("◉ Shot camera — exit", "◉ 샷 카메라 시점 — 나가기")}
+							</button>
+						)}
+
+						<div className="film-frame" hidden={playMode || !lookThroughShot}>
 							<span />
 							<span />
 							<span />
 							<span />
 						</div>
-						<div className={"caption" + (subjectVisible ? "" : " off")} hidden={playMode}>
+						<div className={"caption" + (subjectVisible ? "" : " off")} hidden={playMode || !lookThroughShot}>
 							{subjectVisible ? slateLineKo(shot) : ko("SUBJECT OUT OF FRAME", "피사체가 프레임 밖에 있어요")}
 						</div>
 

--- a/src/dualview.jsx
+++ b/src/dualview.jsx
@@ -113,7 +113,7 @@ export function fitAspect(rect, aspect) {
 	return { x: rect.x + (rect.w - w) / 2, y: rect.y + (rect.h - h) / 2, w, h };
 }
 
-export function DualRender({ stageRef, mainRef, insetRef, shotCamRef, planCamRef, poserCamRef, ikMode = false, planIsMain, playMode = false, insetCollapsed = false, planZoom = 1, shotAspect = SHOT_ASPECT }) {
+export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCamRef, planCamRef, poserCamRef, editorCamRef, ikMode = false, planIsMain, playMode = false, lookThrough = false, insetCollapsed = false, planZoom = 1, shotAspect = SHOT_ASPECT }) {
 	const invalidate = useThree((state) => state.invalidate);
 	// Demand mode draws nothing by itself: the first frame can land before the
 	// layout settles (the inset reads 0x0), and async scene content commits
@@ -178,10 +178,18 @@ export function DualRender({ stageRef, mainRef, insetRef, shotCamRef, planCamRef
 		const shot = shotCamRef.current;
 		const plan = planCamRef.current;
 		const poser = poserCamRef?.current;
+		const editor = editorCamRef?.current;
 		if (shot) {
 			shot.layers.set(0);
 			shot.layers.enable(SHOT_LAYER);
 			shot.layers.enable(GIZMO_LAYER);
+		}
+		if (editor) {
+			// The editor working view sees the set exactly like the shot camera
+			// (ceiling included) plus the editing chrome, never the plan overlay.
+			editor.layers.set(0);
+			editor.layers.enable(SHOT_LAYER);
+			editor.layers.enable(GIZMO_LAYER);
 		}
 		if (plan) {
 			plan.layers.set(0);
@@ -200,6 +208,7 @@ export function DualRender({ stageRef, mainRef, insetRef, shotCamRef, planCamRef
 		const shotCam = shotCamRef.current;
 		const planCam = planCamRef.current;
 		const poserCam = poserCamRef?.current;
+		const editorCam = editorCamRef?.current;
 		const stage = stageRef.current;
 		if (!shotCam || !planCam || !stage || !mainRef.current || !insetRef.current) return;
 
@@ -310,6 +319,25 @@ export function DualRender({ stageRef, mainRef, insetRef, shotCamRef, planCamRef
 		} else if (planIsMain) {
 			draw(planCam, planPane, null, false);
 			if (!insetCollapsed) draw(shotCam, shotPane, fitAspect(shotPane, shotAspect));
+		} else if (editorCam && !lookThrough) {
+			// Split-camera editing: the main pane is the EDITOR camera — free
+			// navigation that never touches the recording. The shot camera only
+			// appears in its own preview pane, framed to the export aspect and
+			// stripped of editing chrome, exactly like an exported frame.
+			editorCam.aspect = mainRect.w / mainRect.h;
+			editorCam.updateProjectionMatrix();
+			draw(editorCam, mainRect);
+			if (!insetCollapsed) draw(planCam, planPane, null, false);
+			const previewEl = shotPreviewRef?.current;
+			if (previewEl && !previewEl.hidden) {
+				const previewRect = rectOf(previewEl);
+				if (previewRect.w >= 2) {
+					const previewMask = shotCam.layers.mask;
+					shotCam.layers.disable(GIZMO_LAYER);
+					draw(shotCam, previewRect, fitAspect(previewRect, shotAspect));
+					shotCam.layers.mask = previewMask;
+				}
+			}
 		} else {
 			draw(shotCam, shotPane, fitAspect(shotPane, shotAspect));
 			if (!insetCollapsed) draw(planCam, planPane, null, false);

--- a/src/object-gizmo.jsx
+++ b/src/object-gizmo.jsx
@@ -218,6 +218,15 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 	}
 	activeScopeRef.current = { id: object?.id, mode };
 
+	// The WHOLE gizmo — visible arrows and rings included, not only the pick
+	// proxies — belongs on GIZMO_LAYER: the working views enable that layer,
+	// while the shot preview, capture and PlayView draws drop it, so editing
+	// chrome can never reach a recorded frame. No dependency list: the handle
+	// meshes remount on tool/selection changes and must be re-layered each time.
+	useEffect(() => {
+		rootRef.current?.traverse((node) => node.layers?.set(GIZMO_LAYER));
+	});
+
 	/** pointer -> NDC inside the rect the shot camera actually rendered into */
 	const pointerRay = (event) => {
 		const pane = paneRef.current;
@@ -241,15 +250,22 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 		// Picking walks past lines/points to the first real surface.
 		const hits = tools.raycaster.intersectObjects(scene.children, true);
 		const hit = hits.find((entry) => entry.object.isMesh);
+		// The camera ghost lives on GIZMO_LAYER so the recording never sees it;
+		// give it its own pick pass and prefer whichever surface is nearer.
+		tools.raycaster.layers.set(GIZMO_LAYER);
+		const ghostHit = tools.raycaster.intersectObjects(scene.children, true).find((entry) => {
+			if (!entry.object.isMesh) return false;
+			for (let node = entry.object; node; node = node.parent) if (node.userData?.shotCameraPick) return true;
+			return false;
+		});
+		tools.raycaster.layers.set(0);
+		if (ghostHit && (!hit || ghostHit.distance < hit.distance)) return { id: "__shotcam__", point: ghostHit.point.clone() };
 		if (!hit) return null;
 		for (let node = hit.object; node; node = node.parent) {
 			if (node.userData?.sceneObjectId) return { id: node.userData.sceneObjectId, point: hit.point.clone() };
 			// Characters are click targets too: a namespaced id routes the
 			// selection to the hierarchy, so the Inspector owns the controls.
 			if (node.userData?.characterPick) return { id: `char:${node.userData.characterPick}`, point: hit.point.clone() };
-			// The shot camera's ghost body: selecting it routes to the camera
-			// hierarchy entry, same as clicking its puck on the plan.
-			if (node.userData?.shotCameraPick) return { id: "__shotcam__", point: hit.point.clone() };
 		}
 		return null; // whatever is in front is set, not an object
 	};

--- a/src/object-gizmo.jsx
+++ b/src/object-gizmo.jsx
@@ -149,6 +149,21 @@ const GROUND = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
 
 export default function ObjectGizmo({ object, objects = [], mode = "move", snap = true, enabled, pickOnly = false, paneRef, camRef, shotAspect = SHOT_ASPECT, onChange, onSelect, onGroundClick, onDragStart, onDragEnd }) {
 	const { gl, scene } = useThree();
+	// shotAspect null = the camera fills the pane (the editor working view):
+	// pointer mapping uses the pane rect itself instead of a letterboxed
+	// sub-rect, and the camera takes the pane's own aspect.
+	const imageRect = (bounds) => {
+		const rect = { x: bounds.left, y: bounds.top, w: bounds.width, h: bounds.height };
+		return shotAspect ? fitAspect(rect, shotAspect) : rect;
+	};
+	const applyAspect = (camera) => {
+		if (shotAspect) {
+			camera.aspect = shotAspect;
+		} else {
+			const bounds = paneRef?.current?.getBoundingClientRect();
+			if (bounds && bounds.height >= 1) camera.aspect = bounds.width / bounds.height;
+		}
+	};
 	const rootRef = useRef(null);
 	const handlesRef = useRef(new Map()); // axis -> { mesh (pick proxy), axis, dir }
 	const screenRingRef = useRef(null); // the outer ring's group, billboarded to the camera each frame
@@ -210,7 +225,7 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 		if (!pane || !camera) return null;
 		const bounds = pane.getBoundingClientRect();
 		if (bounds.width < 2 || bounds.height < 2) return null;
-		const rect = fitAspect({ x: bounds.left, y: bounds.top, w: bounds.width, h: bounds.height }, shotAspect);
+		const rect = imageRect(bounds);
 		tools.ndc.set(
 			((event.clientX - rect.x) / rect.w) * 2 - 1,
 			-((event.clientY - rect.y) / rect.h) * 2 + 1,
@@ -232,6 +247,9 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 			// Characters are click targets too: a namespaced id routes the
 			// selection to the hierarchy, so the Inspector owns the controls.
 			if (node.userData?.characterPick) return { id: `char:${node.userData.characterPick}`, point: hit.point.clone() };
+			// The shot camera's ghost body: selecting it routes to the camera
+			// hierarchy entry, same as clicking its puck on the plan.
+			if (node.userData?.shotCameraPick) return { id: "__shotcam__", point: hit.point.clone() };
 		}
 		return null; // whatever is in front is set, not an object
 	};
@@ -243,7 +261,7 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 		if (!pane || !camera) return null;
 		const bounds = pane.getBoundingClientRect();
 		if (bounds.width < 2 || bounds.height < 2) return null;
-		const rect = fitAspect({ x: bounds.left, y: bounds.top, w: bounds.width, h: bounds.height }, shotAspect);
+		const rect = imageRect(bounds);
 		tools.ndc.set(
 			((event.clientX - rect.x) / rect.w) * 2 - 1,
 			-((event.clientY - rect.y) / rect.h) * 2 + 1,
@@ -268,7 +286,7 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 			// loop (dualview); under demand rendering a layout change may not
 			// have had a frame yet, leaving a stale projection. Re-apply the
 			// render contract here so the pick matches what is on screen.
-			camera.aspect = shotAspect;
+			applyAspect(camera);
 			camera.updateProjectionMatrix();
 			camera.updateMatrixWorld();
 			camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
@@ -696,13 +714,13 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 			// render tick under demand rendering, and re-apply the render
 			// loop's locked aspect (dualview) so QA geometry matches the
 			// drawn frame exactly
-			camera.aspect = shotAspect;
+			applyAspect(camera);
 			camera.updateProjectionMatrix();
 			camera.updateMatrixWorld();
 			camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 			rootRef.current?.updateMatrixWorld(true);
 			const bounds = pane.getBoundingClientRect();
-			const rect = fitAspect({ x: bounds.left, y: bounds.top, w: bounds.width, h: bounds.height }, shotAspect);
+			const rect = imageRect(bounds);
 			return [...handlesRef.current.values()]
 				.filter((entry) => entry.mesh?.parent)
 				.map((entry) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -662,6 +662,61 @@ select {
 	box-shadow: 0 10px 30px #00000073, 0 0 0 1px #ffffff1f;
 	animation: rise var(--med) var(--ease) both;
 }
+/* The shot preview: the recording camera's framed output, bottom-right,
+   always at the export aspect. Chrome-free — what you see is what records. */
+.vp-shot-preview {
+	top: auto;
+	bottom: 14px;
+	right: 15px;
+	width: 24%;
+	min-width: 220px;
+	max-width: 360px;
+	aspect-ratio: var(--shot-aspect, 16 / 9);
+	border-radius: 11px;
+	overflow: hidden;
+	box-shadow: 0 10px 30px #00000073, 0 0 0 1px #ffffff1f;
+	animation: rise var(--med) var(--ease) both;
+}
+.vp-shot-preview-tag {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	cursor: default;
+}
+.vp-look-through {
+	pointer-events: auto;
+	cursor: pointer;
+	background: none;
+	border: 1px solid var(--line2);
+	border-radius: 4px;
+	color: var(--accent, #ffb454);
+	font: inherit;
+	font-size: 9px;
+	padding: 1px 6px;
+}
+.vp-look-through:hover {
+	border-color: var(--accent, #ffb454);
+}
+/* Pill overlay while flying the shot camera itself */
+.vp-look-through-exit {
+	position: absolute;
+	top: 14px;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 6;
+	pointer-events: auto;
+	cursor: pointer;
+	padding: 5px 12px;
+	border-radius: 999px;
+	background: #0e0d10d9;
+	border: 1px solid var(--accent, #ffb454);
+	color: var(--accent, #ffb454);
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: .08em;
+	text-transform: uppercase;
+}
+
 /* the plan pane is the interactive one wherever it lands */
 .vp-pane.plan {
 	pointer-events: auto;

--- a/src/styles.css
+++ b/src/styles.css
@@ -666,55 +666,50 @@ select {
    always at the export aspect. Chrome-free — what you see is what records. */
 .vp-shot-preview {
 	top: auto;
-	bottom: 14px;
+	bottom: 16px;
 	right: 15px;
-	width: 24%;
-	min-width: 220px;
-	max-width: 360px;
+	width: 21%;
+	min-width: 200px;
+	max-width: 330px;
 	aspect-ratio: var(--shot-aspect, 16 / 9);
-	border-radius: 11px;
+	border-radius: 9px;
 	overflow: hidden;
-	box-shadow: 0 10px 30px #00000073, 0 0 0 1px #ffffff1f;
+	box-shadow: 0 12px 32px #00000080, 0 0 0 1px #00000055, inset 0 0 0 1px #ffffff14;
 	animation: rise var(--med) var(--ease) both;
 }
 .vp-shot-preview-tag {
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
+	gap: 5px;
 	cursor: default;
 }
+/* the live-recording cue: one static red dot, no motion */
+.vp-rec-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: #e5484d;
+	box-shadow: 0 0 0 1.5px #e5484d33;
+	flex: none;
+}
+/* compact icon affordance inside the tag, mirroring the caret's manners */
 .vp-look-through {
 	pointer-events: auto;
 	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 2px;
+	margin: -2px -2px -2px 0;
 	background: none;
-	border: 1px solid var(--line2);
+	border: none;
 	border-radius: 4px;
-	color: var(--accent, #ffb454);
-	font: inherit;
-	font-size: 9px;
-	padding: 1px 6px;
+	color: inherit;
+	opacity: .7;
 }
 .vp-look-through:hover {
-	border-color: var(--accent, #ffb454);
-}
-/* Pill overlay while flying the shot camera itself */
-.vp-look-through-exit {
-	position: absolute;
-	top: 14px;
-	left: 50%;
-	transform: translateX(-50%);
-	z-index: 6;
-	pointer-events: auto;
-	cursor: pointer;
-	padding: 5px 12px;
-	border-radius: 999px;
-	background: #0e0d10d9;
-	border: 1px solid var(--accent, #ffb454);
-	color: var(--accent, #ffb454);
-	font-size: 10px;
-	font-weight: 600;
-	letter-spacing: .08em;
-	text-transform: uppercase;
+	opacity: 1;
+	color: var(--accent);
 }
 
 /* the plan pane is the interactive one wherever it lands */
@@ -8299,4 +8294,29 @@ input[type=range] {
 .matte-tools .presets.matte-icons button {
 	width: 2.3rem;
 	font-size: 13px;
+}
+
+/* Look-through pill: the inset tag's glass, floated top-centre of the stage.
+   Declared last so it outranks the base .vp-inset-tag corner anchoring. */
+.vp-inset-tag.vp-look-through-exit {
+	position: absolute;
+	/* the containing block includes the toolbar row — 60px clears it, the
+	   same band the Top-View inset opens in */
+	top: 60px;
+	left: 50%;
+	right: auto;
+	transform: translateX(-50%);
+	z-index: 6;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	pointer-events: auto;
+	cursor: pointer;
+	border-radius: 999px;
+	padding: 4px 11px;
+}
+.vp-look-through-exit .vp-exit-hint {
+	opacity: .6;
+	font-size: 9px;
+	letter-spacing: .04em;
 }

--- a/test/verify-timeline-camera.mjs
+++ b/test/verify-timeline-camera.mjs
@@ -129,7 +129,9 @@ expect(
 expect(
 	"manual viewport framing stays put until preview or playback",
 	app.includes("manualCameraOverrideRef.current = true") &&
-	(app.match(/flyingRef\.current \|\| manualCameraOverrideRef\.current/g) ?? []).length === 2 &&
+	// flying only interrupts playback while look-through hands the fly
+	// controls the shot camera itself; editor-camera flights never touch it
+	(app.match(/\(lookThroughShot && flyingRef\.current\) \|\| manualCameraOverrideRef\.current/g) ?? []).length === 2 &&
 	app.includes("manualCameraOverrideRef.current = false"),
 );
 expect(


### PR DESCRIPTION
## What

Separates the user's editing camera from the recording (shot) camera — previously one camera did fly navigation, gizmo raycasts, playback tracks and export read-back, so inspecting the set wrecked the framing and scrubbing stole the view.

- **Editor camera** owns the main pane: free lens, full-pane aspect, driven by FlyControls. Playback / follow / rail / capture never touch it, and flying it no longer interrupts camera playback.
- **Shot camera** is recording-only: renders into a chrome-free 16:9 preview pane (glass tag, REC dot), and appears in the editor view as a selectable ghost (body + lens + frustum on `GIZMO_LAYER`) movable via the object gizmo or its plan puck — both commit manual framing.
- **Look-through** (expand icon on the preview, exit pill / `Esc`) hands the fly controls the shot camera itself for framing-by-flying — the pre-split behaviour, now opt-in.
- PlayView still shows the framed output full-pane.

Also fixes a latent leak: the gizmo's visible arrows/rings lived on layer 0 and could reach captures; the whole gizmo tree now sits on `GIZMO_LAYER` with a dedicated pick pass.

## Verified locally

- `npm test` full node suite: exit 0
- `verify-ik-browser`: 43 PASS · `verify-camera-rail-browser`: 20 PASS (headless Chrome vs dev server)
- 12-check CDP smoke of the new UX (camera ownership, preview, look-through round-trip, PlayView) with zero page errors
- Screenshot QA of default / camera-selected / look-through states