### PR TITLE
ci: fold the mcp/ verify suites into the test manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,10 @@ jobs:
             mcp/package-lock.json
       - run: npm ci
       - run: npm --prefix mcp ci
+      # tools/run-tests.mjs inventories mcp/ alongside test/ (#52), so the
+      # MCP verify suites — including the hermetic verify:live family — run
+      # under `npm test`; only browser-bound suites stay classified out.
       - run: npm test
-      # Hermetic MCP verify suites (#52). tools/run-tests.mjs inventories only
-      # test/, so these behavioral suites never reach `npm test`; run them
-      # directly. The verify:live family stays out until it is confirmed
-      # hermetic on the runner.
-      - name: MCP verify suites
-        run: |
-          npm --prefix mcp run verify
-          npm --prefix mcp run verify:annotations
-          npm --prefix mcp run verify:prompts
 
   # Real-browser rendering regressions via the CDP QA wrapper. Only the suites
   # that are green against origin/main run here (ik, camera-rail); the other

--- a/mcp/verify-live-port.mjs
+++ b/mcp/verify-live-port.mjs
@@ -77,6 +77,9 @@ const child = spawn(process.execPath, ["tools/dev-full.mjs", "--host", "127.0.0.
 		CCLAY_ARDY_MODE: "remote",
 		CCLAY_ARDY_HOST: "test@ardy",
 		COZYCLAY_LIVE_PORT: String(livePort),
+		// On CI runners picocolors turns color on for a piped Vite, wrapping
+		// the port in ANSI bold and defeating the URL match below.
+		NO_COLOR: "1",
 	},
 	stdio: ["ignore", "pipe", "pipe"],
 });

--- a/mcp/verify-live-port.mjs
+++ b/mcp/verify-live-port.mjs
@@ -32,10 +32,10 @@ const withTimeout = (promise, label, milliseconds = 30_000) => {
 	]).finally(() => clearTimeout(timer));
 };
 
-const waitForOutput = (child, pattern, label, milliseconds) =>
-	withTimeout(
+const waitForOutput = (child, pattern, label, milliseconds) => {
+	let output = "";
+	return withTimeout(
 		new Promise((resolve, reject) => {
-			let output = "";
 			const inspect = (chunk) => {
 				output += chunk.toString();
 				if (pattern.test(output)) finish(resolve);
@@ -53,7 +53,12 @@ const waitForOutput = (child, pattern, label, milliseconds) =>
 		}),
 		label,
 		milliseconds,
-	);
+	).catch((error) => {
+		// A bare timeout hides what the child actually said; name it.
+		error.message += output ? `\nchild output:\n${output}` : "\n(child produced no output)";
+		throw error;
+	});
+};
 
 const terminate = async (child) => {
 	if (child.exitCode !== null || child.signalCode !== null) return;

--- a/mcp/verify-live-port.mjs
+++ b/mcp/verify-live-port.mjs
@@ -22,17 +22,17 @@ const reservePort = () =>
 		});
 	});
 
-const withTimeout = (promise, label) => {
+const withTimeout = (promise, label, milliseconds = 30_000) => {
 	let timer;
 	return Promise.race([
 		promise,
 		new Promise((_, reject) => {
-			timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}.`)), 30_000);
+			timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}.`)), milliseconds);
 		}),
 	]).finally(() => clearTimeout(timer));
 };
 
