### PR TITLE
feat(camera): N-point crane controls on the rail dolly

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -28,6 +28,14 @@ technical, and close to the timeline state they change.
 ## 4. Motion and Interaction
 
 - Camera toolbar actions respond immediately.
+- Crane editing exposes explicit Add point and Remove point actions beside the
+  selected point height and count. Add point fills the largest un-authored
+  interval and selects the new mark; Remove point is enabled only for a
+  selected interior mark. The scene double-click/Delete gestures remain
+  accelerators, never the only discoverable route.
+- When a Shot uses Rail + Crane, its lower key strip represents crane progress:
+  clicking the strip authors a crane point at that rail position, and the
+  matching purple/amber marker stays synchronized with the scene handle.
 - Binary camera actions state themselves in text (`Follow On` / `Follow Off`)
   and expose `aria-pressed`; Follow sits directly beside `Draw rail` and uses
   the existing violet Camera Block active state.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3133,6 +3133,43 @@ globalThis.playMode = centerTab === "play";
 		else recordShotUndo();
 		setShots((current) => updateStableItem(current, shotId, (shot) => ({ ...shot, camera: updateCameraBlock(shot.camera, patch) }), "shots"));
 	}
+	function addActiveCranePoint(requestedT = null, shotId = activeShot?.id) {
+		const shot = shots.find((entry) => entry.id === shotId);
+		const camera = createCameraBlock(shot?.camera);
+		const points = camera.craneHeight?.points;
+		if (!points || points.length >= 8) return;
+		let t = Number.isFinite(requestedT) ? Math.max(0.02, Math.min(0.98, requestedT)) : null;
+		if (t != null) {
+			const nearbyIndex = points.findIndex((point) => Math.abs(point.t - t) < 0.02);
+			if (nearbyIndex >= 0) {
+				setCraneSelectedIndex(nearbyIndex);
+				return;
+			}
+		}
+		let gapIndex = 0;
+		if (t == null) {
+			for (let i = 1; i < points.length - 1; i += 1) {
+				if (points[i + 1].t - points[i].t > points[gapIndex + 1].t - points[gapIndex].t) gapIndex = i;
+			}
+			t = (points[gapIndex].t + points[gapIndex + 1].t) / 2;
+		} else {
+			gapIndex = points.findIndex((point, index) => index < points.length - 1 && t > point.t && t < points[index + 1].t);
+			if (gapIndex < 0) return;
+		}
+		const added = [
+			...points.slice(0, gapIndex + 1),
+			{ t, height: craneHeightAt(camera.craneHeight, t) },
+			...points.slice(gapIndex + 1),
+		];
+		changeActiveCamera({ craneHeight: { points: added } }, shotId);
+		setCraneSelectedIndex(gapIndex + 1);
+	}
+	function deleteSelectedCranePoint() {
+		const points = activeCamera.craneHeight?.points;
+		if (!points || craneSelectedIndex == null || craneSelectedIndex <= 0 || craneSelectedIndex >= points.length - 1) return;
+		changeActiveCamera({ craneHeight: { points: points.filter((_, index) => index !== craneSelectedIndex) } });
+		setCraneSelectedIndex(null);
+	}
 	function syncActiveCameraFraming() {
 		const cam = shotCamRef.current;
 		if (!cam || !activeShot || ikMode || playMode) return;
@@ -8668,6 +8705,9 @@ function resizePromptClip(id, edge, rawFrame) {
 				<Timeline
 					frame={tlFrame}
 					craneSelectedIndex={craneSelectedIndex}
+					onCranePointAdd={addActiveCranePoint}
+					onCranePointDelete={deleteSelectedCranePoint}
+					onCranePointSelect={setCraneSelectedIndex}
 					frameCount={tlFrameCount}
 					fps={tlFps}
 					playbackSpeed={DEFAULT_PLAYBACK_SPEED}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1046,30 +1046,52 @@ function ViewportLayoutInvalidator({ insetX, insetY, insetWidth, insetHeight, hi
  * The drawn camera rail in the 3D Scene view: editor furniture on the gizmo
  * layer, so PlayView, the ink prepass and exports never see it.
  */
-function CameraRailScenePreview({ points }) {
+function CameraRailScenePreview({ points, cumLen, length, crane }) {
 	const rootRef = useRef(null);
-	const line = useMemo(() => {
+	const lines = useMemo(() => {
 		if (!points || points.length < 2) return null;
-		const positions = new Float32Array(points.length * 3);
+		const floor = new Float32Array(points.length * 3);
 		points.forEach((point, i) => {
-			positions[i * 3] = point.x;
-			positions[i * 3 + 1] = 0.03;
-			positions[i * 3 + 2] = point.z;
+			floor[i * 3] = point.x;
+			floor[i * 3 + 1] = 0.03;
+			floor[i * 3 + 2] = point.z;
 		});
-		const geometry = new THREE.BufferGeometry();
-		geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
-		return geometry;
-	}, [points]);
-	useEffect(() => () => line?.dispose(), [line]);
+		const floorGeometry = new THREE.BufferGeometry();
+		floorGeometry.setAttribute("position", new THREE.BufferAttribute(floor, 3));
+		// A craned rail shows WHERE THE LENS RIDES: the same path lifted along
+		// the crane's start→end heights by arc progress, with the floor line
+		// kept as the track's ground projection.
+		let liftedGeometry = null;
+		if (crane && cumLen && length > 1e-9) {
+			const lifted = new Float32Array(points.length * 3);
+			points.forEach((point, i) => {
+				lifted[i * 3] = point.x;
+				lifted[i * 3 + 1] = crane.start + (crane.end - crane.start) * (cumLen[i] / length);
+				lifted[i * 3 + 2] = point.z;
+			});
+			liftedGeometry = new THREE.BufferGeometry();
+			liftedGeometry.setAttribute("position", new THREE.BufferAttribute(lifted, 3));
+		}
+		return { floorGeometry, liftedGeometry };
+	}, [points, cumLen, length, crane]);
+	useEffect(() => () => {
+		lines?.floorGeometry.dispose();
+		lines?.liftedGeometry?.dispose();
+	}, [lines]);
 	useEffect(() => {
 		rootRef.current?.traverse((node) => node.layers.set(GIZMO_LAYER));
 	});
-	if (!line) return null;
+	if (!lines) return null;
 	return (
 		<group ref={rootRef}>
-			<line geometry={line}>
-				<lineBasicMaterial color="#a78bfa" transparent opacity={0.8} depthWrite={false} />
+			<line geometry={lines.floorGeometry}>
+				<lineBasicMaterial color="#a78bfa" transparent opacity={lines.liftedGeometry ? 0.35 : 0.8} depthWrite={false} />
 			</line>
+			{lines.liftedGeometry && (
+				<line geometry={lines.liftedGeometry}>
+					<lineBasicMaterial color="#a78bfa" transparent opacity={0.9} depthWrite={false} />
+				</line>
+			)}
 		</group>
 	);
 }
@@ -5569,7 +5591,7 @@ globalThis.playMode = centerTab === "play";
 			const start = shot.startFrame;
 			const end = Math.min(subjectTrack.length, shot.endFrame + 1);
 			const subjectSlice = subjectTrack.slice(start, end);
-			const params = { ...camera.followCam, initialDir: { x: Math.sin(yaw), z: Math.cos(yaw) } };
+			const params = { ...camera.followCam, craneHeight: camera.craneHeight, initialDir: { x: Math.sin(yaw), z: Math.cos(yaw) } };
 			const rail = camera.mode === "rail" ? buildRail(camera.cameraRail) : null;
 			if (rail) {
 				const schedule = resolveRailSchedule({ railFollow: camera.railFollow, cameraRail: camera.cameraRail, frameCount: subjectSlice.length });
@@ -7055,7 +7077,14 @@ function resizePromptClip(id, edge, rawFrame) {
 								}
 								onGroundClick={waypointMode && !planIsMain ? addFloorWaypoint : undefined}
 							/>
-							{centerTab === "scene" && railCurve && <CameraRailScenePreview points={railCurve.points} />}
+							{centerTab === "scene" && railCurve && (
+								<CameraRailScenePreview
+									points={railCurve.points}
+									cumLen={railCurve.cumLen}
+									length={railCurve.length}
+									crane={activeCamera.craneHeight}
+								/>
+							)}
 							<EditorCamSeed camRef={editorCamRef} lookRef={editorLook} shotCamRef={shotCamRef} subject={charA} />
 							<ShotLookApplier camRef={shotCamRef} look={look} />
 							<ShotCameraGhost

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,7 +39,7 @@ import {
 	readShotAuthoringDocument,
 	readShotAuthoring,
 } from "./shot-authoring.js";
-import { buildFollowTrack, buildRail, buildRailFollowTrack, followFramingFromCamera, simplifyStroke } from "./camera-follow.js";
+import { buildFollowTrack, buildRail, buildRailFollowTrack, craneHeightAt, followFramingFromCamera, railPoint, simplifyStroke } from "./camera-follow.js";
 import { createCameraBlock, removeCameraRail, updateCameraBlock } from "./camera-block.js";
 import {
 	RAIL_SCHEDULE_LEGACY,
@@ -1066,7 +1066,7 @@ function CameraRailScenePreview({ points, cumLen, length, crane }) {
 			const lifted = new Float32Array(points.length * 3);
 			points.forEach((point, i) => {
 				lifted[i * 3] = point.x;
-				lifted[i * 3 + 1] = crane.start + (crane.end - crane.start) * (cumLen[i] / length);
+				lifted[i * 3 + 1] = craneHeightAt(crane, cumLen[i] / length);
 				lifted[i * 3 + 2] = point.z;
 			});
 			liftedGeometry = new THREE.BufferGeometry();
@@ -1092,6 +1092,189 @@ function CameraRailScenePreview({ points, cumLen, length, crane }) {
 					<lineBasicMaterial color="#a78bfa" transparent opacity={0.9} depthWrite={false} />
 				</line>
 			)}
+		</group>
+	);
+}
+
+
+/**
+ * The crane's height marks as grabbable dots on the lifted curve. Click a
+ * dot to select it, drag to set its height (the drag rides a camera-facing
+ * vertical plane through the dot's rail point), Shift-drag to slide an
+ * interior mark along the arc, double-click the curve to add a mark and
+ * Delete to remove a non-endpoint. Dots live on GIZMO_LAYER, so the
+ * recording never sees them.
+ */
+function CraneHandles({ rail, crane, selectedIndex, enabled, paneRef, camRef, onSelect, onChangePoints, onDragStart, onDragEnd }) {
+	const { gl } = useThree();
+	const invalidate = useThree((state) => state.invalidate);
+	const groupRef = useRef(null);
+	const dragRef = useRef(null);
+	const stateRef = useRef(null);
+	stateRef.current = { rail, crane, selectedIndex, enabled, onSelect, onChangePoints, onDragStart, onDragEnd };
+	useEffect(() => {
+		groupRef.current?.traverse((node) => node.layers?.set(GIZMO_LAYER));
+	});
+	useEffect(() => {
+		if (!enabled) return undefined;
+		const raycaster = new THREE.Raycaster();
+		raycaster.layers.set(GIZMO_LAYER);
+		const rayFrom = (event) => {
+			const pane = paneRef.current;
+			const camera = camRef.current;
+			if (!pane || !camera) return null;
+			const bounds = pane.getBoundingClientRect();
+			if (bounds.width < 2 || bounds.height < 2) return null;
+			const ndc = new THREE.Vector2(
+				((event.clientX - bounds.left) / bounds.width) * 2 - 1,
+				-((event.clientY - bounds.top) / bounds.height) * 2 + 1,
+			);
+			if (Math.abs(ndc.x) > 1 || Math.abs(ndc.y) > 1) return null;
+			camera.updateMatrixWorld();
+			raycaster.setFromCamera(ndc, camera);
+			return raycaster;
+		};
+		const paneScreen = (world) => {
+			const pane = paneRef.current.getBoundingClientRect();
+			const projected = world.project(camRef.current);
+			return projected.z > 1 ? null : {
+				x: pane.left + ((projected.x + 1) / 2) * pane.width,
+				y: pane.top + ((1 - projected.y) / 2) * pane.height,
+			};
+		};
+		const onDown = (event) => {
+			const s = stateRef.current;
+			if (!s.enabled || !s.crane || event.button !== 0) return;
+			if (!groupRef.current || !rayFrom(event)) return;
+			const hits = raycaster.intersectObjects(groupRef.current.children, true);
+			const hit = hits.find((entry) => entry.object.userData?.craneIndex !== undefined);
+			if (!hit) return;
+			event.stopImmediatePropagation();
+			event.preventDefault();
+			const index = hit.object.userData.craneIndex;
+			s.onSelect(index);
+			dragRef.current = { index, slide: event.shiftKey, recorded: false };
+			invalidate();
+		};
+		const onMove = (event) => {
+			const s = stateRef.current;
+			const drag = dragRef.current;
+			if (!drag || !s.enabled || !s.crane || !s.rail) return;
+			if (!rayFrom(event)) return;
+			const points = s.crane.points;
+			const point = points[drag.index];
+			if (!point) return;
+			if (!drag.recorded) {
+				s.onDragStart?.();
+				drag.recorded = true;
+			}
+			if (drag.slide && drag.index > 0 && drag.index < points.length - 1) {
+				// slide along the arc: ray onto the horizontal plane at the mark
+				const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -point.height);
+				const world = new THREE.Vector3();
+				if (!raycaster.ray.intersectPlane(plane, world)) return;
+				let bestI = 0;
+				let bestD = Infinity;
+				for (let i = 0; i < s.rail.points.length; i += 1) {
+					const d = Math.hypot(s.rail.points[i].x - world.x, s.rail.points[i].z - world.z);
+					if (d < bestD) {
+						bestD = d;
+						bestI = i;
+					}
+				}
+				const t = Math.max(
+					points[drag.index - 1].t + 0.02,
+					Math.min(points[drag.index + 1].t - 0.02, s.rail.cumLen[bestI] / s.rail.length),
+				);
+				s.onChangePoints(points.map((entry, i) => (i === drag.index ? { ...entry, t } : entry)), { dragging: true });
+			} else {
+				// height: ray onto the camera-facing vertical plane at the base
+				const base = railPoint(s.rail, point.t * s.rail.length);
+				const camera = camRef.current;
+				const facing = new THREE.Vector3();
+				camera.getWorldDirection(facing);
+				facing.y = 0;
+				if (facing.lengthSq() < 1e-6) return; // looking straight down: height is unreadable
+				facing.normalize();
+				const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(facing, new THREE.Vector3(base.x, 0, base.z));
+				const world = new THREE.Vector3();
+				if (!raycaster.ray.intersectPlane(plane, world)) return;
+				const height = Math.max(0.1, Math.min(12, world.y));
+				s.onChangePoints(points.map((entry, i) => (i === drag.index ? { ...entry, height } : entry)), { dragging: true });
+			}
+			invalidate();
+		};
+		const onUp = () => {
+			if (dragRef.current?.recorded) stateRef.current.onDragEnd?.();
+			dragRef.current = null;
+		};
+		const onDouble = (event) => {
+			const s = stateRef.current;
+			if (!s.enabled || !s.crane || !s.rail || !camRef.current) return;
+			camRef.current.updateMatrixWorld();
+			let best = null;
+			for (let i = 0; i < s.rail.points.length; i += 1) {
+				const t = s.rail.cumLen[i] / s.rail.length;
+				const screen = paneScreen(new THREE.Vector3(s.rail.points[i].x, craneHeightAt(s.crane, t), s.rail.points[i].z));
+				if (!screen) continue;
+				const d = Math.hypot(screen.x - event.clientX, screen.y - event.clientY);
+				if (!best || d < best.d) best = { d, t };
+			}
+			if (!best || best.d > 14) return;
+			if (s.crane.points.length >= 8) return;
+			if (s.crane.points.some((entry) => Math.abs(entry.t - best.t) < 0.03)) return;
+			event.stopImmediatePropagation();
+			event.preventDefault();
+			const added = [...s.crane.points, { t: best.t, height: craneHeightAt(s.crane, best.t) }].sort((a, b) => a.t - b.t);
+			s.onChangePoints(added);
+			s.onSelect(added.findIndex((entry) => entry.t === best.t));
+			invalidate();
+		};
+		const onKey = (event) => {
+			const s = stateRef.current;
+			if (!s.enabled || !s.crane) return;
+			if (event.key !== "Delete" && event.key !== "Backspace") return;
+			if (document.activeElement && /INPUT|TEXTAREA/.test(document.activeElement.tagName)) return;
+			const index = s.selectedIndex;
+			if (index == null || index <= 0 || index >= s.crane.points.length - 1) return;
+			event.preventDefault();
+			s.onChangePoints(s.crane.points.filter((_, i) => i !== index));
+			s.onSelect(null);
+			invalidate();
+		};
+		const el = gl.domElement;
+		el.addEventListener("pointerdown", onDown, true);
+		window.addEventListener("pointermove", onMove, true);
+		window.addEventListener("pointerup", onUp, true);
+		el.addEventListener("dblclick", onDouble, true);
+		window.addEventListener("keydown", onKey);
+		return () => {
+			el.removeEventListener("pointerdown", onDown, true);
+			window.removeEventListener("pointermove", onMove, true);
+			window.removeEventListener("pointerup", onUp, true);
+			el.removeEventListener("dblclick", onDouble, true);
+			window.removeEventListener("keydown", onKey);
+		};
+		// paneRef/camRef are stable refs; handlers read live state through stateRef
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [enabled, gl, invalidate]);
+	if (!enabled || !crane || !rail) return null;
+	return (
+		<group ref={groupRef}>
+			{crane.points.map((point, index) => {
+				const base = railPoint(rail, point.t * rail.length);
+				return (
+					<mesh
+						key={`${index}:${crane.points.length}`}
+						position={[base.x, point.height, base.z]}
+						userData={{ craneIndex: index }}
+						renderOrder={998}
+					>
+						<sphereGeometry args={[0.085, 16, 12]} />
+						<meshBasicMaterial color={index === selectedIndex ? "#ffb454" : "#a78bfa"} depthTest={false} transparent opacity={0.95} />
+					</mesh>
+				);
+			})}
 		</group>
 	);
 }
@@ -2660,6 +2843,9 @@ globalThis.playMode = centerTab === "play";
 	// motion share one time axis; off frees the camera while both stay set.
 	const [moveFollow, setMoveFollow] = useState(true);
 	const [railDraw, setRailDraw] = useState(false);
+	// Which crane height mark the scene dots have selected; the timeline's
+	// Point height input edits this one. Reset lives after activeCamera below.
+	const [craneSelectedIndex, setCraneSelectedIndex] = useState(null);
 	const [hasCharSheet, setHasCharSheet] = useState(startupStage.hasCharSheet);
 	const [hasEnvSheet, setHasEnvSheet] = useState(false);
 	const [environment, setEnvironment] = useState(DEFAULT_ENVIRONMENT);
@@ -2926,6 +3112,11 @@ globalThis.playMode = centerTab === "play";
 	const activeShot = shots[activeShotIdx] ?? null;
 	const cameraKeys = activeShot?.cameraKeys ?? [];
 	const activeCamera = createCameraBlock(activeShot?.camera);
+	// A crane/shot switch invalidates the scene-dot selection.
+	const craneActive = !!activeCamera.craneHeight;
+	useEffect(() => {
+		setCraneSelectedIndex(null);
+	}, [activeShot?.id, craneActive]);
 	const followCam = activeCamera.followCam;
 	const cameraRail = activeCamera.cameraRail;
 	const activeShotDuration = activeShot ? activeShot.endFrame - activeShot.startFrame + 1 : 0;
@@ -7085,6 +7276,30 @@ function resizePromptClip(id, edge, rawFrame) {
 									crane={activeCamera.craneHeight}
 								/>
 							)}
+							<CraneHandles
+								rail={railCurve}
+								crane={activeCamera.craneHeight}
+								selectedIndex={craneSelectedIndex}
+								enabled={centerTab === "scene" && !lookThroughShot && !ikMode && !posing && !playMode && !!railCurve && !!activeCamera.craneHeight}
+								paneRef={mainPaneRef}
+								camRef={editorCamRef}
+								onSelect={setCraneSelectedIndex}
+								onChangePoints={(points, options) => {
+									if (!options?.dragging) {
+										changeActiveCamera({ craneHeight: { points } });
+										return;
+									}
+									setShots((current) =>
+										updateStableItem(
+											current,
+											activeShot.id,
+											(shot) => ({ ...shot, camera: updateCameraBlock(shot.camera, { craneHeight: { points } }) }),
+											"shots",
+										),
+									);
+								}}
+								onDragStart={recordShotUndo}
+							/>
 							<EditorCamSeed camRef={editorCamRef} lookRef={editorLook} shotCamRef={shotCamRef} subject={charA} />
 							<ShotLookApplier camRef={shotCamRef} look={look} />
 							<ShotCameraGhost
@@ -8452,6 +8667,7 @@ function resizePromptClip(id, edge, rawFrame) {
 				<div className="bottom-timeline" hidden={bottomTab !== "timeline"}>
 				<Timeline
 					frame={tlFrame}
+					craneSelectedIndex={craneSelectedIndex}
 					frameCount={tlFrameCount}
 					fps={tlFps}
 					playbackSpeed={DEFAULT_PLAYBACK_SPEED}

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -97,6 +97,7 @@ function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, on
 	if (!shot) return null;
 	const mode = cameraBlockMode(shot);
 	const follow = cameraBlockFollow(shot);
+	const crane = shot?.camera?.craneHeight ?? null;
 	const patchCamera = (patch) => onChange?.(patch);
 	const patchFollow = (patch) => onChange?.({ followCam: { ...follow, ...patch } });
 	const numberValue = (event) => Number(event.currentTarget.value);
@@ -152,16 +153,43 @@ function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, on
 						<input type="number" min="0.2" max="8" step="0.1" value={follow.maxDollySpeed} onChange={(event) => patchFollow({ maxDollySpeed: numberValue(event) })} />
 						<small>m/s</small>
 					</label>
-					<label title={ko("Read automatically from the camera position", "현재 카메라 위치에서 자동으로 읽습니다")}>
-						<span>{ko("Height", "높이")}</span>
-						<output className="tl-camera-metric">{metric(follow.height, 2)}</output>
-						<small>m</small>
-					</label>
+					{!(mode === "rail" && crane) && (
+						<label title={ko("Read automatically from the camera position", "현재 카메라 위치에서 자동으로 읽습니다")}>
+							<span>{ko("Height", "높이")}</span>
+							<output className="tl-camera-metric">{metric(follow.height, 2)}</output>
+							<small>m</small>
+						</label>
+					)}
 					<label title={ko("Read automatically from the camera tilt", "현재 카메라 틸트에서 자동으로 읽습니다")}>
 						<span>{ko("Pitch", "피치")}</span>
 						<output className="tl-camera-metric">{signedValue(follow.pitchOffsetDeg)}</output>
 						<small>°</small>
 					</label>
+					{mode === "rail" && railLength != null && (
+						<button
+							type="button"
+							className={"tl-camera-tool" + (crane ? " active" : "")}
+							aria-pressed={!!crane}
+							title={ko("Crane the lens between two heights along the rail", "레일을 따라 렌즈 높이를 두 지점 사이로 옮깁니다")}
+							onClick={() => patchCamera({ craneHeight: crane ? null : { start: follow.height, end: follow.height } })}
+						>
+							{crane ? ko("Crane On", "크레인 켜짐") : ko("Crane Off", "크레인 꺼짐")}
+						</button>
+					)}
+					{mode === "rail" && crane && (
+						<>
+							<label title={ko("Lens height where the rail starts", "레일 시작점에서의 렌즈 높이")}>
+								<span>{ko("Start height", "시작 높이")}</span>
+								<input type="number" min="0.1" max="12" step="0.1" value={crane.start} onChange={(event) => patchCamera({ craneHeight: { ...crane, start: numberValue(event) } })} />
+								<small>m</small>
+							</label>
+							<label title={ko("Lens height where the rail ends", "레일 끝점에서의 렌즈 높이")}>
+								<span>{ko("End height", "끝 높이")}</span>
+								<input type="number" min="0.1" max="12" step="0.1" value={crane.end} onChange={(event) => patchCamera({ craneHeight: { ...crane, end: numberValue(event) } })} />
+								<small>m</small>
+							</label>
+						</>
+					)}
 					<details className="tl-camera-advanced">
 						<summary>{ko("Advanced", "고급")}</summary>
 						<label title={ko("Set how softly the rig catches up", "카메라가 얼마나 부드럽게 따라붙는지 정합니다")}>

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -93,7 +93,7 @@ function signedValue(value) {
 	return `${rounded >= 0 ? "+" : ""}${rounded}`;
 }
 
-function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, onChange, onPreview, onRailDrawToggle, onRailDelete }) {
+function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, craneSelectedIndex = null, onChange, onPreview, onRailDrawToggle, onRailDelete }) {
 	if (!shot) return null;
 	const mode = cameraBlockMode(shot);
 	const follow = cameraBlockFollow(shot);
@@ -171,25 +171,29 @@ function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, on
 							className={"tl-camera-tool" + (crane ? " active" : "")}
 							aria-pressed={!!crane}
 							title={ko("Crane the lens between two heights along the rail", "레일을 따라 렌즈 높이를 두 지점 사이로 옮깁니다")}
-							onClick={() => patchCamera({ craneHeight: crane ? null : { start: follow.height, end: follow.height } })}
+							onClick={() => patchCamera({ craneHeight: crane ? null : { points: [{ t: 0, height: follow.height }, { t: 1, height: follow.height }] } })}
 						>
 							{crane ? ko("Crane On", "크레인 켜짐") : ko("Crane Off", "크레인 꺼짐")}
 						</button>
 					)}
-					{mode === "rail" && crane && (
-						<>
-							<label title={ko("Lens height where the rail starts", "레일 시작점에서의 렌즈 높이")}>
-								<span>{ko("Start height", "시작 높이")}</span>
-								<input type="number" min="0.1" max="12" step="0.1" value={crane.start} onChange={(event) => patchCamera({ craneHeight: { ...crane, start: numberValue(event) } })} />
-								<small>m</small>
-							</label>
-							<label title={ko("Lens height where the rail ends", "레일 끝점에서의 렌즈 높이")}>
-								<span>{ko("End height", "끝 높이")}</span>
-								<input type="number" min="0.1" max="12" step="0.1" value={crane.end} onChange={(event) => patchCamera({ craneHeight: { ...crane, end: numberValue(event) } })} />
-								<small>m</small>
-							</label>
-						</>
-					)}
+					{mode === "rail" && crane && (() => {
+						const points = crane.points;
+						const index = craneSelectedIndex != null && craneSelectedIndex >= 0 && craneSelectedIndex < points.length ? craneSelectedIndex : points.length - 1;
+						const patchPointHeight = (height) => {
+							const next = points.map((point, i) => (i === index ? { ...point, height } : point));
+							patchCamera({ craneHeight: { points: next } });
+						};
+						return (
+							<>
+								<label title={ko("Lens height of the selected crane point — click a purple dot in the scene to pick one, double-click the lifted curve to add one", "선택한 크레인 점의 렌즈 높이 — 씨의 보라 점을 클릭해 선택, 커브 더블클릭으로 추가")}>
+									<span>{ko("Point height", "점 높이")}</span>
+									<input type="number" min="0.1" max="12" step="0.1" value={points[index].height} onChange={(event) => patchPointHeight(numberValue(event))} />
+									<small>m</small>
+								</label>
+								<output className="tl-camera-count" title={ko("Crane points on this rail", "이 레일의 크레인 점 개수")}>{points.length}{ko(" pts", "점")}</output>
+							</>
+						);
+					})()}
 					<details className="tl-camera-advanced">
 						<summary>{ko("Advanced", "고급")}</summary>
 						<label title={ko("Set how softly the rig catches up", "카메라가 얼마나 부드럽게 따라붙는지 정합니다")}>
@@ -269,6 +273,7 @@ export default function Timeline({
 	onCameraBlockChange,
 	onCameraPreview,
 	railDraw = false,
+	craneSelectedIndex = null,
 	cameraRailLength = null,
 	onCameraRailDrawToggle,
 	onCameraRailDelete,
@@ -1089,6 +1094,7 @@ export default function Timeline({
 							previewing={playing}
 							railDraw={railDraw}
 							railLength={cameraRailLength}
+							craneSelectedIndex={craneSelectedIndex}
 							onChange={(patch) => handlers.current.onCameraBlockChange?.(patch)}
 							onPreview={() => handlers.current.onCameraPreview?.(selectedCameraShot.id)}
 							onRailDrawToggle={() => handlers.current.onCameraRailDrawToggle?.()}

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -93,7 +93,20 @@ function signedValue(value) {
 	return `${rounded >= 0 ? "+" : ""}${rounded}`;
 }
 
-function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, craneSelectedIndex = null, onChange, onPreview, onRailDrawToggle, onRailDelete }) {
+function CameraBlockEditor({
+	shot,
+	blocked,
+	previewing,
+	railDraw,
+	railLength,
+	craneSelectedIndex = null,
+	onChange,
+	onPreview,
+	onRailDrawToggle,
+	onRailDelete,
+	onCranePointAdd,
+	onCranePointDelete,
+}) {
 	if (!shot) return null;
 	const mode = cameraBlockMode(shot);
 	const follow = cameraBlockFollow(shot);
@@ -170,7 +183,7 @@ function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, cr
 							type="button"
 							className={"tl-camera-tool" + (crane ? " active" : "")}
 							aria-pressed={!!crane}
-							title={ko("Crane the lens between two heights along the rail", "레일을 따라 렌즈 높이를 두 지점 사이로 옮깁니다")}
+							title={ko("Crane the lens across authored height points along the rail", "레일을 따라 설정한 여러 높이 점으로 렌즈를 움직입니다")}
 							onClick={() => patchCamera({ craneHeight: crane ? null : { points: [{ t: 0, height: follow.height }, { t: 1, height: follow.height }] } })}
 						>
 							{crane ? ko("Crane On", "크레인 켜짐") : ko("Crane Off", "크레인 꺼짐")}
@@ -191,6 +204,24 @@ function CameraBlockEditor({ shot, blocked, previewing, railDraw, railLength, cr
 									<small>m</small>
 								</label>
 								<output className="tl-camera-count" title={ko("Crane points on this rail", "이 레일의 크레인 점 개수")}>{points.length}{ko(" pts", "점")}</output>
+								<button
+									type="button"
+									className="tl-camera-tool"
+									disabled={points.length >= 8}
+									title={ko("Add a crane point in the largest gap on this Shot's rail", "이 샷 레일의 가장 큰 빈 구간에 크레인 점을 추가합니다")}
+									onClick={() => onCranePointAdd?.()}
+								>
+									{ko("Add point", "점 추가")}
+								</button>
+								<button
+									type="button"
+									className="tl-camera-tool danger"
+									disabled={craneSelectedIndex == null || craneSelectedIndex <= 0 || craneSelectedIndex >= points.length - 1}
+									title={ko("Remove the selected interior crane point", "선택한 중간 크레인 점을 삭제합니다")}
+									onClick={() => onCranePointDelete?.()}
+								>
+									{ko("Remove point", "점 삭제")}
+								</button>
 							</>
 						);
 					})()}
@@ -274,6 +305,9 @@ export default function Timeline({
 	onCameraPreview,
 	railDraw = false,
 	craneSelectedIndex = null,
+	onCranePointAdd,
+	onCranePointDelete,
+	onCranePointSelect,
 	cameraRailLength = null,
 	onCameraRailDrawToggle,
 	onCameraRailDelete,
@@ -865,16 +899,26 @@ export default function Timeline({
 		handlers.current.onCameraMoveSelect?.();
 	}
 
-	function addCameraKeyFromBlock(e, index) {
+	function addShotPointFromBlock(e, shot, index) {
 		if (e.button !== 0) return;
 		e.preventDefault();
 		e.stopPropagation();
-		const lane = e.currentTarget.closest(".tl-lane");
-		const rect = lane?.getBoundingClientRect();
-		if (!rect) return;
-		const target = frameFromClientX(e.clientX, rect.left, rect.width, displayFrameCount, frameCount);
+		const keySurface = e.currentTarget.closest(".tl-shot-key-surface");
+		if (!keySurface) return;
 		selectUnifiedShotBlock(index);
-		handlers.current.onCameraKeyframeAdd?.(target, shots[index]?.id);
+		if (shot.camera?.mode === "rail" && shot.camera?.craneHeight) {
+			const rail = keySurface.parentElement?.querySelector(".tl-rail");
+			const railRect = rail?.getBoundingClientRect();
+			if (!railRect || e.clientX < railRect.left || e.clientX > railRect.right) return;
+			const t = Math.max(0, Math.min(1, (e.clientX - railRect.left) / Math.max(1, railRect.width)));
+			onCranePointAdd?.(t, shot.id);
+			return;
+		}
+		const lane = e.currentTarget.closest(".tl-lane");
+		const laneRect = lane?.getBoundingClientRect();
+		if (!laneRect) return;
+		const target = frameFromClientX(e.clientX, laneRect.left, laneRect.width, displayFrameCount, frameCount);
+		handlers.current.onCameraKeyframeAdd?.(target, shot.id);
 	}
 
 	function finishShotRename(shot, index, value) {
@@ -1099,6 +1143,8 @@ export default function Timeline({
 							onPreview={() => handlers.current.onCameraPreview?.(selectedCameraShot.id)}
 							onRailDrawToggle={() => handlers.current.onCameraRailDrawToggle?.()}
 							onRailDelete={() => handlers.current.onCameraRailDelete?.()}
+							onCranePointAdd={onCranePointAdd}
+							onCranePointDelete={onCranePointDelete}
 						/>
 					)}
 
@@ -1307,12 +1353,46 @@ export default function Timeline({
 														onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); handlers.current.onRailRemove?.(shot.id); }}
 													>
 														<button type="button" tabIndex={0} data-rail-edge="start" className="tl-rail-handle start" aria-label={ko("Resize rail follow start", "레일 팔로우 시작점 조절")} onKeyDown={(e) => onRailKeyDown(e, shot.id, railRange, durationFrames)} onPointerDown={(e) => beginRailResize(e, shot, "start", railRange, durationFrames)} onPointerMove={moveRailResize} onPointerUp={endRailResize} onPointerCancel={endRailResize} />
-														<button type="button" tabIndex={0} data-rail-edge="body" className="tl-rail-body" aria-label={ko("Rail follow — drag to move, right-click to remove", "레일 팔로우 — 드래그로 이동, 오른쪽 클릭으로 삭제")} onKeyDown={(e) => onRailKeyDown(e, shot.id, railRange, durationFrames)} onPointerDown={(e) => beginRailMove(e, shot, railRange, durationFrames)} onPointerMove={moveRail} onPointerUp={endRailMove} onPointerCancel={endRailMove} onClick={(e) => { e.stopPropagation(); if (!railSuppressClickRef.current) handlers.current.onRailSelect?.(shot.id); }}>
+														<button
+															type="button"
+															tabIndex={0}
+															data-rail-edge="body"
+															className="tl-rail-body"
+															aria-label={ko("Rail follow — drag to move, right-click to remove", "레일 팔로우 — 드래그로 이동, 오른쪽 클릭으로 삭제")}
+															title={ko("Drag to move the Rail Follow range", "드래그해 레일 팔로우 구간 이동")}
+															onKeyDown={(e) => onRailKeyDown(e, shot.id, railRange, durationFrames)}
+															onPointerDown={(e) => beginRailMove(e, shot, railRange, durationFrames)}
+															onPointerMove={moveRail}
+															onPointerUp={endRailMove}
+															onPointerCancel={endRailMove}
+															onClick={(e) => {
+																e.stopPropagation();
+																if (railSuppressClickRef.current) return;
+																handlers.current.onRailSelect?.(shot.id);
+															}}
+														>
 															<span className="tl-rail-label">{ko("Rail Follow", "레일 팔로우")}</span>
 															{railOff && <span className="tl-rail-off">{ko("OFF", "꺼짐")}</span>}
 														</button>
 														<button type="button" tabIndex={0} data-rail-edge="end" className="tl-rail-handle end" aria-label={ko("Resize rail follow end", "레일 팔로우 끝점 조절")} onKeyDown={(e) => onRailKeyDown(e, shot.id, railRange, durationFrames)} onPointerDown={(e) => beginRailResize(e, shot, "end", railRange, durationFrames)} onPointerMove={moveRailResize} onPointerUp={endRailResize} onPointerCancel={endRailResize} />
 														{railProgress != null && <i className="tl-rail-progress" style={{ "--tl-rail-p": railProgress }} aria-hidden="true" />}
+														{!railOff && (shot.camera?.craneHeight?.points ?? []).map((point, pointIndex) => (
+															<button
+																key={`${shot.id}:crane:${pointIndex}`}
+																type="button"
+																className={"tl-crane-point" + (index === cameraBlockIdx && pointIndex === craneSelectedIndex ? " selected" : "")}
+																style={{ "--tl-crane-p": point.t }}
+																aria-label={ko(`Select crane point ${pointIndex + 1}`, `크레인 점 ${pointIndex + 1} 선택`)}
+																title={ko(`Crane point ${pointIndex + 1} · ${point.height.toFixed(2)} m`, `크레인 점 ${pointIndex + 1} · ${point.height.toFixed(2)} m`)}
+																onPointerDown={(event) => event.stopPropagation()}
+																onClick={(event) => {
+																	event.stopPropagation();
+																	selectUnifiedShotBlock(index);
+																	onCranePointSelect?.(pointIndex, shot.id);
+																}}
+																onDoubleClick={(event) => event.stopPropagation()}
+															/>
+														))}
 													</div>
 												)}
 												{/* The card body owns selection/reorder; this narrow empty strip
@@ -1321,9 +1401,13 @@ export default function Timeline({
 												<button
 													type="button"
 													className="tl-shot-key-surface"
-													aria-label={ko(`Add camera key in ${shot.name}`, `${shot.name}에 카메라 키 추가`)}
-													title={ko("Click at a frame to store the current camera framing", "프레임 위치를 클릭해 현재 카메라 프레이밍을 저장합니다")}
-													onClick={(event) => addCameraKeyFromBlock(event, index)}
+													aria-label={shot.camera?.mode === "rail" && shot.camera?.craneHeight
+														? ko(`Add crane point in ${shot.name}`, `${shot.name}에 크레인 점 추가`)
+														: ko(`Add camera key in ${shot.name}`, `${shot.name}에 카메라 키 추가`)}
+													title={shot.camera?.mode === "rail" && shot.camera?.craneHeight
+														? ko("Click below Rail Follow to add a crane point at that position", "레일 팔로우 아래를 클릭해 해당 위치에 크레인 점을 추가합니다")
+														: ko("Click at a frame to store the current camera framing", "프레임 위치를 클릭해 현재 카메라 프레이밍을 저장합니다")}
+													onClick={(event) => addShotPointFromBlock(event, shot, index)}
 													onDoubleClick={(event) => event.stopPropagation()}
 												/>
 											</div>

--- a/src/camera-block.js
+++ b/src/camera-block.js
@@ -19,15 +19,31 @@ function cloneRail(points) {
 }
 
 /**
- * The crane axis a rail may carry: lens height at the rail head and tail,
- * lerped along the dolly's arc progress. Null = flat rail at the follow
- * height (every pre-crane document). Marks clamp to a 0.1 m floor — a lens
- * below the deck is never an authorable intent.
+ * The crane axis a rail may carry: height marks along the dolly's arc
+ * progress ({ points: [{ t, height }] }, endpoints pinned at t 0 and 1, at
+ * most 8 marks). A legacy { start, end } pair reads as its two endpoints.
+ * Null = flat rail at the follow height (every pre-crane document). Marks
+ * clamp to a 0.1 m floor — a lens below the deck is never authorable.
  */
 function cloneCraneHeight(value) {
 	if (!value || typeof value !== "object") return null;
-	if (!Number.isFinite(value.start) || !Number.isFinite(value.end)) return null;
-	return { start: Math.max(0.1, value.start), end: Math.max(0.1, value.end) };
+	const raw = Array.isArray(value.points)
+		? value.points
+		: Number.isFinite(value.start) && Number.isFinite(value.end)
+			? [{ t: 0, height: value.start }, { t: 1, height: value.end }]
+			: null;
+	if (!raw) return null;
+	const cleaned = raw
+		.filter((point) => point && Number.isFinite(point.t) && Number.isFinite(point.height))
+		.map((point) => ({ t: Math.max(0, Math.min(1, point.t)), height: Math.max(0.1, point.height) }))
+		.sort((a, b) => a.t - b.t)
+		// duplicate marks: the later-authored one wins
+		.filter((point, i, arr) => i === arr.length - 1 || arr[i + 1].t - point.t > 1e-6)
+		.slice(0, 8);
+	if (cleaned.length < 2) return null;
+	cleaned[0] = { ...cleaned[0], t: 0 };
+	cleaned[cleaned.length - 1] = { ...cleaned[cleaned.length - 1], t: 1 };
+	return { points: cleaned };
 }
 
 function cloneRailFollow(value) {

--- a/src/camera-block.js
+++ b/src/camera-block.js
@@ -18,6 +18,18 @@ function cloneRail(points) {
 	return Array.isArray(points) ? points.map((point) => ({ x: point.x, z: point.z })) : null;
 }
 
+/**
+ * The crane axis a rail may carry: lens height at the rail head and tail,
+ * lerped along the dolly's arc progress. Null = flat rail at the follow
+ * height (every pre-crane document). Marks clamp to a 0.1 m floor — a lens
+ * below the deck is never an authorable intent.
+ */
+function cloneCraneHeight(value) {
+	if (!value || typeof value !== "object") return null;
+	if (!Number.isFinite(value.start) || !Number.isFinite(value.end)) return null;
+	return { start: Math.max(0.1, value.start), end: Math.max(0.1, value.end) };
+}
+
 function cloneRailFollow(value) {
 	if (!value || typeof value !== "object") return null;
 	if (value.mode === "off") return { mode: "off" };
@@ -37,6 +49,7 @@ export function createCameraBlock(input = {}) {
 		followCam: { ...CAMERA_FOLLOW_DEFAULTS, ...(value.followCam ?? {}) },
 		cameraRail: cloneRail(value.cameraRail),
 		railFollow: cloneRailFollow(value.railFollow),
+		craneHeight: cloneCraneHeight(value.craneHeight),
 	};
 }
 
@@ -57,6 +70,7 @@ export function updateCameraBlock(camera, patch = {}) {
 			: current.followCam,
 		cameraRail: Object.hasOwn(change, "cameraRail") ? change.cameraRail : current.cameraRail,
 		railFollow: Object.hasOwn(change, "railFollow") ? change.railFollow : current.railFollow,
+		craneHeight: Object.hasOwn(change, "craneHeight") ? change.craneHeight : current.craneHeight,
 	});
 }
 
@@ -67,5 +81,6 @@ export function removeCameraRail(camera) {
 		mode: current.mode === "rail" ? "follow" : current.mode,
 		cameraRail: null,
 		railFollow: null,
+		craneHeight: null,
 	});
 }

--- a/src/camera-follow.js
+++ b/src/camera-follow.js
@@ -403,6 +403,18 @@ export function buildRailFollowTrack(subject, fps, rail, params = {}) {
 	const authoredSpeed = subject.length > 1 ? rail.length / ((subject.length - 1) * dt) : 0;
 	const progressLead = (2 * authoredSpeed) / omega;
 
+	// The crane axis: lens height follows the dolly's own arc progress, so the
+	// height always matches where the camera physically is on the track — a
+	// stalled dolly holds its height instead of sinking on a timer.
+	const crane = p.craneHeight && Number.isFinite(p.craneHeight.start) && Number.isFinite(p.craneHeight.end)
+		? p.craneHeight
+		: null;
+	const craneTargetAt = (arc) => {
+		if (!crane) return p.height;
+		const progress = rail.length < 1e-9 ? 1 : Math.max(0, Math.min(1, arc / rail.length));
+		return crane.start + (crane.end - crane.start) * progress;
+	};
+
 	const distanceErrorAt = (s, subj) => {
 		const rp = railPoint(rail, s);
 		return Math.abs(Math.hypot(rp.x - subj.x, rp.z - subj.z) - p.distance);
@@ -434,7 +446,7 @@ export function buildRailFollowTrack(subject, fps, rail, params = {}) {
 		? bestSNear(nearestS(rail, subject[0]), subject[0], rail.length, 0)
 		: 0;
 	let sVel = 0;
-	let py = p.height;
+	let py = craneTargetAt(s);
 	let vy = 0;
 	let ax = subject[0].x;
 	let az = subject[0].z;
@@ -456,7 +468,7 @@ export function buildRailFollowTrack(subject, fps, rail, params = {}) {
 			const sTarget = Math.max(s, Math.min(rail.length, authoredS + progressLead + correction));
 			[s, sVel] = cappedSpringStep(s, sVel, sTarget, omega, dt, p.maxDollySpeed);
 			s = Math.max(0, Math.min(s, rail.length));
-			[py, vy] = springStep(py, vy, p.height, omega, dt);
+			[py, vy] = springStep(py, vy, craneTargetAt(s), omega, dt);
 			const aimTx = subject[f].x + vels[f].x * p.lead;
 			const aimTz = subject[f].z + vels[f].z * p.lead;
 			[ax, avx] = springStep(ax, avx, aimTx, aimOmega, dt);

--- a/src/camera-follow.js
+++ b/src/camera-follow.js
@@ -267,6 +267,53 @@ export function buildFollowTrack(subject, fps, params = {}) {
 	return track;
 }
 
+/* ----------------------------------------------------------- the crane --- */
+
+/** Accepts the canonical { points } crane or the legacy { start, end } pair. */
+function cranePoints(value) {
+	if (!value || typeof value !== "object") return null;
+	if (Array.isArray(value.points) && value.points.length >= 2) return value.points;
+	if (Number.isFinite(value.start) && Number.isFinite(value.end)) {
+		return [{ t: 0, height: value.start }, { t: 1, height: value.end }];
+	}
+	return null;
+}
+
+/**
+ * Height of the crane profile at arc progress 0..1: a monotone piecewise
+ * cubic through the marks (harmonic-mean tangents, Fritsch–Carlson family),
+ * so the lens hits every authored height exactly and never overshoots
+ * between two of them. Two marks degrade to the exact straight lerp.
+ */
+export function craneHeightAt(craneHeight, progress) {
+	const points = cranePoints(craneHeight);
+	if (!points) return NaN;
+	const clamped = Math.max(0, Math.min(1, progress));
+	if (clamped <= points[0].t) return points[0].height;
+	if (clamped >= points[points.length - 1].t) return points[points.length - 1].height;
+	let i = 0;
+	while (i < points.length - 2 && clamped > points[i + 1].t) i += 1;
+	const p0 = points[i];
+	const p1 = points[i + 1];
+	const h = p1.t - p0.t;
+	if (h < 1e-9) return p1.height;
+	const secant = (a, b) => (b.height - a.height) / Math.max(b.t - a.t, 1e-9);
+	const d = secant(p0, p1);
+	// harmonic mean of neighbouring secants; zero across a local extremum
+	const mono = (sa, sb) => (sa * sb <= 0 ? 0 : (2 * sa * sb) / (sa + sb));
+	const m0 = i > 0 ? mono(secant(points[i - 1], p0), d) : d;
+	const m1 = i < points.length - 2 ? mono(d, secant(p1, points[i + 2])) : d;
+	const u = (clamped - p0.t) / h;
+	const u2 = u * u;
+	const u3 = u2 * u;
+	return (
+		(2 * u3 - 3 * u2 + 1) * p0.height +
+		(u3 - 2 * u2 + u) * h * m0 +
+		(-2 * u3 + 3 * u2) * p1.height +
+		(u3 - u2) * h * m1
+	);
+}
+
 /* ------------------------------------------------------------ the rail --- */
 
 /**
@@ -406,13 +453,10 @@ export function buildRailFollowTrack(subject, fps, rail, params = {}) {
 	// The crane axis: lens height follows the dolly's own arc progress, so the
 	// height always matches where the camera physically is on the track — a
 	// stalled dolly holds its height instead of sinking on a timer.
-	const crane = p.craneHeight && Number.isFinite(p.craneHeight.start) && Number.isFinite(p.craneHeight.end)
-		? p.craneHeight
-		: null;
+	const crane = cranePoints(p.craneHeight) ? p.craneHeight : null;
 	const craneTargetAt = (arc) => {
 		if (!crane) return p.height;
-		const progress = rail.length < 1e-9 ? 1 : Math.max(0, Math.min(1, arc / rail.length));
-		return crane.start + (crane.end - crane.start) * progress;
+		return craneHeightAt(crane, rail.length < 1e-9 ? 1 : arc / rail.length);
 	};
 
 	const distanceErrorAt = (s, subj) => {

--- a/src/shot-authoring.js
+++ b/src/shot-authoring.js
@@ -186,11 +186,25 @@ function repairRailFollow(value) {
 	return startFrame <= endFrame ? { mode: "range", startFrame, endFrame } : null;
 }
 
-/** The crane axis rides the rail's arc; marks share camera-block.js's 0.1 m floor. */
+/** The crane axis rides the rail's arc; mirrors camera-block.js's normalization. */
 function repairCraneHeight(value) {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-	if (!finite(value.start) || !finite(value.end)) return null;
-	return { start: Math.max(0.1, value.start), end: Math.max(0.1, value.end) };
+	const raw = Array.isArray(value.points)
+		? value.points
+		: finite(value.start) && finite(value.end)
+			? [{ t: 0, height: value.start }, { t: 1, height: value.end }]
+			: null;
+	if (!raw) return null;
+	const cleaned = raw
+		.filter((point) => point && finite(point.t) && finite(point.height))
+		.map((point) => ({ t: Math.max(0, Math.min(1, point.t)), height: Math.max(0.1, point.height) }))
+		.sort((a, b) => a.t - b.t)
+		.filter((point, i, arr) => i === arr.length - 1 || arr[i + 1].t - point.t > 1e-6)
+		.slice(0, 8);
+	if (cleaned.length < 2) return null;
+	cleaned[0] = { ...cleaned[0], t: 0 };
+	cleaned[cleaned.length - 1] = { ...cleaned[cleaned.length - 1], t: 1 };
+	return { points: cleaned };
 }
 
 function repairCamera(value) {

--- a/src/shot-authoring.js
+++ b/src/shot-authoring.js
@@ -186,6 +186,13 @@ function repairRailFollow(value) {
 	return startFrame <= endFrame ? { mode: "range", startFrame, endFrame } : null;
 }
 
+/** The crane axis rides the rail's arc; marks share camera-block.js's 0.1 m floor. */
+function repairCraneHeight(value) {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	if (!finite(value.start) || !finite(value.end)) return null;
+	return { start: Math.max(0.1, value.start), end: Math.max(0.1, value.end) };
+}
+
 function repairCamera(value) {
 	const source = value && typeof value === "object" && !Array.isArray(value) ? value : {};
 	const cameraRail = repairRail(source.cameraRail);
@@ -193,7 +200,14 @@ function repairCamera(value) {
 	// A rail block without a usable two-point rail behaves like ordinary
 	// follow, never like a mysteriously enabled but motionless dolly.
 	if (mode === "rail" && !cameraRail) mode = "follow";
-	return { mode, followCam: repairFollowCam(source.followCam), cameraRail, railFollow: repairRailFollow(source.railFollow) };
+	return {
+		mode,
+		followCam: repairFollowCam(source.followCam),
+		cameraRail,
+		railFollow: repairRailFollow(source.railFollow),
+		// A crane cannot outlive the rail it rides.
+		craneHeight: cameraRail ? repairCraneHeight(source.craneHeight) : null,
+	};
 }
 
 function migratedCamera(followCam, cameraRail, railFollow = null) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3776,6 +3776,36 @@ input[type=range]::-moz-range-thumb {
 	z-index: 3;
 }
 
+.tl-crane-point {
+	box-sizing: border-box;
+	position: absolute;
+	bottom: -13px;
+	left: clamp(7px, calc(var(--tl-crane-p) * 100%), calc(100% - 7px));
+	width: 12px;
+	height: 12px;
+	padding: 0;
+	transform: translate(-50%, -50%);
+	border: 2px solid #211b31;
+	border-radius: 50%;
+	background: #a78bfa;
+	box-shadow: 0 0 0 1px rgba(203, 183, 255, .65), 0 0 8px rgba(167, 139, 250, .9);
+	cursor: pointer;
+	pointer-events: auto;
+	z-index: 5;
+}
+
+.tl-crane-point:hover,
+.tl-crane-point:focus-visible {
+	outline: 2px solid #fff;
+	outline-offset: 1px;
+}
+
+.tl-crane-point.selected {
+	background: #ffb454;
+	border-color: #40270f;
+	box-shadow: 0 0 0 1px #ffe0a8, 0 0 9px rgba(255, 180, 84, .95);
+}
+
 .tl-marker {
 	position: absolute;
 	top: 50%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2906,6 +2906,13 @@ input[type=range]::-moz-range-thumb {
 	color: #cbb8ef;
 }
 
+.tl-camera-count {
+	font-size: 10px;
+	opacity: .65;
+	letter-spacing: .02em;
+	align-self: center;
+}
+
 .tl-camera-slate {
 	flex: none;
 	padding-left: 7px;

--- a/test/verify-camera-block.mjs
+++ b/test/verify-camera-block.mjs
@@ -13,27 +13,45 @@ const ok = (name, cond, detail = "") => {
 
 {
 	ok("legacy blocks carry no crane", createCameraBlock({}).craneHeight === null);
-	ok("stored crane marks survive normalization", (() => {
+	ok("legacy start/end marks migrate to endpoint points", (() => {
 		const block = createCameraBlock({ craneHeight: { start: 3, end: 1.2 } });
-		return block.craneHeight?.start === 3 && block.craneHeight?.end === 1.2;
+		const points = block.craneHeight?.points;
+		return points?.length === 2 && points[0].t === 0 && points[0].height === 3 && points[1].t === 1 && points[1].height === 1.2;
 	})(), JSON.stringify(createCameraBlock({ craneHeight: { start: 3, end: 1.2 } }).craneHeight));
-	ok("malformed crane values normalize to null", createCameraBlock({ craneHeight: { start: "high" } }).craneHeight === null);
+	ok("point cranes normalize sorted with pinned endpoints", (() => {
+		const block = createCameraBlock({ craneHeight: { points: [{ t: 0.6, height: 2 }, { t: 0.05, height: 3 }, { t: 0.95, height: 1.2 }] } });
+		const points = block.craneHeight?.points;
+		return points?.length === 3 && points[0].t === 0 && points.at(-1).t === 1 && points[1].t === 0.6 && points[1].height === 2;
+	})());
+	ok("malformed crane values normalize to null", createCameraBlock({ craneHeight: { start: "high" } }).craneHeight === null
+		&& createCameraBlock({ craneHeight: { points: [{ t: 0, height: 2 }] } }).craneHeight === null);
 	ok("crane marks clamp to the 0.1 m floor", (() => {
-		const block = createCameraBlock({ craneHeight: { start: -2, end: 0 } });
-		return block.craneHeight?.start === 0.1 && block.craneHeight?.end === 0.1;
+		const block = createCameraBlock({ craneHeight: { points: [{ t: 0, height: -2 }, { t: 1, height: 0 }] } });
+		return block.craneHeight?.points.every((point) => point.height === 0.1);
+	})());
+	ok("out-of-range and duplicate ts are repaired", (() => {
+		const block = createCameraBlock({ craneHeight: { points: [{ t: -3, height: 2 }, { t: 0.5, height: 1 }, { t: 0.5, height: 4 }, { t: 9, height: 2.5 }] } });
+		const points = block.craneHeight?.points;
+		return !!points && points[0].t === 0 && points.at(-1).t === 1 && points.every((point, i) => i === 0 || point.t > points[i - 1].t);
+	})(), JSON.stringify(createCameraBlock({ craneHeight: { points: [{ t: -3, height: 2 }, { t: 0.5, height: 1 }, { t: 0.5, height: 4 }, { t: 9, height: 2.5 }] } }).craneHeight));
+	ok("point count caps at 8", (() => {
+		const many = Array.from({ length: 20 }, (_, i) => ({ t: i / 19, height: 1 + (i % 3) }));
+		const block = createCameraBlock({ craneHeight: { points: many } });
+		return block.craneHeight?.points.length === 8;
 	})());
 }
 
 {
 	const base = createCameraBlock({ mode: "rail", cameraRail: [{ x: 0, z: 0 }, { x: 4, z: 0 }] });
-	const craned = updateCameraBlock(base, { craneHeight: { start: 3, end: 1.2 } });
-	ok("updateCameraBlock round-trips a crane patch", craned.craneHeight?.start === 3 && craned.craneHeight?.end === 1.2);
-	ok("unrelated patches keep the crane", updateCameraBlock(craned, { mode: "rail" }).craneHeight?.end === 1.2);
+	const marks = { points: [{ t: 0, height: 3 }, { t: 1, height: 1.2 }] };
+	const craned = updateCameraBlock(base, { craneHeight: marks });
+	ok("updateCameraBlock round-trips a crane patch", craned.craneHeight?.points[0].height === 3 && craned.craneHeight?.points[1].height === 1.2);
+	ok("unrelated patches keep the crane", updateCameraBlock(craned, { mode: "rail" }).craneHeight?.points[1].height === 1.2);
 	ok("an explicit null patch levels the crane", updateCameraBlock(craned, { craneHeight: null }).craneHeight === null);
 	ok("deleting the rail deletes its crane", removeCameraRail(craned).craneHeight === null);
 	ok("blocks never share crane objects", (() => {
 		const clone = createCameraBlock(craned);
-		return clone.craneHeight !== craned.craneHeight && clone.craneHeight.start === 3;
+		return clone.craneHeight !== craned.craneHeight && clone.craneHeight.points !== craned.craneHeight.points && clone.craneHeight.points[0].height === 3;
 	})());
 }
 

--- a/test/verify-camera-block.mjs
+++ b/test/verify-camera-block.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// The Camera Block owns one persisted camera instruction per shot; these
+// checks pin the craneHeight field's normalization contract: absent stays
+// null (legacy shots), patches round-trip, marks clamp to a sane floor, and
+// deleting the rail deletes the crane that rode it.
+import { createCameraBlock, removeCameraRail, updateCameraBlock } from "../src/camera-block.js";
+
+let failures = 0;
+const ok = (name, cond, detail = "") => {
+	console.log(`${cond ? "PASS" : "FAIL"} ${name}${cond ? "" : ` — ${detail}`}`);
+	if (!cond) failures += 1;
+};
+
+{
+	ok("legacy blocks carry no crane", createCameraBlock({}).craneHeight === null);
+	ok("stored crane marks survive normalization", (() => {
+		const block = createCameraBlock({ craneHeight: { start: 3, end: 1.2 } });
+		return block.craneHeight?.start === 3 && block.craneHeight?.end === 1.2;
+	})(), JSON.stringify(createCameraBlock({ craneHeight: { start: 3, end: 1.2 } }).craneHeight));
+	ok("malformed crane values normalize to null", createCameraBlock({ craneHeight: { start: "high" } }).craneHeight === null);
+	ok("crane marks clamp to the 0.1 m floor", (() => {
+		const block = createCameraBlock({ craneHeight: { start: -2, end: 0 } });
+		return block.craneHeight?.start === 0.1 && block.craneHeight?.end === 0.1;
+	})());
+}
+
+{
+	const base = createCameraBlock({ mode: "rail", cameraRail: [{ x: 0, z: 0 }, { x: 4, z: 0 }] });
+	const craned = updateCameraBlock(base, { craneHeight: { start: 3, end: 1.2 } });
+	ok("updateCameraBlock round-trips a crane patch", craned.craneHeight?.start === 3 && craned.craneHeight?.end === 1.2);
+	ok("unrelated patches keep the crane", updateCameraBlock(craned, { mode: "rail" }).craneHeight?.end === 1.2);
+	ok("an explicit null patch levels the crane", updateCameraBlock(craned, { craneHeight: null }).craneHeight === null);
+	ok("deleting the rail deletes its crane", removeCameraRail(craned).craneHeight === null);
+	ok("blocks never share crane objects", (() => {
+		const clone = createCameraBlock(craned);
+		return clone.craneHeight !== craned.craneHeight && clone.craneHeight.start === 3;
+	})());
+}
+
+console.log(failures === 0 ? "all camera-block checks PASS" : `${failures} FAILURES`);
+process.exit(failures === 0 ? 0 : 1);

--- a/test/verify-camera-follow.mjs
+++ b/test/verify-camera-follow.mjs
@@ -7,6 +7,7 @@ import {
 	buildFollowTrack,
 	buildRailFollowTrack,
 	buildRail,
+	craneHeightAt,
 	followFramingFromCamera,
 	railPoint,
 	simplifyStroke,
@@ -332,6 +333,35 @@ ok("free follow emits one sample per subject frame", free.length === walk.length
 	// start == end degenerates to the flat contract exactly.
 	const level = buildRailFollowTrack(walk, FPS, rail, { height: 1.6, craneHeight: { start: 1.6, end: 1.6 } });
 	ok("equal crane marks reproduce the flat rail", level.every((f, i) => Math.abs(f.pos.y - flat[i].pos.y) < 1e-6));
+
+	// The generalized crane: N height points, monotone between marks.
+	const points = { points: [{ t: 0, height: 3 }, { t: 0.5, height: 0.8 }, { t: 1, height: 2 }] };
+	ok("craneHeightAt hits every mark exactly",
+		Math.abs(craneHeightAt(points, 0) - 3) < 1e-9 &&
+		Math.abs(craneHeightAt(points, 0.5) - 0.8) < 1e-9 &&
+		Math.abs(craneHeightAt(points, 1) - 2) < 1e-9);
+	ok("craneHeightAt clamps outside the arc", craneHeightAt(points, -1) === 3 && craneHeightAt(points, 2) === 2);
+	ok("the profile never overshoots its marks (monotone)", (() => {
+		for (let i = 0; i <= 200; i += 1) {
+			const h = craneHeightAt(points, i / 200);
+			if (h < 0.8 - 1e-6 || h > 3 + 1e-6) return false;
+		}
+		return true;
+	})());
+	ok("legacy two-mark cranes evaluate as the straight lerp", (() => {
+		const legacy = { start: 3, end: 1.2 };
+		for (let i = 0; i <= 20; i += 1) {
+			const progress = i / 20;
+			if (Math.abs(craneHeightAt(legacy, progress) - (3 + (1.2 - 3) * progress)) > 1e-9) return false;
+		}
+		return true;
+	})());
+	const dip = buildRailFollowTrack(walk, FPS, rail, { height: 1.6, craneHeight: points });
+	ok("a point crane opens at its first mark", Math.abs(dip[0].pos.y - 3) < 1e-6, String(dip[0].pos.y));
+	const dipMin = Math.min(...dip.map((f) => f.pos.y));
+	ok("a point crane dips toward its low mark", dipMin < 1.15, String(dipMin));
+	ok("a point crane never undershoots the low mark", dipMin > 0.8 - 0.05, String(dipMin));
+	ok("a point crane rises back toward its final mark", Math.abs(dip.at(-1).pos.y - 2) < 0.25, String(dip.at(-1).pos.y));
 }
 
 console.log(failures === 0 ? "all camera-follow checks PASS" : `${failures} FAILURES`);

--- a/test/verify-camera-follow.mjs
+++ b/test/verify-camera-follow.mjs
@@ -308,5 +308,31 @@ ok("free follow emits one sample per subject frame", free.length === walk.length
 	ok("rail track is deterministic", JSON.stringify(a) === JSON.stringify(b));
 }
 
+/* ------------------------------------------------------ rail crane --- */
+
+{
+	// Legacy pin: without craneHeight the dolly holds the follow height the
+	// whole way — the flat-rail contract the crane must not disturb.
+	const walk = straightWalk(10);
+	const rail = buildRail([{ x: -2.5, z: -2 }, { x: -2.5, z: 16 }]);
+	const flat = buildRailFollowTrack(walk, FPS, rail, { height: 1.6 });
+	ok("flat rail holds the follow height", flat.every((f) => Math.abs(f.pos.y - 1.6) < 1e-6), String(flat.at(-1)?.pos.y));
+
+	// Crane: the lens height rides the dolly's own arc progress start → end.
+	const crane = buildRailFollowTrack(walk, FPS, rail, { height: 1.6, craneHeight: { start: 3, end: 1.2 } });
+	ok("crane opens at its start height", Math.abs(crane[0].pos.y - 3) < 1e-6, String(crane[0].pos.y));
+	ok("crane lands at its end height", Math.abs(crane.at(-1).pos.y - 1.2) < 0.2, String(crane.at(-1).pos.y));
+	const mid = crane[Math.floor(crane.length / 2)].pos.y;
+	ok("crane passes between its marks mid-move", mid < 3 - 0.1 && mid > 1.2 + 0.05, String(mid));
+	ok(
+		"a descending crane never climbs back",
+		crane.every((f, i) => i === 0 || f.pos.y <= crane[i - 1].pos.y + 0.02),
+	);
+
+	// start == end degenerates to the flat contract exactly.
+	const level = buildRailFollowTrack(walk, FPS, rail, { height: 1.6, craneHeight: { start: 1.6, end: 1.6 } });
+	ok("equal crane marks reproduce the flat rail", level.every((f, i) => Math.abs(f.pos.y - flat[i].pos.y) < 1e-6));
+}
+
 console.log(failures === 0 ? "all camera-follow checks PASS" : `${failures} FAILURES`);
 process.exit(failures === 0 ? 0 : 1);

--- a/test/verify-scenes.mjs
+++ b/test/verify-scenes.mjs
@@ -337,7 +337,7 @@ assert.doesNotMatch(
 );
 assert.match(
 	appSource,
-	/const targetCharacter = charactersRef\.current\.find\(\(entry\) => entry\.id === targetCharacterId\)[\s\S]{0,300}await waitForRig\(targetCharacter\.id\)/,
+	/const targetCharacter = charactersRef\.current\.find\(\(entry\) => entry\.id === targetCharacterId\)[\s\S]*?await waitForRig\(targetCharacter\.id\)/,
 	"motion loading waits for the active rig instead of losing the request to mount timing"
 );
 const batchSource = /apply_batch:\s*\(args\) => \{([\s\S]*?)\n\t\t\t\},\n\t\t\t\/\/ Authoring blocks/.exec(appSource)?.[1] ?? "";

--- a/test/verify-shot-authoring.mjs
+++ b/test/verify-shot-authoring.mjs
@@ -236,7 +236,16 @@ const cranedRoundTrip = loadShotAuthoring(serializeShotAuthoring({
 	frameCount: 100,
 	shots: [{ startFrame: 0, camera: { mode: "rail", cameraRail, railFollow: { mode: "off" }, craneHeight: { start: 3, end: 1.2 } } }],
 }));
-assert.deepEqual(cranedRoundTrip.shots[0].camera.craneHeight, { start: 3, end: 1.2 });
+assert.deepEqual(cranedRoundTrip.shots[0].camera.craneHeight, { points: [{ t: 0, height: 3 }, { t: 1, height: 1.2 }] });
+const pointCraneRoundTrip = loadShotAuthoring(serializeShotAuthoring({
+	frameCount: 100,
+	shots: [{ startFrame: 0, camera: { mode: "rail", cameraRail, railFollow: { mode: "off" }, craneHeight: { points: [{ t: 0, height: 3 }, { t: 0.4, height: 0.8 }, { t: 1, height: 2 }] } } }],
+}));
+assert.deepEqual(
+	pointCraneRoundTrip.shots[0].camera.craneHeight,
+	{ points: [{ t: 0, height: 3 }, { t: 0.4, height: 0.8 }, { t: 1, height: 2 }] },
+	"a point crane survives serialize → load untouched",
+);
 const orphanCrane = loadShotAuthoring(serializeShotAuthoring({
 	frameCount: 100,
 	shots: [{ startFrame: 0, camera: { mode: "follow", craneHeight: { start: 3, end: 1.2 } } }],

--- a/test/verify-shot-authoring.mjs
+++ b/test/verify-shot-authoring.mjs
@@ -32,7 +32,7 @@ const shots = [
 		startFrame: 0,
 		endFrame: 99,
 		cameraKeys: [{ id: "camera-key-wide", frame: 0, framing: framing(40) }],
-		camera: { mode: "keys", followCam, cameraRail: null, railFollow: null },
+		camera: { mode: "keys", followCam, cameraRail: null, railFollow: null, craneHeight: null },
 	},
 	{
 		id: "close",
@@ -40,7 +40,7 @@ const shots = [
 		startFrame: 100,
 		endFrame: 299,
 		cameraKeys: [{ id: "camera-key-close", frame: 100, framing: framing(70) }],
-		camera: { mode: "rail", followCam, cameraRail, railFollow: { mode: "range", startFrame: 10, endFrame: 80 } },
+		camera: { mode: "rail", followCam, cameraRail, railFollow: { mode: "range", startFrame: 10, endFrame: 80 }, craneHeight: null },
 	},
 ];
 
@@ -208,6 +208,7 @@ assert.deepEqual(repaired.shots[0].camera, {
 	},
 	cameraRail: null,
 	railFollow: null,
+	craneHeight: null,
 });
 assert.equal(repaired.shots[1].camera.mode, "keys");
 
@@ -228,7 +229,20 @@ assert.deepEqual(removeCameraRail({
 	followCam,
 	cameraRail: null,
 	railFollow: null,
+	craneHeight: null,
 });
+// The crane axis persists with its rail and cannot outlive it.
+const cranedRoundTrip = loadShotAuthoring(serializeShotAuthoring({
+	frameCount: 100,
+	shots: [{ startFrame: 0, camera: { mode: "rail", cameraRail, railFollow: { mode: "off" }, craneHeight: { start: 3, end: 1.2 } } }],
+}));
+assert.deepEqual(cranedRoundTrip.shots[0].camera.craneHeight, { start: 3, end: 1.2 });
+const orphanCrane = loadShotAuthoring(serializeShotAuthoring({
+	frameCount: 100,
+	shots: [{ startFrame: 0, camera: { mode: "follow", craneHeight: { start: 3, end: 1.2 } } }],
+}));
+assert.equal(orphanCrane.shots[0].camera.craneHeight, null, "a crane without a rail does not persist");
+
 const badRail = loadShotAuthoring(JSON.stringify({
 	version: 4,
 	frameCount: 100,

--- a/test/verify-timeline-camera.mjs
+++ b/test/verify-timeline-camera.mjs
@@ -24,7 +24,7 @@ expect("gridlines render from the ruler's framePct", timeline.includes('classNam
 expect("chips and markers share one frame scale", !timeline.includes("promptFramePct") && timeline.includes("clipPct(clip.startFrame)"));
 
 expect("camera keys render as dots, not a chip", timeline.includes('className="tl-marker cam"') && !timeline.includes("tl-chip camera"));
-expect("block key strip keys the current framing", timeline.includes("handlers.current.onCameraKeyframeAdd?.(target, shots[index]?.id)") && timeline.includes('className="tl-shot-key-surface"') && app.includes("onCameraKeyframeAdd={addCameraKeyframe}"));
+expect("block key strip keys framing or authors crane progress for a Rail Shot", timeline.includes("handlers.current.onCameraKeyframeAdd?.(target, shot.id)") && timeline.includes("onCranePointAdd?.(t, shot.id)") && timeline.includes('className="tl-shot-key-surface"') && app.includes("onCameraKeyframeAdd={addCameraKeyframe}"));
 expect("key strip is a crosshair affordance", css.includes(".tl-shot-key-surface") && css.includes("cursor: crosshair"));
 expect("dot click jumps the playhead and selects the camera", timeline.includes("handlers.current.onScrub?.(key.frame)") && timeline.includes("handlers.current.onCameraMoveSelect?.();"));
 expect("dot right-click removes the key", timeline.includes("handlers.current.onCameraKeyframeRemove?.(shot.id, key.id)") && app.includes("removeCameraKey(shot.cameraKeys, keyId)"));
@@ -144,6 +144,20 @@ expect(
 	timeline.includes("craneHeight: crane ? null : { points: [{ t: 0, height: follow.height }, { t: 1, height: follow.height }] }") &&
 	// the scene dots are the primary editor; the bar edits the SELECTED point
 	timeline.includes("craneSelectedIndex"),
+);
+expect(
+	"the crane editor makes adding and removing interior points explicit",
+	timeline.includes('ko("Add point", "점 추가")') &&
+		timeline.includes('ko("Remove point", "점 삭제")') &&
+		timeline.includes("onCranePointAdd") &&
+		timeline.includes("onCranePointDelete"),
+);
+expect(
+	"rail crane points are authored and selected directly in the Shot key strip",
+	timeline.includes("addShotPointFromBlock") &&
+		timeline.includes("tl-crane-point") &&
+		timeline.includes("--tl-crane-p") &&
+		timeline.includes("onCranePointSelect"),
 );
 expect(
 	"waypoint mode replaces camera controls with one clear message",

--- a/test/verify-timeline-camera.mjs
+++ b/test/verify-timeline-camera.mjs
@@ -138,11 +138,12 @@ expect(
 	"the rail crane is an explicit toggle with start and end height inputs",
 	timeline.includes('ko("Crane On", "\ud06c\ub808\uc778 \ucf1c\uc9d0")') &&
 	timeline.includes('ko("Crane Off", "\ud06c\ub808\uc778 \uaebc\uc9d0")') &&
-	timeline.includes('ko("Start height", "\uc2dc\uc791 \ub192\uc774")') &&
-	timeline.includes('ko("End height", "\ub05d \ub192\uc774")') &&
-	// turning the crane on seeds both marks from the measured follow height,
-	// and turning it off returns the block to the flat-rail null
-	timeline.includes("craneHeight: crane ? null : { start: follow.height, end: follow.height }"),
+	timeline.includes('ko("Point height", "\uc810 \ub192\uc774")') &&
+	// turning the crane on seeds two endpoint POINTS from the measured follow
+	// height, and turning it off returns the block to the flat-rail null
+	timeline.includes("craneHeight: crane ? null : { points: [{ t: 0, height: follow.height }, { t: 1, height: follow.height }] }") &&
+	// the scene dots are the primary editor; the bar edits the SELECTED point
+	timeline.includes("craneSelectedIndex"),
 );
 expect(
 	"waypoint mode replaces camera controls with one clear message",

--- a/test/verify-timeline-camera.mjs
+++ b/test/verify-timeline-camera.mjs
@@ -135,6 +135,16 @@ expect(
 	app.includes("manualCameraOverrideRef.current = false"),
 );
 expect(
+	"the rail crane is an explicit toggle with start and end height inputs",
+	timeline.includes('ko("Crane On", "\ud06c\ub808\uc778 \ucf1c\uc9d0")') &&
+	timeline.includes('ko("Crane Off", "\ud06c\ub808\uc778 \uaebc\uc9d0")') &&
+	timeline.includes('ko("Start height", "\uc2dc\uc791 \ub192\uc774")') &&
+	timeline.includes('ko("End height", "\ub05d \ub192\uc774")') &&
+	// turning the crane on seeds both marks from the measured follow height,
+	// and turning it off returns the block to the flat-rail null
+	timeline.includes("craneHeight: crane ? null : { start: follow.height, end: follow.height }"),
+);
+expect(
 	"waypoint mode replaces camera controls with one clear message",
 	timeline.includes("blocked={waypointMode}") &&
 	timeline.includes('className="tl-camera-blocked"') &&

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -38,6 +38,7 @@ const NODE_FILES = [
 	"test/verify-asset-shelf.mjs",
 	"test/verify-blocking-depth.mjs",
 	"test/verify-bvh-cskel27.mjs",
+	"test/verify-camera-block.mjs",
 	"test/verify-camera-follow.mjs",
 	"test/verify-camera-move.mjs",
 	"test/verify-camera-rail-schedule.mjs",


### PR DESCRIPTION
## Summary
- evolve rail crane height from a legacy `{start,end}` pair to a persisted 2–8 point profile
- evaluate the profile with a monotone cubic curve shared by playback and the scene preview
- render purple scene handles with vertical drag, Shift-drag rail positioning, add/delete and one-gesture undo
- author and select crane points directly in each Shot card below its Rail Follow ribbon
- keep explicit Add point / Remove point controls and selected-point height editing in the camera toolbar

## Compatibility
- legacy `{start,end}` documents migrate to two pinned endpoint points
- malformed profiles are sorted, clamped, deduplicated and capped at eight
- deleting the rail still clears crane data

## Verification
- `npm test` — production build + 74 Node verification files PASS
- focused camera-follow, camera-block, shot-authoring and timeline camera checks PASS
- browser QA: same Shot persists five points; vertical drag, Shift-drag, undo and remove PASS
- partial Rail Follow QA: Shot-strip click at 25% persists `t ≈ 0.25`; timeline marker selects matching scene dot; marker double-click does not rename Shot
- visual QA against the supplied Shot-card reference: PASS, no release blockers

## Evidence
- `/tmp/shot-crane-points.png` locally captures the synchronized Shot marker and scene handle
