### PR TITLE
fix(mcp): let the npm-served studio attach to the live hub

### DIFF
--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -432,7 +432,10 @@ server = createServer((req, res) => {
 		if (runtime.firstLaunch) {
 			markTelemetryFirstLaunch(STATE_FILE);
 		}
-		const script = `<script>window.__COZYCLAY_RUNTIME__ = ${JSON.stringify(runtime).replaceAll("<", "\\u003c")};</script>`;
+		// __COZYCLAY_LIVE__ opts the production build into the loopback live
+		// socket (src/App.jsx gates on DEV || this flag); without it an
+		// npx-served studio can never attach to the MCP server's live hub.
+		const script = `<script>window.__COZYCLAY_RUNTIME__ = ${JSON.stringify(runtime).replaceAll("<", "\\u003c")}; window.__COZYCLAY_LIVE__ = true;</script>`;
 		const html = readFileSync(target, "utf8").replace("</head>", `${script}\n</head>`);
 		res.writeHead(200, {
 			"content-type": "text/html; charset=utf-8",

--- a/test/process/verify-package-telemetry.mjs
+++ b/test/process/verify-package-telemetry.mjs
@@ -151,6 +151,7 @@ try {
 		assert.equal(runtime.telemetryEnabled, true);
 		assert.equal(runtime.firstLaunch, true);
 		assert.match(runtime.installationId, /^[0-9a-f-]{36}$/);
+		assert.match(html, /window\.__COZYCLAY_LIVE__ = true;/, "the served studio opts into the loopback live socket (issue #58)");
 
 		const forged = await fetch(`http://127.0.0.1:${port}/__cozyclay/telemetry`, {
 			method: "POST",


### PR DESCRIPTION
## Summary
Fixes #58.

`src/App.jsx` opens the loopback live socket only when `import.meta.env.DEV || window.__COZYCLAY_LIVE__ === true`. The npm package ships a production build, and `bin/cozyclay.mjs` never set the flag — so a studio launched via `npx cozyclay` could **never** attach to an MCP server. Every tool call fell back to memory-only mode, and the open tab never reflected `set_camera`/`frame_shot`, exactly as reported.

The fix injects `window.__COZYCLAY_LIVE__ = true` into the served `/app/` HTML, next to the existing `__COZYCLAY_RUNTIME__` injection. The GitHub Pages deploy serves raw `dist/` without injection, so a web-hosted studio still never dials localhost.

## Verification
- `test/process/verify-package-telemetry.mjs` now asserts the served studio HTML carries the live flag (fails on main, passes here).
- End-to-end on macOS: `bin/cozyclay.mjs` serving the built dist + `mcp/server.mjs` over stdio + a real Chrome tab at `/app/` — `live_status` goes from "No live editor connected" to "Live editor connected. Workspace handles: …" within seconds, with no dev server involved.
- Full `npm test`: 92 node verification files pass.
