### PR TITLE
ci: run the hermetic MCP verify suites on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
       - run: npm ci
       - run: npm --prefix mcp ci
       - run: npm test
+      # Hermetic MCP verify suites (#52). tools/run-tests.mjs inventories only
+      # test/, so these behavioral suites never reach `npm test`; run them
+      # directly. The verify:live family stays out until it is confirmed
+      # hermetic on the runner.
+      - name: MCP verify suites
+        run: |
+          npm --prefix mcp run verify
+          npm --prefix mcp run verify:annotations
+          npm --prefix mcp run verify:prompts
 
   # Real-browser rendering regressions via the CDP QA wrapper. Only the suites
   # that are green against origin/main run here (ik, camera-rail); the other


### PR DESCRIPTION
P1 of #52.

`tools/run-tests.mjs` inventories only `test/`, so the 14 `mcp/verify-*.mjs` suites never reach `npm test` — the only MCP coverage in CI today is the source-text lint plus two one-line shims. This adds the hermetic suites as an explicit CI step next to the existing `npm --prefix mcp ci` install:

- `npm --prefix mcp run verify` (verify.mjs, verify-protocol-version.mjs, verify-http-origin.mjs)
- `npm --prefix mcp run verify:annotations`
- `npm --prefix mcp run verify:prompts`

All four pass locally against main (24 tools registered / 420 framing combinations checked, protocol 2025-11-25 PASS, origin guard 403/403/200, annotations + prompts PASS). One gotcha confirmed while verifying: the suites need the ROOT `npm ci` too (`mcp/server.mjs` imports `src/scene-objects.js` -> `three`), which the workflow already runs before this step.

Left open for P2 (folding `mcp/` into the run-tests manifest) and the `verify:live` family, per the open question in #52.

Refs #52.