-const waitForOutput = (child, pattern, label) =>
+const waitForOutput = (child, pattern, label, milliseconds) =>
 	withTimeout(
 		new Promise((resolve, reject) => {
 			let output = "";
@@ -52,6 +52,7 @@ const waitForOutput = (child, pattern, label) =>
 			child.once("exit", onExit);
 		}),
 		label,
+		milliseconds,
 	);
 
 const terminate = async (child) => {
@@ -75,7 +76,10 @@ const child = spawn(process.execPath, ["tools/dev-full.mjs", "--host", "127.0.0.
 	stdio: ["ignore", "pipe", "pipe"],
 });
 try {
-	await waitForOutput(child, new RegExp(`http://127\\.0\\.0\\.1:${vitePort}/`), "dev-full Vite startup");
+	// A cold Vite start on a CI runner optimizes dependencies first and can
+	// take well past 30s; ci.yml's own dev-server step allows 120s for the
+	// same boot.
+	await waitForOutput(child, new RegExp(`http://127\\.0\\.0\\.1:${vitePort}/`), "dev-full Vite startup", 120_000);
 	const source = await (await fetch(`http://127.0.0.1:${vitePort}/src/live-control.js`)).text();
 	assert.match(source, new RegExp(`\"VITE_COZYCLAY_LIVE_PORT\": \"${livePort}\"`));
 	assert.equal(liveControlUrl(String(livePort)), `ws://127.0.0.1:${livePort}/live`);

--- a/test/verify-mcp-http-origin.mjs
+++ b/test/verify-mcp-http-origin.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-await import("../mcp/verify-http-origin.mjs");

--- a/test/verify-mcp-motion-job.mjs
+++ b/test/verify-mcp-motion-job.mjs
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-await import("../mcp/verify-live-motion-job.mjs");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -36,7 +36,6 @@ const NODE_FILES = [
 	"test/process/verify-lifecycle.mjs",
 	"test/process/verify-mcp-package-isolation.mjs",
 	"test/process/verify-package-telemetry.mjs",
-	"test/verify-mcp-motion-job.mjs",
 	"test/verify-analytics.mjs",
 	"test/verify-appearance.mjs",
 	"test/verify-asset-shelf.mjs",
@@ -57,7 +56,6 @@ const NODE_FILES = [
 	"test/verify-live-control.mjs",
 	"test/verify-matte-editor.mjs",
 	"test/verify-matte.mjs",
-	"test/verify-mcp-http-origin.mjs",
 	"test/verify-mp4-duration.mjs",
 	"test/verify-mcp-invariants.mjs",
 	"test/verify-motion-edit.mjs",
@@ -86,6 +84,16 @@ const NODE_FILES = [
 	"test/verify-update-check.mjs",
 	"test/verify-usd-camera.mjs",
 	"test/verify-video-frames.mjs",
+	"mcp/verify.mjs",
+	"mcp/verify-http-origin.mjs",
+	"mcp/verify-live.mjs",
+	"mcp/verify-live-motion-job.mjs",
+	"mcp/verify-live-p0.mjs",
+	"mcp/verify-live-port.mjs",
+	"mcp/verify-live-routing.mjs",
+	"mcp/verify-prompts.mjs",
+	"mcp/verify-protocol-version.mjs",
+	"mcp/verify-tool-annotations.mjs",
 ];
 
 const BROWSER_FILES = [
@@ -102,8 +110,8 @@ function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })
 		.flatMap((entry) => {
 			const path = join(directory, entry.name);
-			if (entry.isDirectory()) return verificationFiles(path);
-			return entry.isFile() && /^verify-.*\.mjs$/.test(entry.name) ? [relative(".", path)] : [];
+			if (entry.isDirectory()) return entry.name === "node_modules" ? [] : verificationFiles(path);
+			return entry.isFile() && /^verify(-.*)?\.mjs$/.test(entry.name) ? [relative(".", path)] : [];
 		})
 		.sort();
 }
@@ -144,9 +152,12 @@ const categories = new Map([
 	...BROWSER_FILES.map((file) => [file, { kind: "browser", reason: "requires the QA browser wrapper and a running Vite app" }]),
 	["test/ardy/verify-npz.mjs", { kind: "external", reason: "requires a configured remote ARDY host and NumPy environment" }],
 	["test/process/verify-mcp-package-isolation.mjs", { kind: "package-integration", reason: "installs the MCP runtime from the npm registry with an isolated cache" }],
+	...["mcp/verify-live-batch.mjs", "mcp/verify-live-capture.mjs", "mcp/verify-live-editor-model.mjs", "mcp/verify-live-scene-parity.mjs"].map(
+		(file) => [file, { kind: "browser", reason: "drives a real Chrome editor over the live socket" }],
+	),
 ]);
 const { listOnly, scope } = parseArguments(process.argv.slice(2));
-const inventory = verificationFiles("test");
+const inventory = [...verificationFiles("test"), ...verificationFiles("mcp")];
 const unclassified = inventory.filter((file) => !categories.has(file));
 const stale = [...categories.keys()].filter((file) => !inventory.includes(file));
 if (unclassified.length > 0 || stale.length > 0) {


### PR DESCRIPTION
## Summary
P2 of #52 (closes #52 — P1 landed in #56).

`tools/run-tests.mjs` inventoried only `test/`, so 12 of the 14 `mcp/verify-*.mjs` suites never gated a pull request. This extends the inventory to `mcp/` under the same classified-or-error rule:

- 10 suites classified `node`: they reserve ephemeral loopback ports and fake the editor in-process, and each passes standalone from the repo root.
- 4 suites classified `browser` — `verify-live-batch`, `verify-live-capture`, `verify-live-editor-model`, `verify-live-scene-parity`: they spawn a real Chrome editor (hardcoded macOS Chrome path), which answered the open hermeticity question the hard way on the Linux runner.
- The two one-line shims (`test/verify-mcp-http-origin.mjs`, `test/verify-mcp-motion-job.mjs`) retire.
- The explicit "MCP verify suites" CI step from #56 collapses back into `npm test`, which now also covers the node-safe live suites it left out.

The inventory walk skips `node_modules` and now also matches `verify.mjs` (no dash), so a new MCP suite cannot be added without declaring how it runs.

## Verification
- Each `node`-kind mcp suite passes standalone from the repo root after `npm --prefix mcp ci`.
- Full `npm test`: `TEST MANIFEST scope=all runnable=89 total=102`, all pass in one run.
- `--scope ardy` unchanged (17 runnable).
