### PR TITLE
fix: contain the three failures that turn the studio into a blank screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1029,6 +1029,34 @@ function RenderLoopController({ stageRef }) {
 	return null;
 }
 
+/** GPU resets — sleep/wake, a driver restart, VRAM pressure from an export —
+ * kill the WebGL context, and without listeners the stage goes black and
+ * stays black with no message. preventDefault on webglcontextlost is the
+ * documented opt-in for browser-driven restoration; on restore, kick the
+ * demand loop so the first frame actually paints. */
+function ContextLossGuard({ onLostChange }) {
+	const gl = useThree((state) => state.gl);
+	const invalidate = useThree((state) => state.invalidate);
+	useEffect(() => {
+		const canvas = gl.domElement;
+		const onLost = (event) => {
+			event.preventDefault();
+			onLostChange(true);
+		};
+		const onRestored = () => {
+			onLostChange(false);
+			invalidate();
+		};
+		canvas.addEventListener("webglcontextlost", onLost);
+		canvas.addEventListener("webglcontextrestored", onRestored);
+		return () => {
+			canvas.removeEventListener("webglcontextlost", onLost);
+			canvas.removeEventListener("webglcontextrestored", onRestored);
+		};
+	}, [gl, invalidate, onLostChange]);
+	return null;
+}
+
 function ViewportLayoutInvalidator({ insetX, insetY, insetWidth, insetHeight, hierarchyWidth, sidebarWidth, timelineHeight, planZoom }) {
 	const invalidate = useThree((state) => state.invalidate);
 	useEffect(() => {
@@ -1723,7 +1751,12 @@ globalThis.playMode = centerTab === "play";
 	const planHostRef = planIsMain ? mainPaneRef : insetPaneRef;
 
 	useEffect(() => {
-		localStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(workspaceLayout));
+		try {
+			localStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(workspaceLayout));
+		} catch {
+			// Full or blocked storage must not crash a panel resize; the
+			// layout simply does not persist this session.
+		}
 	}, [workspaceLayout]);
 
 	// Wheel over the inset zooms the Top-View plan: scroll up closes in on
@@ -2875,6 +2908,7 @@ globalThis.playMode = centerTab === "play";
 	const [copied, setCopied] = useState(false);
 	const [recordedVideoName, setRecordedVideoName] = useState(null);
 	const [toast, setToast] = useState(startup.toast ?? "");
+	const [glContextLost, setGlContextLost] = useState(false);
 	const [bridge, setBridge] = useState(null);
 	const [ardyPrompt, setArdyPrompt] = useState("");
 	const [ardyDuration, setArdyDuration] = useState(4); // matches the 4 s generation cap
@@ -7120,6 +7154,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						    shadow is the cue that says a subject stands ON the deck rather
 						    than floats above it — without walls it is the only one left. */}
 						<Canvas shadows frameloop={renderActive ? "always" : "demand"} dpr={[1, 2]} gl={{ preserveDrawingBuffer: true, antialias: true }}>
+							<ContextLossGuard onLostChange={setGlContextLost} />
 							<RenderLoopController stageRef={stageRef} />
 							<ViewportLayoutInvalidator
 								insetX={insetPos?.x ?? null}
