### PR TITLE
docs: align the controls table and ARDY help with what the code does

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,18 @@ See [`tools/ardy/README.md`](tools/ardy/README.md) for details. This workflow is
 | Right-drag | Look around (fly) |
 | RMB + WASD | Walk while flying |
 | RMB + Q/E | Crane down / up |
+| RMB + Shift | Boost fly speed 2.6× |
 | Middle-drag | Pan |
 | Alt + drag | Orbit the selection |
-| Scroll | Dolly |
+| Scroll | Dolly; while flying, sets the fly speed instead |
 | Click | Select; empty space clears |
 | W / E / R | Move / rotate / scale tool |
-| Ctrl (during drag) | Invert grid snapping |
+| Ctrl/Cmd (during drag) | Invert grid snapping |
 | Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z | Undo / redo |
 | Esc | Cancel the in-flight drag |
 | End | Drop the selection to the surface |
 | Ctrl/Cmd+D | Duplicate the selection |
+| Delete / Backspace | Delete the selection |
 | F | Frame the selection |
 
 ## Validate

--- a/tools/ardy/README.md
+++ b/tools/ardy/README.md
@@ -161,7 +161,7 @@ first:
 
 1. SSH reachability (`BatchMode` + `ConnectTimeout`, so a dead host or a
    missing key errors in seconds, not minutes).
-2. `~/ardy/.venv/bin/python` and `scripts/cclay_constrained_generate.py`
+2. `~/ardy/.venv-cuda/bin/python` and `scripts/cclay_constrained_generate.py`
    exist on the box (points at `sync-to-box --apply` when missing).
 3. The base motion resolves to a file that exists on the box.
 4. The device probe: the one-line torch check mirroring the generator's

--- a/tools/ardy/bridge.mjs
+++ b/tools/ardy/bridge.mjs
@@ -1006,7 +1006,7 @@ remote mode (generation on an ssh box):
   CCLAY_ARDY_VENV         generator venv python on the box (default ~/ardy/.venv-cuda/bin/python)
   CCLAY_ARDY_ENCODER_URL  text encoder service           (default http://127.0.0.1:9550/)
 
-local mode (generation on this machine; run tools/ardy/setup-local.sh once):
+local mode (generation on this machine; run npm run ardy:setup once):
   CCLAY_ARDY_LOCAL_DIR    local ARDY checkout            (default ~/.cozyclay/ardy)
   CCLAY_ARDY_LOCAL_VENV   generator venv python          (default <local-dir>/.venv/bin/python)
   CCLAY_ARDY_ENCODER_URL  text encoder service           (default http://127.0.0.1:9550/)

--- a/tools/ardy/run-on-box.sh
+++ b/tools/ardy/run-on-box.sh
@@ -56,7 +56,7 @@
 # env (names shared with CozyClay scripts/ardy/sync-to-box):
 #   CCLAY_ARDY_HOST  ssh destination for the ARDY host (required)
 #   CCLAY_ARDY_REPO  ARDY checkout on the box       (default $HOME/ardy)
-#   CCLAY_ARDY_VENV  venv python on the box         (default ~/ardy/.venv/bin/python)
+#   CCLAY_ARDY_VENV  venv python on the box         (default ~/ardy/.venv-cuda/bin/python)
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Closes #53.

Four small doc/help drifts, each verified against the code before editing:

- **README controls table** — `Scroll | Dolly` now says what the wheel does mid-fly (it sets the fly speed, `src/controls.jsx:190`); added the `Delete`/`Backspace` delete shortcut (`src/App.jsx:2780`) and the `RMB + Shift` 2.6× fly boost (`src/controls.jsx:13`); snap inversion is spelled `Ctrl/Cmd` to match `src/object-gizmo.jsx:329` and the rest of the table.
- **`tools/ardy/README.md` preflight** — step 2 now checks `~/ardy/.venv-cuda/bin/python`, the generator's actual default (`run-on-box.sh:71`); the script's own comments say `.venv` and `.venv-cuda` are not interchangeable, so the preflight as written validated the wrong environment.
- **`tools/ardy/run-on-box.sh` header comment** — same stale `.venv` default; the usage block at line 134 was already right.
- **`tools/ardy/bridge.mjs` help** — pointed at `tools/ardy/setup-local.sh`, which does not exist; it now says `npm run ardy:setup`.

Docs and help strings only — no behavior change. (`test/ardy/verify-npz.mjs` also defaults `CCLAY_ARDY_VENV` to `.venv`, but that is a code default in an external-classified test, so it is left out of a docs pass.)
