### PR TITLE
fix: re-authorize stored File System Access handles instead of failing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -124,6 +124,7 @@ import {
 	pickProjectFileForOpen,
 	pickProjectFileForSave,
 	queryHandlePermission,
+	requestHandlePermission,
 	readProjectDocument,
 	readProjectFile,
 	storeProjectHandle,
@@ -3557,6 +3558,12 @@ globalThis.playMode = centerTab === "play";
 	 * recents list or a file enumerated in the projects folder. */
 	async function openProjectByHandle(handle) {
 		try {
+			// A stored handle may have been demoted to "prompt" since the last
+			// session (#51); this click is the user gesture that can re-grant it.
+			if ((await requestHandlePermission(handle)) !== "granted") {
+				setToast(ko("Project access was not granted — allow access and try again.", "프로젝트 접근이 허용되지 않았어요. 접근을 허용하고 다시 시도해 주세요."));
+				return;
+			}
 			const file = await readProjectFile(handle);
 			const result = readProjectDocument(file.text);
 			if (!result.ok) {
@@ -3591,24 +3598,34 @@ globalThis.playMode = centerTab === "play";
 	}
 
 	// Re-open the last project on launch when the browser still grants access.
+	// A handle Chromium demoted to "prompt" cannot be re-requested here (no
+	// user gesture), so it becomes a one-click restore offer instead (#51).
 	const projectAutoOpenedRef = useRef(false);
+	const [restoreOffer, setRestoreOffer] = useState(null);
+	async function restoreStoredProject(record) {
+		try {
+			const file = await readProjectFile(record.handle);
+			const result = readProjectDocument(file.text);
+			if (!result.ok) return;
+			projectHandleRef.current = record.handle;
+			await rehydrateProjectAssets(result.project, result.warnings);
+			applyProject(result.project);
+			setToast(isKo ? `프로젝트 복원됨: ${result.project.name}` : `Project restored: ${result.project.name}`);
+		} catch {
+			/* missing or unreadable file: fall back to the session cache */
+		}
+	}
 	useEffect(() => {
 		if (projectAutoOpenedRef.current) return;
 		projectAutoOpenedRef.current = true;
 		loadStoredProjectHandle().then(async (record) => {
 			if (!record?.handle) return;
-			if ((await queryHandlePermission(record.handle)) !== "granted") return;
-			try {
-				const file = await readProjectFile(record.handle);
-				const result = readProjectDocument(file.text);
-				if (!result.ok) return;
-				projectHandleRef.current = record.handle;
-				await rehydrateProjectAssets(result.project, result.warnings);
-				applyProject(result.project);
-				setToast(isKo ? `프로젝트 복원됨: ${result.project.name}` : `Project restored: ${result.project.name}`);
-			} catch {
-				/* missing or unreadable file: fall back to the session cache */
+			const permission = await queryHandlePermission(record.handle);
+			if (permission === "granted") {
+				await restoreStoredProject(record);
+				return;
 			}
+			if (permission === "prompt") setRestoreOffer(record);
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
@@ -8939,6 +8956,26 @@ function resizePromptClip(id, edge, rawFrame) {
 					<button type="button" aria-label={ko("Undo object deletion", "오브젝트 삭제 실행 취소")} onClick={undoObjectDeletion}>
 						{ko("Undo", "실행 취소")}
 					</button>
+				</div>
+			)}
+			{restoreOffer && (
+				<div className="asset-delete-toast" role="status">
+					<span>{isKo ? `마지막 프로젝트 복원${restoreOffer.name ? `: ${restoreOffer.name}` : ""}` : `Restore last project${restoreOffer.name ? `: ${restoreOffer.name}` : ""}`}</span>
+					<button
+						type="button"
+						onClick={async () => {
+							const record = restoreOffer;
+							setRestoreOffer(null);
+							if ((await requestHandlePermission(record.handle)) !== "granted") {
+								setToast(ko("Project access was not granted.", "프로젝트 접근이 허용되지 않았어요."));
+								return;
+							}
+							await restoreStoredProject(record);
+						}}
+					>
+						{ko("Restore", "복원")}
+					</button>
+					<button type="button" onClick={() => setRestoreOffer(null)} aria-label={ko("Dismiss", "닫기")}>✕</button>
 				</div>
 			)}
 			{assetTrash.length > 0 && assetUndoOffered && (

--- a/src/project-browser.jsx
+++ b/src/project-browser.jsx
@@ -9,6 +9,7 @@ import {
 	pickProjectsDirectory,
 	queryHandlePermission,
 	removeRecentProject,
+	requestHandlePermission,
 	storeProjectsDirectory,
 } from "./project.js";
 
@@ -25,6 +26,9 @@ export default function ProjectBrowser({ currentName, onOpen, onOpenFile, onNew,
 	const [folder, setFolder] = useState(null);
 	const [folderProjects, setFolderProjects] = useState([]);
 	const [folderDenied, setFolderDenied] = useState(false);
+	// A stored folder handle Chromium demoted to "prompt": one click on the
+	// re-allow button re-grants it without re-picking the folder (#51).
+	const [lostFolder, setLostFolder] = useState(null);
 
 	useEffect(() => {
 		loadRecentProjects().then(setRecents);
@@ -33,6 +37,7 @@ export default function ProjectBrowser({ currentName, onOpen, onOpenFile, onNew,
 			const permission = await queryHandlePermission(handle);
 			if (permission !== "granted") {
 				setFolderDenied(true);
+				if (permission === "prompt") setLostFolder(handle);
 				return;
 			}
 			setFolder(handle);
@@ -40,12 +45,23 @@ export default function ProjectBrowser({ currentName, onOpen, onOpenFile, onNew,
 		});
 	}, []);
 
+	const reauthorizeFolder = async () => {
+		if (!lostFolder) return;
+		if ((await requestHandlePermission(lostFolder)) !== "granted") return;
+		const handle = lostFolder;
+		setLostFolder(null);
+		setFolderDenied(false);
+		setFolder(handle);
+		setFolderProjects(await listProjectsInDirectory(handle));
+	};
+
 	const chooseFolder = async () => {
 		try {
 			const handle = await pickProjectsDirectory();
 			await storeProjectsDirectory(handle);
 			setFolder(handle);
 			setFolderDenied(false);
+			setLostFolder(null);
 			setFolderProjects(await listProjectsInDirectory(handle));
 		} catch (err) {
 			if (err?.name !== "AbortError") setFolderDenied(true);
@@ -106,7 +122,16 @@ export default function ProjectBrowser({ currentName, onOpen, onOpenFile, onNew,
 								</button>
 							</div>
 						</div>
-						{folderDenied && <p className="project-browser-empty">{ko("Folder access is not granted — choose it again.", "폴더 접근 권한이 없어요. 다시 지정해 주세요.")}</p>}
+						{folderDenied && (
+						<p className="project-browser-empty">
+							{lostFolder
+								? ko("Folder access needs to be re-allowed.", "폴더 접근을 다시 허용해야 해요.")
+								: ko("Folder access is not granted — choose it again.", "폴더 접근 권한이 없어요. 다시 지정해 주세요.")}
+							{lostFolder && (
+								<button type="button" onClick={reauthorizeFolder}>{ko("Re-allow", "다시 허용")}</button>
+							)}
+						</p>
+					)}
 						{folder && folderProjects.length === 0 && !folderDenied && (
 							<p className="project-browser-empty">{ko("No .cclayproject files in this folder.", "이 폴더에 .cclayproject 파일이 없어요.")}</p>
 						)}

--- a/src/project-browser.jsx
+++ b/src/project-browser.jsx
@@ -123,15 +123,15 @@ export default function ProjectBrowser({ currentName, onOpen, onOpenFile, onNew,
 							</div>
 						</div>
 						{folderDenied && (
-						<p className="project-browser-empty">
-							{lostFolder
-								? ko("Folder access needs to be re-allowed.", "폴더 접근을 다시 허용해야 해요.")
-								: ko("Folder access is not granted — choose it again.", "폴더 접근 권한이 없어요. 다시 지정해 주세요.")}
-							{lostFolder && (
-								<button type="button" onClick={reauthorizeFolder}>{ko("Re-allow", "다시 허용")}</button>
-							)}
-						</p>
-					)}
+							<p className="project-browser-empty">
+								{lostFolder
+									? ko("Folder access needs to be re-allowed.", "폴더 접근을 다시 허용해야 해요.")
+									: ko("Folder access is not granted — choose it again.", "폴더 접근 권한이 없어요. 다시 지정해 주세요.")}
+								{lostFolder && (
+									<button type="button" onClick={reauthorizeFolder}>{ko("Re-allow", "다시 허용")}</button>
+								)}
+							</p>
+						)}
 						{folder && folderProjects.length === 0 && !folderDenied && (
 							<p className="project-browser-empty">{ko("No .cclayproject files in this folder.", "이 폴더에 .cclayproject 파일이 없어요.")}</p>
 						)}

--- a/src/project.js
+++ b/src/project.js
@@ -371,3 +371,16 @@ export async function queryHandlePermission(handle) {
 		return "denied";
 	}
 }
+
+/** Escalate a stored handle back to "granted". Chromium demotes a persisted
+ * handle's permission to "prompt" when the page is next opened; inside a user
+ * gesture the browser answers requestPermission() with a one-click prompt.
+ * "granted" | "prompt" | "denied" — never throws. */
+export async function requestHandlePermission(handle) {
+	try {
+		if ((await handle.queryPermission({ mode: "readwrite" })) === "granted") return "granted";
+		return await handle.requestPermission({ mode: "readwrite" });
+	} catch {
+		return "denied";
+	}
+}

--- a/test/verify-project.mjs
+++ b/test/verify-project.mjs
@@ -117,6 +117,43 @@ assert.equal(malformedAssets.ok, true, "malformed embedded assets never reject a
 assert.deepEqual(malformedAssets.project.assets, [], "malformed embedded assets are skipped");
 assert.equal(malformedAssets.warnings.length, 3, "each skipped embedded asset is warned about");
 
+// --- handle re-authorization (#51) -----------------------------------------
+// Chromium demotes a persisted handle's permission to "prompt" on the next
+// visit; requestHandlePermission escalates it back inside a user gesture.
+import { requestHandlePermission } from "../src/project.js";
+
+{
+	const calls = [];
+	const handle = (query, request) => ({
+		async queryPermission(options) {
+			calls.push(["query", options?.mode]);
+			if (query instanceof Error) throw query;
+			return query;
+		},
+		async requestPermission(options) {
+			calls.push(["request", options?.mode]);
+			if (request instanceof Error) throw request;
+			return request;
+		},
+	});
+
+	calls.length = 0;
+	assert.equal(await requestHandlePermission(handle("granted", "granted")), "granted", "a granted handle stays granted");
+	assert.deepEqual(calls, [["query", "readwrite"]], "a granted handle never re-prompts");
+
+	calls.length = 0;
+	assert.equal(await requestHandlePermission(handle("prompt", "granted")), "granted", "a demoted handle is re-requested");
+	assert.deepEqual(calls, [["query", "readwrite"], ["request", "readwrite"]], "a demoted handle escalates through requestPermission");
+
+	assert.equal(await requestHandlePermission(handle("prompt", "denied")), "denied", "a refused prompt reports denied");
+	assert.equal(await requestHandlePermission(handle(new Error("boom"), "granted")), "denied", "a throwing queryPermission reports denied, never throws");
+	assert.equal(await requestHandlePermission(handle("prompt", new Error("boom"))), "denied", "a throwing requestPermission reports denied, never throws");
+}
+
+const browserSource = readFileSync(new URL("../src/project-browser.jsx", import.meta.url), "utf8");
+assert.match(appSource, /requestHandlePermission/, "opening a stored handle re-authorizes it inside the click gesture (#51)");
+assert.match(browserSource, /requestHandlePermission/, "the projects folder offers one-click re-authorization (#51)");
+
 // --- App wiring ------------------------------------------------------------
 assert.match(appSource, /createProjectDocument/, "App builds the project envelope");
 assert.match(appSource, /readProjectDocument/, "App parses project files");


### PR DESCRIPTION
Closes #51.

Every stored File System Access handle was checked with `queryPermission()` and never re-authorized — `requestPermission()` appeared nowhere in `src/`. Chromium demotes a persisted handle to `"prompt"` on the next visit, so healthy handles were treated as unusable in three places. This adds one helper and wires all three:

- **`requestHandlePermission(handle)`** (`src/project.js`) — returns `"granted"` without prompting when the handle is still granted, otherwise escalates through `requestPermission({ mode: "readwrite" })`; never throws, mirrors `queryHandlePermission`.
- **Recent-project click** (`openProjectByHandle`, `src/App.jsx`) — the click is a user gesture, so the demoted handle is re-requested with a one-click browser prompt before the read; a refusal now gets a specific toast instead of the generic "Could not open the project" from the `NotAllowedError`.
- **Projects folder** (`src/project-browser.jsx`) — a folder demoted to `"prompt"` now shows a "Re-allow" button that re-grants and enumerates in one click, instead of presenting the state as a denial and forcing a re-pick every session.
- **Auto-reopen on launch** — no user gesture exists there, so `requestPermission()` cannot be called; a `"prompt"` handle becomes a one-click "Restore last project: <name>" offer (same pattern as the asset-delete undo toast) whose button re-grants and restores. `"granted"` restores exactly as before; `"denied"` stays silent.

Tests: `test/verify-project.mjs` gains behavioral cases for the helper (granted never re-prompts; prompt escalates with `mode: "readwrite"`; refusal and throwing handles report `"denied"`) plus wiring guards, captured failing before the implementation. Full suite: PASS 81 Node verification files; vite build green.

Manual repro (Chrome): save a project to disk + pick a projects folder → close the tab → reopen. Before: nothing restores, folder shows as denied, Recent click errors. After: a restore offer appears; Recent click and the folder Re-allow button each re-grant with one browser prompt.