@@ -7455,6 +7490,16 @@ function resizePromptClip(id, edge, rawFrame) {
 								shotAspect={shotOutput.aspect}
 							/>
 						</Canvas>
+
+						{glContextLost && (
+							<div className="gl-lost-overlay" role="alert">
+								<div className="gl-lost-card">
+									<strong>{ko("The 3D view lost its graphics context", "3D 뷰가 그래픽 컨텍스트를 잃었어요")}</strong>
+									<p>{ko("Waiting for the browser to restore it. If this stays, reload the studio — scenes autosave.", "브라우저가 복구하기를 기다리는 중이에요. 계속 멈춰 있으면 새로고침하세요 — 장면은 자동 저장됩니다.")}</p>
+									<button type="button" onClick={() => window.location.reload()}>{ko("Reload", "새로고침")}</button>
+								</div>
+							</div>
+						)}
 
 						<div ref={mainPaneRef} className={"vp-pane vp-main" + (planIsMain ? " plan" : "")} />
 						<div

--- a/src/error-boundary.jsx
+++ b/src/error-boundary.jsx
@@ -1,0 +1,41 @@
+import { Component } from "react";
+import { ko } from "./locale.js";
+
+/**
+ * Last line of defense for the whole tree. A render-time throw anywhere in
+ * App unmounts everything React manages, and over an autosaving document
+ * that reads as a silent white page, mid-edit, with no message and no way
+ * back. Catch it, say what broke, and offer the one recovery that always
+ * works: reload, which resumes from the last autosaved state.
+ *
+ * Deliberately dependency-free beyond ko(): the fallback must render when
+ * app state is exactly what just crashed.
+ */
+export default class ErrorBoundary extends Component {
+	constructor(props) {
+		super(props);
+		this.state = { error: null };
+	}
+
+	static getDerivedStateFromError(error) {
+		return { error };
+	}
+
+	componentDidCatch(error, info) {
+		console.error("[cozyclay] render crash", error, info?.componentStack ?? "");
+	}
+
+	render() {
+		if (!this.state.error) return this.props.children;
+		return (
+			<div className="crash-screen" role="alert">
+				<h1>{ko("The studio hit a render error", "스튜디오에 렌더링 오류가 발생했어요")}</h1>
+				<p>{ko("Scenes autosave as you work, so reloading resumes from the last saved state.", "작업 중 장면은 자동 저장되므로, 새로고침하면 마지막 저장 상태에서 이어집니다.")}</p>
+				<pre className="crash-detail">{String((this.state.error && this.state.error.message) || this.state.error)}</pre>
+				<button type="button" onClick={() => window.location.reload()}>
+					{ko("Reload the studio", "스튜디오 새로고침")}
+				</button>
+			</div>
+		);
+	}
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.jsx";
+import ErrorBoundary from "./error-boundary.jsx";
 import "./styles.css";
 import { registerPwa } from "./pwa.js";
 import { LOCALE } from "./locale.js";
@@ -12,6 +13,8 @@ document.documentElement.lang = LOCALE;
 
 createRoot(document.getElementById("root")).render(
 	<StrictMode>
-		<App />
+		<ErrorBoundary>
+			<App />
+		</ErrorBoundary>
 	</StrictMode>,
 );

--- a/src/styles.css
+++ b/src/styles.css
@@ -8386,3 +8386,78 @@ input[type=range] {
 	font-size: 9px;
 	letter-spacing: .04em;
 }
+
+/* --------------------------------------------------- failure containment --- */
+/* The crash screen replaces the whole app when a render error escapes the
+   tree; the GL overlay covers the stage while the browser restores a lost
+   context. Both are deliberately plain — they must render when app state is
+   exactly what just broke. */
+.crash-screen {
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 24px;
+	background: var(--bg, #1e1e1e);
+	color: var(--fg, #d2d2d2);
+	text-align: center;
+}
+.crash-screen h1 {
+	font-size: 18px;
+	margin: 0;
+}
+.crash-screen p {
+	margin: 0;
+	color: var(--muted, #9a9a9a);
+	max-width: 52ch;
+}
+.crash-screen .crash-detail {
+	max-width: min(72ch, 90vw);
+	overflow: auto;
+	padding: 10px 14px;
+	border: 1px solid var(--line2, #3c3c3c);
+	border-radius: 6px;
+	background: var(--panel, #2c2c2c);
+	color: var(--muted, #9a9a9a);
+	font-size: 12px;
+	text-align: left;
+	white-space: pre-wrap;
+}
+.crash-screen button,
+.gl-lost-card button {
+	padding: 6px 16px;
+	border: 1px solid var(--line2, #3c3c3c);
+	border-radius: 6px;
+	background: var(--card, #383838);
+	color: var(--fg, #d2d2d2);
+	cursor: pointer;
+}
+.gl-lost-overlay {
+	position: absolute;
+	inset: 0;
+	z-index: 9;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(12, 12, 14, .78);
+}
+.gl-lost-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	max-width: 46ch;
+	padding: 18px 22px;
+	border: 1px solid var(--line2, #3c3c3c);
+	border-radius: 8px;
+	background: var(--panel, #2c2c2c);
+	color: var(--fg, #d2d2d2);
+	text-align: center;
+}
+.gl-lost-card p {
+	margin: 0;
+	color: var(--muted, #9a9a9a);
+	font-size: 12px;
+}

--- a/test/verify-korean-ui.mjs
+++ b/test/verify-korean-ui.mjs
@@ -112,7 +112,7 @@ assert.equal(koLocale.ko("Frame", "프레임"), "프레임");
 assert.equal(koLocale.ko("Collapse timeline", "타임라인 접기"), "타임라인 접기");
 
 // Files converted to the English-default + Korean-option pattern.
-for (const path of ["src/result-modal.jsx", "src/hierarchy-panel.jsx", "src/object-catalog.jsx"]) {
+for (const path of ["src/result-modal.jsx", "src/hierarchy-panel.jsx", "src/object-catalog.jsx", "src/error-boundary.jsx"]) {
 	assertKoreanInsideLocaleConstructs(path);
 	assertKoPairsHaveBothSides(path);
 }

--- a/test/verify-resilience.mjs
+++ b/test/verify-resilience.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Failure containment: a render error, a lost WebGL context, or a full
+// localStorage must degrade into a message with a way back — never a silent
+// white or black screen over an autosaving document. App.jsx only runs in a
+// browser, so like verify-record-mp4-source this asserts the wiring in the
+// source; the browser owns the rest.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(`../src/${path}`, import.meta.url), "utf8");
+
+// --- the error boundary wraps the whole tree -------------------------------
+const main = await read("main.jsx");
+assert.match(main, /<ErrorBoundary>\s*<App \/>\s*<\/ErrorBoundary>/, "App must render inside the error boundary");
+
+const boundary = await read("error-boundary.jsx");
+assert.match(boundary, /static getDerivedStateFromError/, "the boundary must derive fallback state from the error");
+assert.match(boundary, /componentDidCatch/, "the crash must reach the console, not vanish");
+assert.match(boundary, /window\.location\.reload/, "the crash screen must offer the reload recovery");
+assert.match(boundary, /role="alert"/, "the crash screen announces itself to assistive tech");
+
+// --- a lost GL context is handled, not ignored -----------------------------
+const app = await read("App.jsx");
+assert.match(app, /addEventListener\("webglcontextlost", onLost\)/, "the stage must listen for context loss");
+assert.match(app, /addEventListener\("webglcontextrestored", onRestored\)/, "…and for its restoration");
+assert.match(
+	app,
+	/const onLost = \(event\) => \{\s*event\.preventDefault\(\);/,
+	"preventDefault on webglcontextlost is the opt-in for browser-driven restoration",
+);
+assert.match(app, /removeEventListener\("webglcontextlost", onLost\)/, "the listeners must unmount with the guard");
+assert.match(app, /glContextLost && \(/, "the lost context must surface as an overlay, not a black stage");
+
+// --- storage writes in render paths cannot throw ---------------------------
+assert.match(
+	app,
+	/try \{\s*localStorage\.setItem\(WORKSPACE_LAYOUT_KEY/,
+	"the layout write runs on every panel resize and must not crash on full storage",
+);
+
+console.log("PASS failure containment is wired: boundary, GL context guard, guarded layout write");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -75,6 +75,7 @@ const NODE_FILES = [
 	"test/verify-project.mjs",
 	"test/verify-pwa.mjs",
 	"test/verify-package-signature.mjs",
+	"test/verify-resilience.mjs",
 	"test/verify-retime.mjs",
 	"test/verify-sample-at.mjs",
 	"test/verify-scene-asset-cache.mjs",


### PR DESCRIPTION
Closes #63.

Three failure modes, one experience — the studio vanishes silently over an autosaving document. Each now degrades into a message with a way back.

**Error boundary** (`src/error-boundary.jsx`, wired in `main.jsx`). A render-time throw anywhere in the App tree previously unmounted everything to a white page. The boundary names the error, says that scenes autosave, and offers the reload that resumes from the last saved state. It is deliberately dependency-free beyond `ko()` — the fallback must render when app state is exactly what just crashed. Copy follows the English-default + Korean-option pattern and the file is registered in the `verify-korean-ui` converted-files list.

**Context-loss guard** (`ContextLossGuard` in `App.jsx`, mounted inside the Canvas next to `RenderLoopController`). `preventDefault()` on `webglcontextlost` is the documented opt-in for browser-driven restoration — nothing called it, so a GPU reset left the stage black with no message and no recovery. While the context is gone an overlay over the stage says what happened and offers reload; on `webglcontextrestored` it clears and calls `invalidate()`, because under the demand frameloop nothing else would repaint the first frame.

**Guarded layout write.** The workspace-layout effect wrote to `localStorage` unguarded on every panel resize; every sibling write (`persistScenes`, `locale.js`, `saveCustomPoses`) is already wrapped. Now this one is too — full storage costs persistence for the session, not a crash mid-drag.

**Verification.** `test/verify-resilience.mjs` (registered in the manifest) asserts the wiring in the source, the same way `verify-record-mp4-source` does for App-level behavior: the boundary wraps `<App />` and derives fallback state, the stage adds/removes both context listeners with `preventDefault` on loss, the overlay renders from the lost state, and the layout write sits in a `try`.

Verified live in Chrome against the built app: `WEBGL_lose_context.loseContext()` raises the overlay over the stage; `restoreContext()` clears it and the viewport repaints — characters, gizmo and both insets — with no console errors. `npm test` node manifest passes locally except pre-existing environment failures unrelated to this diff (`verify-bridge-launch`, `verify-generation-bridge-launch`, and the two `test/demo` worker suites fail identically on a clean `main` checkout on this machine).
