### PR TITLE
feat(analytics): investor-grade metrics — persistent anonymous id, proxy-ready host

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
       - run: npm test
         env:
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          # Optional first-party proxy host (repo variable); empty falls back to us.i.posthog.com.
+          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ All runtime libraries intentionally live in `devDependencies` because the publis
 
 ## Analytics & privacy
 
-The hosted site at [cozyclay.org](https://cozyclay.org/) collects anonymous usage analytics via [PostHog](https://posthog.com/) (US Cloud). There are no cookies — PostHog is configured with in-memory persistence only — no session recording, and Do-Not-Track is respected.
+The hosted site at [cozyclay.org](https://cozyclay.org/) collects anonymous usage analytics via [PostHog](https://posthog.com/) (US Cloud). There are no cookies and no session recording, and Do-Not-Track is respected. A random anonymous identifier is kept in your browser's localStorage so that returning visits and retention can be counted; it contains no personal data, is never linked to an identity, and is removed by clearing site data or using the opt-out toggle.
 
 Events collected:
 

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -119,9 +119,25 @@ export function getAnalyticsOptOut() {
 	return readStorage(OPT_OUT_KEY) === "1";
 }
 
+function clearAnalyticsStorage() {
+	try {
+		const store = storage();
+		if (!store) return;
+		const doomed = [];
+		for (let i = 0; i < store.length; i += 1) {
+			const key = store.key(i);
+			if (key && key.startsWith("ph_") && key.endsWith("_posthog")) doomed.push(key);
+		}
+		for (const key of doomed) store.removeItem(key);
+	} catch {
+		// Best effort; never let cleanup break the app.
+	}
+}
+
 export function setAnalyticsOptOut(optOut) {
 	const value = optOut === true;
 	writeStorage(OPT_OUT_KEY, value ? "1" : "0");
+	if (value) clearAnalyticsStorage();
 	if (!posthog) return;
 	try {
 		if (value) {
@@ -177,9 +193,14 @@ export async function initAnalytics() {
 				// Keep the wire contract at the nine disclosed events: no $pageleave.
 				capture_pageleave: false,
 				person_profiles: "never",
-				persistence: "memory",
+				// Device-scoped anonymous id in localStorage (no cookies): keeps
+				// unique-user and retention metrics real across visits.
+				persistence: "localStorage",
 				respect_dnt: true,
 				disable_session_recording: true,
+				capture_dead_clicks: false,
+				// Needed once api_host points at a first-party proxy; harmless otherwise.
+				ui_host: "https://us.posthog.com",
 				before_send: scrubEventUrls,
 			});
 			initialized = true;


### PR DESCRIPTION
## Why

Analytics purpose upgraded from privacy-max hobby posture to **investor-evidence metrics** (MAU/WAU, D1/D7/D30 retention cohorts, MoM growth). The previous in-memory persistence made every visit a new visitor, so unique-user and retention charts were impossible by design.

## What

- `persistence: 'localStorage'` — device-scoped anonymous id survives reloads/visits → unique users + retention cohorts become real. Still no cookies, no PII, `person_profiles:'never'` unchanged.
- Opt-out now also **wipes all `ph_*` storage keys**, so the disclosed removal path is literally true.
- `capture_dead_clicks: false` — keeps the wire at the nine disclosed events (dead-clicks helper script no longer loads).
- `ui_host` pinned; `VITE_POSTHOG_HOST` injectable via repo **variable** — flipping on the free managed reverse proxy later is a DNS CNAME + one repo variable, zero code change.
- README disclosure updated (localStorage identifier + removal paths).

## Verification (real browser + local mock ingest)

- `distinct_id` identical across reload (`stableAcrossReload: true`) — retention enabler proven.
- `dead-clicks` script not requested; only disclosed events on the wire.
- Opt-out leaves **0** `ph_*` keys and stops capture.
- `node test/verify-analytics.mjs` green, `vite build` green, YAML parses.