### PR TITLE
ci(metrics): permanent traffic/stars/npm time series

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,47 @@
+name: metrics-snapshot
+
+on:
+  schedule:
+    # Twice a week: the traffic API only keeps 14 days, so one failed run
+    # still leaves the next run inside the window.
+    - cron: "17 1 * * 1,4"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check out the metrics ledger branch
+        run: |
+          git config user.name "metrics-snapshot"
+          git config user.email "actions@github.com"
+          if git fetch origin metrics 2>/dev/null; then
+            git worktree add ../metrics origin/metrics -b metrics
+          else
+            git worktree add --detach ../metrics
+            cd ../metrics
+            git checkout --orphan metrics
+            git rm -rf --quiet . || true
+            echo "# CozyClay metrics ledger (appended by .github/workflows/metrics.yml)" > README.md
+          fi
+      - name: Append snapshots
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node tools/metrics-snapshot.mjs ../metrics/data
+      - name: Commit and push
+        run: |
+          cd ../metrics
+          git add -A
+          if git diff --cached --quiet; then
+            echo "no changes"
+          else
+            git commit -m "metrics: snapshot $(date -u +%F)"
+            git push origin HEAD:metrics
+          fi

--- a/tools/metrics-snapshot.mjs
+++ b/tools/metrics-snapshot.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Snapshot GitHub traffic + repo stats + npm downloads into JSONL ledgers.
+ *
+ * GitHub's traffic API only keeps 14 days, so this must run on a schedule
+ * (.github/workflows/metrics.yml) to build a permanent time series. Rows are
+ * deduped by date so overlapping 14-day windows never double-count.
+ *
+ * Usage: GITHUB_TOKEN=... node tools/metrics-snapshot.mjs <output-dir>
+ */
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO = process.env.METRICS_REPO || "NomaDamas/CozyClay";
+const NPM_PACKAGE = process.env.METRICS_NPM_PACKAGE || "cozyclay";
+const outDir = process.argv[2];
+if (!outDir) {
+	console.error("usage: node tools/metrics-snapshot.mjs <output-dir>");
+	process.exit(2);
+}
+mkdirSync(outDir, { recursive: true });
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+	console.error("GITHUB_TOKEN is required (traffic API needs push access)");
+	process.exit(2);
+}
+
+async function github(path) {
+	const res = await fetch(`https://api.github.com/repos/${REPO}${path}`, {
+		headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json" },
+	});
+	if (!res.ok) throw new Error(`GET ${path} -> ${res.status}`);
+	return res.json();
+}
+
+function loadRows(file) {
+	if (!existsSync(file)) return new Map();
+	const rows = new Map();
+	for (const line of readFileSync(file, "utf8").split("\n")) {
+		if (!line.trim()) continue;
+		const row = JSON.parse(line);
+		rows.set(row.date, row);
+	}
+	return rows;
+}
+
+function saveRows(file, rows) {
+	const sorted = [...rows.values()].sort((a, b) => a.date.localeCompare(b.date));
+	writeFileSync(file, sorted.map((r) => JSON.stringify(r)).join("\n") + "\n");
+	return sorted.length;
+}
+
+const today = new Date().toISOString().slice(0, 10);
+
+// 1) Daily traffic (views + clones), deduped by date. Today's partial day is
+// excluded so a later run can record the complete figure.
+const [views, clones] = await Promise.all([github("/traffic/views"), github("/traffic/clones")]);
+const trafficFile = join(outDir, "traffic-daily.jsonl");
+const traffic = loadRows(trafficFile);
+const byDate = new Map();
+for (const v of views.views ?? []) {
+	byDate.set(v.timestamp.slice(0, 10), { views: v.count, view_uniques: v.uniques });
+}
+for (const c of clones.clones ?? []) {
+	const date = c.timestamp.slice(0, 10);
+	byDate.set(date, { ...byDate.get(date), clones: c.count, clone_uniques: c.uniques });
+}
+let added = 0;
+for (const [date, row] of byDate) {
+	if (date >= today) continue;
+	if (!traffic.has(date)) added += 1;
+	traffic.set(date, { date, views: 0, view_uniques: 0, clones: 0, clone_uniques: 0, ...traffic.get(date), ...row });
+}
+const trafficTotal = saveRows(trafficFile, traffic);
+
+// 2) Point-in-time repo stats + weekly npm downloads, one row per run date.
+const repo = await github("");
+let npm = null;
+try {
+	const res = await fetch(`https://api.npmjs.org/downloads/point/last-week/${NPM_PACKAGE}`);
+	if (res.ok) npm = await res.json();
+} catch {
+	// npm stats are best effort.
+}
+const statsFile = join(outDir, "repo-stats.jsonl");
+const stats = loadRows(statsFile);
+stats.set(today, {
+	date: today,
+	stars: repo.stargazers_count,
+	forks: repo.forks_count,
+	watchers: repo.subscribers_count,
+	open_issues: repo.open_issues_count,
+	npm_weekly_downloads: npm?.downloads ?? null,
+});
+const statsTotal = saveRows(statsFile, stats);
+
+console.log(`traffic-daily: +${added} new day(s), ${trafficTotal} total; repo-stats: ${statsTotal} snapshot(s)`);


### PR DESCRIPTION
GitHub's traffic API only keeps 14 days, so growth history is being lost continuously. This adds a twice-weekly (Mon/Thu) workflow that appends daily views/clones (deduped by date), star/fork counts, and weekly npm downloads to JSONL ledgers on an orphan `metrics` branch. Verified locally against the live APIs: captures the current 14-day window (3.9k views / 2.0k uniques), idempotent re-runs add nothing. Merging this also redeploys Pages, which bakes the new `VITE_POSTHOG_HOST=https://t.cozyclay.org` managed-proxy variable into the bundle.