### PR TITLE
fix: stabilize Studio camera drag and preserve flow

### DIFF
--- a/.omo/plans/scheduled-inpainting.md
+++ b/.omo/plans/scheduled-inpainting.md
@@ -1,0 +1,100 @@
+# Scheduled Inpainting — frozen contracts (2026-08-28)
+
+Goal: Kimodo generation that PRESERVES an existing take while regenerating only
+what the user edited, via inference-time scheduled inpainting
+(Disney "Interactive Generative Motion Editing via Scheduled Inpainting", 2026).
+
+Core equation, applied inside the denoising loop (RePaint-style):
+  x_blended = alpha_t * noise(base, t) + (1 - alpha_t) * x_gen
+  alpha_t   = alpha_time(t; sigma_s, sigma_e) * alpha_mask(frame)
+  alpha_time = 1            when t > sigma_s
+             = (t-sigma_e)/(sigma_s-sigma_e)  when sigma_e <= t <= sigma_s
+             = 0            when t < sigma_e
+(t in diffusion-time units 0..1000. High noise -> preserve structure from base;
+low noise -> model finishes freely.)
+
+HARD RULE: `twostage_denoiser.py:102` (the binary observed_motion input channel)
+is trained binary and MUST NOT be changed. All blending happens in the sampling
+loop on the evolving sample, outside the denoiser's input contract.
+
+## C1 — Preserve-mask JSON (per-frame, v1)
+
+```json
+{
+  "version": 1,
+  "genFps": 30,
+  "genFrames": 180,
+  "weights": [1.0, 1.0, "... genFrames floats in 0..1 ..."]
+}
+```
+- `weights[f]` = alpha_mask for generation frame f. 1 = fully preserve base,
+  0 = free generation. Dense array, length exactly `genFrames`.
+- Built from edits with a Gaussian falloff (mu = influence radius in gen
+  frames); edges must taper, never step (paper: square kernel = broken).
+- Reserved for v2 (do NOT implement): `jointWeights`.
+
+## C2 — Kimodo CLI flags (scripts/generate.py)
+
+```
+--base_motion <path.npz>     # a kimodo-native output npz (same format generate saves)
+--preserve_start <int>       # sigma_s, 0..1000, default 500
+--preserve_end <int>         # sigma_e, 0..1000, default 50, must be <= sigma_s
+--preserve_mask <path.json>  # C1 file; optional, default = all ones
+```
+- `--base_motion` absent => behavior BIT-IDENTICAL to current code (same seed
+  => same output). This is the non-negotiable regression invariant.
+- `sigma_s = 0` => inpainting fully off even with a base motion.
+
+## C2b — Base-motion prep API (kimodo/preserve_prep.py, new file)
+
+```python
+prepare_base_motion(npz_path, motion_rep, target_frames, target_fps=30)
+  -> (base_normalized: Tensor[target_frames, motion_rep_dim], meta: dict)
+```
+- Loads a kimodo output npz, resamples to target_fps/target_frames (linear on
+  positions, slerp-equivalent on rotations is NOT required v1 — nearest/linear
+  on the rep is acceptable, document the choice), re-canonicalizes (smoothed
+  root XZ at frame 0 -> origin), encodes via motion_rep, then
+  motion_rep.normalize. Output is ready to noise-and-blend.
+- meta records: source_fps, source_frames, resample_ratio, canonical_offset.
+
+## C3 — Bridge request field (wave 2)
+
+```json
+"preserve": {
+  "sourceMotion": "/ardy/motions/<run-id>",
+  "strength": 0.5,
+  "editRanges": [{ "startFrame": 40, "endFrame": 80 }]
+}
+```
+- App frames (20 fps clip space); scaling to gen space happens in the mask
+  builder, same rule as root2d constraints.
+- strength s in [0,1]: s=0 => preserve off; else sigma_s = round(1000*s),
+  sigma_e = min(50, sigma_s). Default 0.5 (= paper's recommended 500/50).
+- Mutually REQUIRES posePin rules to stay valid; cannot combine with
+  `regenerateSegments`.
+
+## C4 — File ownership (agents must not touch files outside their row)
+
+| Agent | Files |
+|---|---|
+| A | CozyClay: tools/kimodo/measure-preserve.mjs (new) |
+| B | kimodo-custom: kimodo/model/kimodo_model.py, kimodo/scripts/generate.py |
+| C | CozyClay: tools/kimodo/preserve-mask.mjs (new), test/verify-kimodo-preserve.mjs (new) |
+| D | kimodo-custom: kimodo/preserve_prep.py (new), tests/test_preserve_prep.py (new) |
+| E | CozyClay: tools/ardy/bridge.mjs, tools/kimodo/generate.mjs, tools/kimodo/runner.mjs, src/ardy/pose-pin.js |
+| F | CozyClay: src/App.jsx (preserve slider region), src/styles.css |
+
+NO agent commits. Files only; main session commits after merge review.
+
+## Acceptance gates (wave 3, on the box, fixed seed)
+
+- G1 reconstruction: no edits + strength 0.5 => L2P vs base >= 10x better than
+  the no-preserve baseline. FAIL => STOP the project, report.
+- G2 locality: one edited range; frames outside the Gaussian influence keep
+  G1-level L2P; frames inside move toward the edit.
+- G3 monotonicity: strength 0.2 / 0.5 / 0.8 => L2P-to-base strictly decreasing
+  with strength, constraint error strictly increasing.
+- G4 no side effects: foot sliding within +1mm/frame of baseline; 2-segment
+  seam jump <= 0.4 m; all existing verify-* suites green.
+- G5 eyeball: before/after render side by side.

--- a/.omo/plans/scheduled-inpainting.md
+++ b/.omo/plans/scheduled-inpainting.md
@@ -69,8 +69,13 @@ prepare_base_motion(npz_path, motion_rep, target_frames, target_fps=30)
 ```
 - App frames (20 fps clip space); scaling to gen space happens in the mask
   builder, same rule as root2d constraints.
-- strength s in [0,1]: s=0 => preserve off; else sigma_s = round(1000*s),
-  sigma_e = min(50, sigma_s). Default 0.5 (= paper's recommended 500/50).
+- strength s in [0,1]: s=0 => preserve off; else
+  sigma_s = max(50, round(1000*(1-s))), sigma_e = min(50, sigma_s).
+  Default 0.5 (= paper's recommended 500/50, unchanged by the inversion).
+  AMENDED after gate G3: alpha_time is 1 ABOVE sigma_s, so a smaller sigma_s
+  preserves MORE; the original round(1000*s) made the slider work backwards.
+  Measured (all-ones mask, seed 5678): sigma_s 200/500/800/1000 ->
+  L2P 0.00455/0.00467/0.00480/0.00487.
 - Mutually REQUIRES posePin rules to stay valid; cannot combine with
   `regenerateSegments`.
 
@@ -98,3 +103,23 @@ NO agent commits. Files only; main session commits after merge review.
 - G4 no side effects: foot sliding within +1mm/frame of baseline; 2-segment
   seam jump <= 0.4 m; all existing verify-* suites green.
 - G5 eyeball: before/after render side by side.
+
+## Gate results (2026-08-29, box run, Kimodo-SOMA-RP-v1.1, RTX 3070)
+
+Prompt "a person walks forward, then turns left and keeps walking", 5 s,
+150 gen frames @30 -> 120 @24. Take A seed 1234; everything else seed 5678.
+
+- no-preserve baseline: L2P 0.072930 m
+- G1 (500/50, all-ones): L2P 0.004670 -> 15.6x improvement. PASS
+- sigma_s=0 control: bit-identical to no-preserve run. Regression invariant PASS
+- G2 (edit [48,72) app frames): out-of-range 0.005104 (1.09x G1), in-range
+  0.037644 (7.4x out). PASS
+- G3: monotone but in the WRONG direction under the original mapping ->
+  mapping inverted (see C3 amendment). With the inversion the measured curve
+  is strictly tighter as strength rises. PASS after fix
+- G4: preserve runs slide LESS than the base (delta negative); suite 97 files
+  green. PASS
+- Known follow-ups: preserve_prep device fix landed (arange needed device=);
+  whole-clip-only base retention means edited takes have no base lineage yet
+  (bridge logs `preserve SKIPPED`); influenceRadius 10 ramp covers 86 frames
+  on a 120-frame clip — tune before shipping; every run 15-16 s wall.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -530,6 +530,13 @@ const ARDY_PROMPT_MAX = 500; // bridge contract: prompt must be non-empty, cappe
 const ARDY_DURATION_MIN = 1; // the UI works in whole seconds; the bridge floor is 0.15 s
 const ARDY_DURATION_MAX = 1200; // bridge contract: duration capped at 1200 s
 const ARDY_SEED_MAX = 2 ** 31 - 1; // bridge contract: optional seed, integer in 0..2**31-1
+// Scheduled inpainting (contract C3): how hard a regeneration holds onto the
+// take that is already loaded. 0 turns preserving OFF entirely; 0.5 is the
+// paper's recommended setting. The app ships this RAW number and nothing else:
+// the strength -> denoising-schedule mapping (sigma_s = round(1000 * strength),
+// sigma_e = min(50, sigma_s), diffusion time 0..1000) lives on the box side, and
+// duplicating it here is exactly how the two would silently drift apart.
+const ARDY_PRESERVE_DEFAULT = 0.5;
 const DEFAULT_PROMPT_CLIPS = [];
 
 // Named ingest failures, in both locales. A reason the user cannot act on is
@@ -3946,6 +3953,12 @@ globalThis.playMode = centerTab === "play";
 	// box picks a fresh random one each run); otherwise a plain integer in
 	// 0..2**31-1 to reproduce a result.
 	const [ardySeed, setArdySeed] = useState("");
+	// How much of the loaded take a regeneration keeps (scheduled inpainting).
+	// 1 = hold the take everywhere the user did not edit, 0 = ignore it and
+	// generate fresh. Only ever consulted when the take still has a bridge
+	// source to preserve FROM, so the control renders with the take, not with
+	// the panel.
+	const [preserveStrength, setPreserveStrength] = useState(ARDY_PRESERVE_DEFAULT);
 	// Off by default on purpose: pinning runs the box's pose mode, which builds
 	// on a fixed reference base, so it is a choice the operator makes when they
 	// actually want the pose in the generated clip.
@@ -7859,6 +7872,33 @@ function resizePromptClip(id, edge, rawFrame) {
 				edits: editEntries.map(({ frame, tracks, pose }) => ({ frame, tracks, pose })),
 			};
 		} else if (hasPromptSchedule) body.segments = toArdySegments(segments);
+		// Scheduled inpainting (contract C3). The run reconstructs the take that
+		// is already loaded everywhere the user did NOT edit, so it addresses that
+		// take's bridge source npz — without one there is nothing to preserve and
+		// the field must not be sent. strength travels RAW; the box maps it to
+		// sigma_s/sigma_e (see ARDY_PRESERVE_DEFAULT).
+		// Never on a root-path run: waypoints re-plan the whole rollout from
+		// authored Root2D pins, and the contract forbids preserving across a
+		// regenerated block set. The slider is grayed in waypoint mode for the
+		// same reason, so the wire and the UI cannot disagree. regenerateSegments
+		// is not authored by this app today; the guard is here so it stays true
+		// if it ever is.
+		if (motion?.url && preserveStrength > 0 && !waypointMode && body.regenerateSegments === undefined) {
+			body.preserve = {
+				sourceMotion: motion.url,
+				strength: preserveStrength,
+				// Edited spans leave on the BRIDGE clock like every other frame
+				// number crossing this boundary (waypoints, motionEdit); the mask
+				// builder scales them on to the generation clock itself. Ranges are
+				// half-open, so one that collapses under the rounding is dropped —
+				// the mask builder refuses an empty range outright, and an empty
+				// LIST is the legitimate "nothing was edited" case (all-ones mask,
+				// pure reconstruction) rather than an error.
+				editRanges: editedSegments
+					.map((segment) => ({ startFrame: toArdyFrame(segment.startFrame), endFrame: toArdyFrame(segment.endFrame) }))
+					.filter((range) => range.endFrame > range.startFrame),
+			};
+		}
 		// The request is fully packaged HERE, against the active character's
 		// live layer — the queue only needs the frozen payload. Results are
 		// delivered to THIS character even if the selection moves on while
@@ -9710,6 +9750,53 @@ function resizePromptClip(id, edge, rawFrame) {
 								placeholder={ko("empty = random", "비우면 랜덤")}
 							/>
 						</Field>
+						{/* Scheduled inpainting, and it lives beside the button that
+						    consumes it for the same reason the seed does. There is
+						    nothing to preserve until a take with a bridge source is
+						    loaded, so the whole row is ABSENT before then rather than
+						    present and inert — unlike the waypoint case, no explanation
+						    would help; the user simply has to generate once first. */}
+						{motion?.url && (
+							<Field label={ko("Keep the current take", "현재 테이크 유지")}>
+								<div className="preserve-strength-row" data-disabled={waypointMode ? "true" : undefined}>
+									<input
+										type="range"
+										data-preserve-strength
+										min={0}
+										max={1}
+										step={0.05}
+										value={preserveStrength}
+										disabled={waypointMode}
+										title={waypointMode
+											? ko(
+												"A root path re-plans the whole take from its waypoints, so it cannot also keep the old one — leave waypoint mode to use this.",
+												"루트 경로는 웨이포인트로 테이크 전체를 다시 계획하므로 이전 테이크를 함께 유지할 수 없어요 — 사용하려면 웨이포인트 모드를 끄세요.",
+											)
+											: ko(
+												"How hard the regeneration holds the loaded take outside the frames you edited.",
+												"수정하지 않은 프레임에서 로드된 테이크를 얼마나 강하게 유지할지 정합니다.",
+											)}
+										onChange={(event) => setPreserveStrength(Number(event.target.value))}
+									/>
+									<span className="preserve-strength-value">{Math.round(preserveStrength * 100)}%</span>
+								</div>
+								{/* The two poles sit at the ends they actually mean: the
+								    slider value IS the preserve strength, so 0 (left) is a
+								    fresh take and 1 (right) holds the original hardest. */}
+								<p className="inspector-hint preserve-strength-scale">
+									<span>{ko("generate fresh", "새로 생성")}</span>
+									<span>{ko("keep original", "원본 유지")}</span>
+								</p>
+								{waypointMode && (
+									<p className="inspector-hint">
+										{ko(
+											"Off while a root path is active — waypoints regenerate the whole take.",
+											"루트 경로가 켜져 있는 동안은 꺼집니다 — 웨이포인트는 테이크 전체를 다시 생성해요.",
+										)}
+									</p>
+								)}
+							</Field>
+						)}
 						<button
 							type="button"
 							className="btn primary full generate prompt-block-generate"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7883,7 +7883,11 @@ function resizePromptClip(id, edge, rawFrame) {
 		// same reason, so the wire and the UI cannot disagree. regenerateSegments
 		// is not authored by this app today; the guard is here so it stays true
 		// if it ever is.
-		if (motion?.url && preserveStrength > 0 && !waypointMode && body.regenerateSegments === undefined) {
+		// body.segments too: scheduled inpainting v1 is single-segment only, and
+		// the bridge refuses the pair. A chained rollout (2 s + 2 s prompt
+		// blocks) must still generate — preserve silently steps aside rather
+		// than turning every multi-block generation into a 400.
+		if (motion?.url && preserveStrength > 0 && !waypointMode && body.regenerateSegments === undefined && body.segments === undefined) {
 			body.preserve = {
 				sourceMotion: motion.url,
 				strength: preserveStrength,

--- a/src/controls.jsx
+++ b/src/controls.jsx
@@ -54,6 +54,7 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 	const keys = useRef(new Set());
 	const gesture = useRef(null); // { kind: "fly" | "pan" | "orbit", pointerId, x, y, ... }
 	const speedScale = useRef(1);
+	const invalidateRaf = useRef(0);
 	const flyStateRef = useRef(onFlyStateChange);
 	flyStateRef.current = onFlyStateChange;
 	const cameraChangeRef = useRef(onCameraChange);
@@ -70,6 +71,24 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 		const isTyping = () => {
 			const el = document.activeElement;
 			return !!el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT");
+		};
+		// Pointer events can arrive faster than the display refreshes. Camera
+		// refs are updated immediately for the latest input, but invalidate the
+		// demand renderer at most once per animation frame so a 120/240 Hz mouse
+		// cannot queue multiple full WebGL renders for the same visible frame.
+		const scheduleInvalidate = () => {
+			if (invalidateRaf.current) return;
+			invalidateRaf.current = requestAnimationFrame(() => {
+				invalidateRaf.current = 0;
+				invalidate();
+			});
+		};
+		const flushInvalidate = () => {
+			if (invalidateRaf.current) {
+				cancelAnimationFrame(invalidateRaf.current);
+				invalidateRaf.current = 0;
+			}
+			invalidate();
 		};
 
 		/* Physical key positions, not characters: `e.key` follows the OS input
@@ -101,12 +120,12 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 			}
 			gesture.current = null;
 			if (typeof window !== "undefined") window.__cozyclayCameraGesture = false;
-			invalidate();
+			flushInvalidate();
 			keys.current.clear();
 			// the fly speed set with the wheel persists between flights, as it does in Unity
 			element.style.cursor = "";
 			flyStateRef.current?.(false);
-			invalidate();
+			flushInvalidate();
 			if (active.changed) cameraChangeRef.current?.();
 		};
 
@@ -128,7 +147,7 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 			element.focus();
 			element.style.cursor = kind === "fly" ? "crosshair" : kind === "pan" ? "grabbing" : "move";
 			if (kind === "fly") flyStateRef.current?.(true);
-			invalidate();
+			scheduleInvalidate();
 		};
 
 		/** the point Alt-drag turns around: the caller's selection, or a point
@@ -159,7 +178,7 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 					// Camera gestures run in demand mode. One explicit
 					// invalidation per changed input is enough; keeping the
 					// entire scene loop on "always" rendered frozen panes too.
-					invalidate();
+					scheduleInvalidate();
 				}
 				return;
 			}
@@ -175,7 +194,7 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 				active.changed = active.changed || dx !== 0 || dy !== 0;
 				if (dx !== 0 || dy !== 0) {
 					cameraChangeRef.current?.();
-					invalidate();
+					scheduleInvalidate();
 				}
 				return;
 			}
@@ -196,7 +215,7 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 			active.changed = active.changed || dx !== 0 || dy !== 0;
 			if (dx !== 0 || dy !== 0) {
 				cameraChangeRef.current?.();
-				invalidate();
+				scheduleInvalidate();
 			}
 		};
 
@@ -228,6 +247,10 @@ export function FlyControls({ enabled, camRef, look, getPivot, onFlyStateChange,
 		// Alt-tabbing away mid-fly must not leave keys stuck down.
 		window.addEventListener("blur", endGesture);
 		return () => {
+			if (invalidateRaf.current) {
+				cancelAnimationFrame(invalidateRaf.current);
+				invalidateRaf.current = 0;
+			}
 			keys.current.clear();
 			gesture.current = null;
 			flyStateRef.current?.(false);

--- a/src/dualview.jsx
+++ b/src/dualview.jsx
@@ -116,6 +116,7 @@ export function fitAspect(rect, aspect) {
 export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCamRef, planCamRef, poserCamRef, editorCamRef, ikMode = false, planIsMain, playMode = false, lookThrough = false, insetCollapsed = false, planZoom = 1, shotAspect = SHOT_ASPECT }) {
 	const invalidate = useThree((state) => state.invalidate);
 	const lastPoserPose = useRef({ position: new THREE.Vector3(), quaternion: new THREE.Quaternion(), valid: false });
+	const interactivePixelRatio = useRef({ base: null, reduced: false, needsFrozenRedraw: false });
 	// Demand mode draws nothing by itself: the first frame can land before the
 	// layout settles (the inset reads 0x0), and async scene content commits
 	// later. Force frames on mount and after the DOM has caught up.
@@ -244,6 +245,26 @@ export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCa
 			lastPose.valid = false;
 		}
 		const navigatingCamera = cameraGesture || cameraMoved;
+		// Camera navigation is transient editor chrome: render it at one device
+		// pixel per CSS pixel, then restore the configured DPR before the first
+		// settled frame. At DPR 2 this cuts the moving viewport's fragment work to
+		// roughly a quarter without changing the authored or exported frame.
+		const pixelState = interactivePixelRatio.current;
+		if (navigatingCamera && !pixelState.reduced) {
+			pixelState.base = gl.getPixelRatio();
+			if (pixelState.base > 1) gl.setPixelRatio(1);
+			pixelState.reduced = true;
+			pixelState.needsFrozenRedraw = true;
+		} else if (!navigatingCamera && pixelState.reduced) {
+			gl.setPixelRatio(pixelState.base ?? 1);
+			pixelState.base = null;
+			pixelState.reduced = false;
+			pixelState.needsFrozenRedraw = false;
+		}
+		// setPixelRatio resizes the shared canvas and clears its old pixels. Paint
+		// frozen panes once, without ink, after that resize; later gesture frames
+		// can leave them untouched again.
+		const redrawFrozenPanes = navigatingCamera && pixelState.needsFrozenRedraw;
 		// Shadow maps are unchanged while only the camera moves. Three otherwise
 		// rebuilds every shadow map on every navigation frame, even though the
 		// poser scene is static, which is the largest hidden cost of right-drag.
@@ -322,6 +343,9 @@ export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCa
 				gl.autoClear = true;
 			}
 		};
+		const drawVisibleInset = (...args) => {
+			if (!insetCollapsed) draw(...args);
+		};
 
 		gl.autoClear = true;
 		shotCam.aspect = shotAspect;
@@ -359,10 +383,10 @@ export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCa
 			poserCam.aspect = mainRect.w / mainRect.h;
 			poserCam.updateProjectionMatrix();
 			draw(poserCam, mainRect, null, !navigatingCamera);
-			if (!navigatingCamera && !insetCollapsed) draw(shotCam, insetRect, fitAspect(insetRect, shotAspect));
+			if (!navigatingCamera || redrawFrozenPanes) drawVisibleInset(shotCam, insetRect, fitAspect(insetRect, shotAspect), !navigatingCamera);
 		} else if (planIsMain) {
 			draw(planCam, planPane, null, false);
-			if (!insetCollapsed) draw(shotCam, shotPane, fitAspect(shotPane, shotAspect));
+			if (!navigatingCamera || redrawFrozenPanes) drawVisibleInset(shotCam, shotPane, fitAspect(shotPane, shotAspect), !navigatingCamera);
 		} else if (editorCam && !lookThrough) {
 			// Split-camera editing: the main pane is the EDITOR camera — free
 			// navigation that never touches the recording. The shot camera only
@@ -370,22 +394,26 @@ export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCa
 			// stripped of editing chrome, exactly like an exported frame.
 			editorCam.aspect = mainRect.w / mainRect.h;
 			editorCam.updateProjectionMatrix();
-			draw(editorCam, mainRect);
-			if (!insetCollapsed) draw(planCam, planPane, null, false);
+			// A right-drag is a camera gesture even with IK off. Keep the main
+			// image readable while the camera is moving by deferring the expensive
+			// edge/ink pass until the gesture ends; the static panes stay frozen too.
+			draw(editorCam, mainRect, null, !navigatingCamera);
+			if (!navigatingCamera || redrawFrozenPanes) drawVisibleInset(planCam, planPane, null, false);
 			const previewEl = shotPreviewRef?.current;
-			if (previewEl && !previewEl.hidden) {
+			if (previewEl && !previewEl.hidden && (!navigatingCamera || redrawFrozenPanes)) {
 				const previewRect = rectOf(previewEl);
 				if (previewRect.w >= 2) {
 					const previewMask = shotCam.layers.mask;
 					shotCam.layers.disable(GIZMO_LAYER);
-					draw(shotCam, previewRect, fitAspect(previewRect, shotAspect));
+					draw(shotCam, previewRect, fitAspect(previewRect, shotAspect), !navigatingCamera);
 					shotCam.layers.mask = previewMask;
 				}
 			}
 		} else {
-			draw(shotCam, shotPane, fitAspect(shotPane, shotAspect));
-			if (!insetCollapsed) draw(planCam, planPane, null, false);
+			draw(shotCam, shotPane, fitAspect(shotPane, shotAspect), !navigatingCamera);
+			if (!navigatingCamera || redrawFrozenPanes) drawVisibleInset(planCam, planPane, null, false);
 		}
+		if (redrawFrozenPanes) pixelState.needsFrozenRedraw = false;
 
 		gl.setScissorTest(false);
 		gl.setViewport(0, 0, size.width, size.height);

--- a/src/posestudio.jsx
+++ b/src/posestudio.jsx
@@ -291,6 +291,7 @@ export function IkHandles({ chains, fkJoints, ikState, enabled, focus, onFocus, 
 	const poseInputRef = useRef({ values: [], count: 0, valid: false });
 	const exposurePerfRef = useRef({ passes: 0, skippedFrames: 0, raycasts: 0, lastPassMs: 0 });
 	const exposureLastPassAt = useRef(0);
+	const cameraGestureRef = useRef(false);
 	const blockerRefs = useRef([]);
 	const skinnedBlockerProxiesRef = useRef(new Map());
 	const occlusionRay = useRef(new THREE.Raycaster()).current;
@@ -510,73 +511,87 @@ export function IkHandles({ chains, fkJoints, ikState, enabled, focus, onFocus, 
 		// track's visibilityDepth describes its legitimate under-skin depth.
 		// Centreline torso/head controls get enough allowance to stay usable,
 		// while a far-side shoulder or limb remains hidden behind the body.
-		camera.updateMatrixWorld();
-		camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
-		camera.getWorldPosition(tmp.cameraPos);
 		const blockers = blockerRefs.current;
-		blockers.length = 0;
 		const input = exposureInputRef.current;
 		const poseInput = poseInputRef.current;
-		let inputIndex = 0;
-		let poseInputIndex = 0;
-		let exposureDirty = !input.valid;
-		let poseDirty = !poseInput.valid;
-		const captureInput = (value) => {
-			if (Math.abs((input.values[inputIndex] ?? Infinity) - value) > 1e-6) exposureDirty = true;
-			input.values[inputIndex] = value;
-			inputIndex += 1;
-		};
-		const capturePoseInput = (value) => {
-			captureInput(value);
-			if (Math.abs((poseInput.values[poseInputIndex] ?? Infinity) - value) > 1e-6) poseDirty = true;
-			poseInput.values[poseInputIndex] = value;
-			poseInputIndex += 1;
-		};
-		for (const value of camera.matrixWorld.elements) captureInput(value);
-		for (const mesh of Object.values(handleRefs.current)) {
-			if (!mesh?.parent) continue;
-			capturePoseInput(mesh.position.x);
-			capturePoseInput(mesh.position.y);
-			capturePoseInput(mesh.position.z);
-		}
-		scene.traverse((object) => {
-			if (!object.isMesh || !object.visible || object.layers.isEnabled(POSER_LAYER)) return;
-			const materials = Array.isArray(object.material) ? object.material : null;
-			let opaque = false;
-			if (materials) {
-				for (const material of materials) {
-					if (material && material.visible !== false && material.opacity > 0.01 && material.depthWrite !== false) {
-						opaque = true;
-						break;
+		const cameraGesture = typeof window !== "undefined" && window.__cozyclayCameraGesture === true;
+		const cameraGestureEnded = cameraGestureRef.current && !cameraGesture;
+		cameraGestureRef.current = cameraGesture;
+		if (cameraGesture) {
+			// Camera-only movement cannot change the rig silhouette. Keep the last
+			// exposure result and defer the expensive scene/proxy scan until release.
+			exposurePerfRef.current.skippedFrames += 1;
+		} else {
+			camera.updateMatrixWorld();
+			camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+			camera.getWorldPosition(tmp.cameraPos);
+			blockers.length = 0;
+			// A release must refresh visibility once even if the gesture was shorter
+			// than the normal 100 ms exposure throttle window.
+			if (cameraGestureEnded) input.valid = false;
+			let inputIndex = 0;
+			let poseInputIndex = 0;
+			let exposureDirty = !input.valid;
+			let poseDirty = !poseInput.valid;
+			const captureInput = (value) => {
+				if (Math.abs((input.values[inputIndex] ?? Infinity) - value) > 1e-6) exposureDirty = true;
+				input.values[inputIndex] = value;
+				inputIndex += 1;
+			};
+			const capturePoseInput = (value) => {
+				captureInput(value);
+				if (Math.abs((poseInput.values[poseInputIndex] ?? Infinity) - value) > 1e-6) poseDirty = true;
+				poseInput.values[poseInputIndex] = value;
+				poseInputIndex += 1;
+			};
+			for (const value of camera.matrixWorld.elements) captureInput(value);
+			for (const mesh of Object.values(handleRefs.current)) {
+				if (!mesh?.parent) continue;
+				capturePoseInput(mesh.position.x);
+				capturePoseInput(mesh.position.y);
+				capturePoseInput(mesh.position.z);
+			}
+			scene.traverse((object) => {
+				// Lines are editor overlays, not opaque geometry. Treating drei's
+				// Line2/LineSegments2 as blockers invokes its screen-space raycast
+				// without a camera and throws on every exposure pass.
+				if (!object.isMesh || object.isLine || object.isLine2 || object.isLineSegments2 || !object.visible || object.layers.isEnabled(POSER_LAYER)) return;
+				const materials = Array.isArray(object.material) ? object.material : null;
+				let opaque = false;
+				if (materials) {
+					for (const material of materials) {
+						if (material && material.visible !== false && material.opacity > 0.01 && material.depthWrite !== false) {
+							opaque = true;
+							break;
+						}
+					}
+				} else {
+					const material = object.material;
+					opaque = !!material && material.visible !== false && material.opacity > 0.01 && material.depthWrite !== false;
+				}
+				if (!opaque) return;
+				blockers.push(object);
+				captureInput(object.id);
+				for (const value of object.matrixWorld.elements) {
+					if (object.isSkinnedMesh) capturePoseInput(value);
+					else captureInput(value);
+				}
+				for (const value of object.morphTargetInfluences ?? []) capturePoseInput(value);
+				if (object.isSkinnedMesh) {
+					// Handle centres do not reveal an in-place joint rotation
+					// (notably a head turn), so every skinning bone participates
+					// in the proxy-bake signature.
+					for (const bone of object.skeleton?.bones ?? []) {
+						for (const value of bone.matrixWorld.elements) capturePoseInput(value);
 					}
 				}
-			} else {
-				const material = object.material;
-				opaque = !!material && material.visible !== false && material.opacity > 0.01 && material.depthWrite !== false;
-			}
-			if (!opaque) return;
-			blockers.push(object);
-			captureInput(object.id);
-			for (const value of object.matrixWorld.elements) {
-				if (object.isSkinnedMesh) capturePoseInput(value);
-				else captureInput(value);
-			}
-			for (const value of object.morphTargetInfluences ?? []) capturePoseInput(value);
-			if (object.isSkinnedMesh) {
-				// Handle centres do not reveal an in-place joint rotation
-				// (notably a head turn), so every skinning bone participates
-				// in the proxy-bake signature.
-				for (const bone of object.skeleton?.bones ?? []) {
-					for (const value of bone.matrixWorld.elements) capturePoseInput(value);
-				}
-			}
-		});
-		if (input.count !== inputIndex) exposureDirty = true;
-		input.count = inputIndex;
-		input.values.length = inputIndex;
-		if (poseInput.count !== poseInputIndex) poseDirty = true;
-		poseInput.count = poseInputIndex;
-		poseInput.values.length = poseInputIndex;
+			});
+			if (input.count !== inputIndex) exposureDirty = true;
+			input.count = inputIndex;
+			input.values.length = inputIndex;
+			if (poseInput.count !== poseInputIndex) poseDirty = true;
+			poseInput.count = poseInputIndex;
+			poseInput.values.length = poseInputIndex;
 
 		// Camera navigation changes the input signature every frame, but the
 		// character silhouette and all handle positions are unchanged. Running
@@ -586,7 +601,7 @@ export function IkHandles({ chains, fkJoints, ikState, enabled, focus, onFocus, 
 		// this still follows a slow orbit without making every pointer sample
 		// pay the full proxy cost.
 		const cameraOnlyExposure = exposureDirty && !poseDirty;
-		const exposureThrottled = cameraOnlyExposure && performance.now() - exposureLastPassAt.current < 100;
+		const exposureThrottled = !cameraGestureEnded && cameraOnlyExposure && performance.now() - exposureLastPassAt.current < 100;
 		if (exposureThrottled) {
 			exposurePerfRef.current.skippedFrames += 1;
 		} else if (exposureDirty) {
@@ -687,8 +702,9 @@ export function IkHandles({ chains, fkJoints, ikState, enabled, focus, onFocus, 
 			exposurePerfRef.current.raycasts += Object.keys(handleRefs.current).length;
 			exposurePerfRef.current.lastPassMs = performance.now() - passStartedAt;
 			exposureLastPassAt.current = performance.now();
-		} else {
-			exposurePerfRef.current.skippedFrames += 1;
+			} else {
+				exposurePerfRef.current.skippedFrames += 1;
+			}
 		}
 
 		let near = Infinity;

--- a/src/styles.css
+++ b/src/styles.css
@@ -9012,3 +9012,40 @@ input[type=range] {
 	color: var(--muted, #9a9a9a);
 	font-size: 12px;
 }
+
+/* ------------------------------------------- preserve (inpainting) -------- */
+/* The "keep the current take" strength, in the Prompt Blocks panel. Same shape
+   as .trail-falloff-row — flat range plus a tabular readout — with one state
+   that row does not have: a root path owns the whole rollout, so the slider is
+   GRAYED rather than removed while waypoint mode is on. Removing it would take
+   the explanation away with it; the disabled control still carries its title.
+   Appended at the end on purpose: the global input[type=range] rules further up
+   the cascade (the Unity density and widget-material passes) would otherwise
+   win over anything written beside the trail row. */
+.preserve-strength-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.preserve-strength-row input[type="range"] {
+	flex: 1;
+	min-width: 0;
+}
+.preserve-strength-row input[type="range"]:disabled {
+	opacity: .35;
+	cursor: not-allowed;
+}
+.preserve-strength-value {
+	font-variant-numeric: tabular-nums;
+	opacity: .8;
+}
+.preserve-strength-row[data-disabled="true"] .preserve-strength-value {
+	opacity: .35;
+}
+/* Both poles on one line, each at the end it describes. */
+.preserve-strength-scale {
+	display: flex;
+	justify-content: space-between;
+	gap: 8px;
+	margin-top: 3px;
+}

--- a/test/verify-kimodo-preserve.mjs
+++ b/test/verify-kimodo-preserve.mjs
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { buildPreserveMask, preserveMaskStats, PRESERVE_MASK_VERSION } from "../tools/kimodo/preserve-mask.mjs";
+
+function pass(label) { console.log(`PASS ${label}`); }
+const near = (a, b, tol = 1e-9) => Math.abs(a - b) <= tol;
+
+// Scheduled inpainting preserves an existing take and regenerates only what the
+// user edited. The mask is the ONLY thing standing between "the edit is smoothly
+// blended into the old take" and "the character snaps at the seam", so every
+// assertion below pins one property the blend depends on: frame space, the shape
+// of the shoulder, how overlaps combine, and the clip's own edges.
+const APP_FPS = 20;
+const GEN_FPS = 30;
+
+// The Gaussian the module builds, restated independently so the tests compare
+// against the CONTRACT rather than against whatever the implementation did.
+const shoulder = (distance, radius) => 1 - Math.exp(-(distance * distance) / (2 * (radius / 2) ** 2));
+
+// ---- no edits at all: pure reconstruction ---------------------------------
+// This is acceptance gate G1 (no edits + strength 0.5 must reproduce the base
+// take). An empty edit list is therefore VALID input, not an error, and must
+// mean "preserve everything".
+{
+	const mask = buildPreserveMask([], { appFps: APP_FPS, genFps: GEN_FPS, genFrames: 180 });
+	assert.equal(mask.version, PRESERVE_MASK_VERSION, "the emitted mask must declare the v1 schema");
+	assert.equal(mask.version, 1);
+	assert.equal(mask.genFps, GEN_FPS);
+	assert.equal(mask.genFrames, 180);
+	assert.equal(mask.weights.length, 180, "weights must be dense, one per generation frame");
+	assert.ok(mask.weights.every((weight) => weight === 1), "with no edits every frame is fully preserved");
+	assert.deepEqual(preserveMaskStats(mask), { freeFrames: 0, preservedFrames: 180, rampFrames: 0 });
+	pass("an empty edit list preserves the whole take");
+}
+
+// ---- one edit zeroes its span and grows symmetric shoulders ----------------
+// Inside the edit the model must be completely free (weight 0) or the user's
+// change cannot happen; outside it the influence has to decay smoothly and
+// identically in both directions, or the seam is asymmetric and the character
+// leans into one side of the edit.
+{
+	const mask = buildPreserveMask([{ startFrame: 40, endFrame: 80 }], {
+		appFps: APP_FPS,
+		genFps: GEN_FPS,
+		genFrames: 180,
+	});
+	// The edit is free end to end.
+	for (let frame = 60; frame < 120; frame += 1) {
+		assert.equal(mask.weights[frame], 0, `frame ${frame} is inside the edit and must be free`);
+	}
+	// The shoulders match the documented Gaussian exactly, one step out and ten.
+	assert.ok(near(mask.weights[59], shoulder(1, 10)), `leading shoulder at d=1, got ${mask.weights[59]}`);
+	assert.ok(near(mask.weights[120], shoulder(1, 10)), `trailing shoulder at d=1, got ${mask.weights[120]}`);
+	assert.ok(near(mask.weights[50], shoulder(10, 10)), `leading shoulder at d=10, got ${mask.weights[50]}`);
+	assert.ok(near(mask.weights[129], shoulder(10, 10)), `trailing shoulder at d=10, got ${mask.weights[129]}`);
+	// SYMMETRY: frame `start - k` must equal frame `(end - 1) + k`. The exclusive
+	// end is the classic off-by-one here; asymmetry means the trailing shoulder
+	// is shifted a frame relative to the leading one.
+	for (let step = 1; step <= 40; step += 1) {
+		assert.ok(
+			near(mask.weights[60 - step], mask.weights[119 + step]),
+			`shoulders must be symmetric at step ${step}: ${mask.weights[60 - step]} vs ${mask.weights[119 + step]}`
+		);
+	}
+	// The shoulder is monotone: influence only ever fades as you move away.
+	for (let frame = 120; frame < 179; frame += 1) {
+		assert.ok(
+			mask.weights[frame + 1] >= mask.weights[frame],
+			`the shoulder must not rise and fall; frame ${frame} -> ${frame + 1}`
+		);
+	}
+	// Far from the edit the base take is preserved untouched.
+	assert.equal(mask.weights[0], 1, "a frame far from the edit must be fully preserved");
+	assert.equal(mask.weights[179], 1, "a frame far from the edit must be fully preserved");
+	pass("a single edit zeroes its span and tapers symmetrically on both sides");
+}
+
+// ---- app frames scale onto the generation clock ---------------------------
+// CozyClay authors edits against the app's 20 fps clip; Kimodo generates at 30.
+// Skipping the scale would free the wrong two thirds of the take, and the rule
+// must be the SAME one buildRoot2dConstraints uses or a waypoint and an edit
+// authored on the same app frame land on different generation frames.
+{
+	const mask = buildPreserveMask([{ startFrame: 40, endFrame: 80 }], {
+		appFps: APP_FPS,
+		genFps: GEN_FPS,
+		genFrames: 180,
+	});
+	// app [40, 80) @ 20 fps -> gen [60, 120) @ 30 fps, half-open at both ends.
+	assert.notEqual(mask.weights[59], 0, "gen frame 59 is before the edit and must not be free");
+	assert.equal(mask.weights[60], 0, "app frame 40 @20fps must free gen frame 60 @30fps");
+	assert.equal(mask.weights[119], 0, "the last frame of the edit is end-1 = 119");
+	assert.notEqual(mask.weights[120], 0, "the range is half-open: gen frame 120 is outside the edit");
+	// A 1:1 clock must not move anything at all.
+	const unscaled = buildPreserveMask([{ startFrame: 10, endFrame: 20 }], {
+		appFps: 30,
+		genFps: 30,
+		genFrames: 60,
+	});
+	assert.equal(unscaled.weights[9] === 0, false);
+	assert.equal(unscaled.weights[10], 0, "with appFps == genFps the frames pass through unchanged");
+	assert.equal(unscaled.weights[19], 0);
+	assert.equal(unscaled.weights[20] === 0, false);
+	pass("20 fps app ranges scale onto 30 fps generation frames");
+}
+
+// ---- overlapping edits take the MINIMUM weight -----------------------------
+// Two shoulders meeting in a gap must not add up to more preservation than
+// either edit asked for on its own. Min is the only rule that keeps the mask
+// monotone in the number of edits: adding an edit can never preserve a frame
+// harder than it was before.
+{
+	const options = { appFps: 30, genFps: 30, genFrames: 120 };
+	const first = buildPreserveMask([{ startFrame: 30, endFrame: 40 }], options);
+	const second = buildPreserveMask([{ startFrame: 50, endFrame: 60 }], options);
+	const both = buildPreserveMask(
+		[{ startFrame: 30, endFrame: 40 }, { startFrame: 50, endFrame: 60 }],
+		options
+	);
+	for (let frame = 0; frame < 120; frame += 1) {
+		assert.ok(
+			near(both.weights[frame], Math.min(first.weights[frame], second.weights[frame])),
+			`frame ${frame} must take the minimum of the two edits, got ${both.weights[frame]}`
+		);
+		assert.ok(both.weights[frame] <= first.weights[frame], `adding an edit must never raise frame ${frame}`);
+	}
+	// Both spans are still fully free, and the gap between them is a blend, not a
+	// preserved island.
+	for (const frame of [30, 39, 50, 59]) assert.equal(both.weights[frame], 0, `frame ${frame} is inside an edit`);
+	assert.ok(both.weights[45] > 0 && both.weights[45] < 1, "the gap between two edits stays a partial blend");
+	// Literally overlapping ranges collapse into one continuous free span.
+	const merged = buildPreserveMask(
+		[{ startFrame: 30, endFrame: 45 }, { startFrame: 40, endFrame: 60 }],
+		options
+	);
+	for (let frame = 30; frame < 60; frame += 1) {
+		assert.equal(merged.weights[frame], 0, `overlapping edits must free the whole union, frame ${frame}`);
+	}
+	pass("overlapping edits combine by minimum weight");
+}
+
+// ---- an edit on the clip's first frame ------------------------------------
+// The shoulder would like to extend before frame 0. There is nothing there to
+// preserve, so it must simply be absent rather than shifted inward (which would
+// preserve frames the user actually edited).
+{
+	const mask = buildPreserveMask([{ startFrame: 0, endFrame: 10 }], {
+		appFps: 30,
+		genFps: 30,
+		genFrames: 60,
+	});
+	assert.equal(mask.weights.length, 60, "a clipped shoulder must not change the mask length");
+	for (let frame = 0; frame < 10; frame += 1) assert.equal(mask.weights[frame], 0, `frame ${frame} is edited`);
+	assert.ok(near(mask.weights[10], shoulder(1, 10)), "only the trailing shoulder exists");
+	assert.ok(mask.weights.every((weight) => Number.isFinite(weight)), "clipping must not produce NaN");
+	pass("an edit touching frame 0 has no leading shoulder and no out-of-range frames");
+}
+
+// ---- an edit on the clip's last frame -------------------------------------
+// The exclusive end is the trap: clamping it to genFrames - 1 would silently
+// preserve the final frame even though the user edited right up to it.
+{
+	const mask = buildPreserveMask([{ startFrame: 50, endFrame: 60 }], {
+		appFps: 30,
+		genFps: 30,
+		genFrames: 60,
+	});
+	assert.equal(mask.weights.length, 60);
+	assert.equal(mask.weights[59], 0, "an edit running to the clip end must free the LAST frame");
+	assert.equal(mask.weights[50], 0);
+	assert.ok(near(mask.weights[49], shoulder(1, 10)), "only the leading shoulder exists");
+	// An edit that runs PAST the end still owns the frames it shares with the
+	// clip; clamping is the honest reading, dropping it would ignore the edit.
+	const overrun = buildPreserveMask([{ startFrame: 55, endFrame: 999 }], {
+		appFps: 30,
+		genFps: 30,
+		genFrames: 60,
+	});
+	assert.equal(overrun.weights.length, 60);
+	for (let frame = 55; frame < 60; frame += 1) assert.equal(overrun.weights[frame], 0, `frame ${frame} is edited`);
+	pass("an edit touching the last frame frees it and never ramps past the clip");
+}
+
+// ---- a range that rounds down to nothing still frees a frame --------------
+// A 60 fps app clock halves onto a 30 fps generation clock, so a one-frame edit
+// can round to an empty span. Collapsing it would drop the user's edit while
+// reporting success.
+{
+	const mask = buildPreserveMask([{ startFrame: 10, endFrame: 11 }], {
+		appFps: 60,
+		genFps: 30,
+		genFrames: 60,
+	});
+	assert.equal(mask.weights[5], 0, "a collapsed range must still free at least one generation frame");
+	assert.equal(preserveMaskStats(mask).freeFrames, 1);
+	pass("a range that rounds onto a single generation frame is not dropped");
+}
+
+// ---- the boundary must never be a hard step -------------------------------
+// The paper's ablation is explicit: a square kernel breaks motion at the seam.
+// The per-frame delta at a range boundary is the direct measure of that, so it
+// is asserted rather than assumed.
+{
+	const mask = buildPreserveMask([{ startFrame: 40, endFrame: 80 }], {
+		appFps: APP_FPS,
+		genFps: GEN_FPS,
+		genFrames: 180,
+	});
+	let maxDelta = 0;
+	for (let frame = 0; frame < mask.weights.length - 1; frame += 1) {
+		maxDelta = Math.max(maxDelta, Math.abs(mask.weights[frame + 1] - mask.weights[frame]));
+	}
+	assert.ok(maxDelta < 0.5, `the default radius must never step; max per-frame delta was ${maxDelta}`);
+	// The step ACROSS the boundary itself is the smallest one in the whole ramp:
+	// the Gaussian is flattest at d = 0 and steepest around d = sigma, which is
+	// exactly the property that stops the character snapping where the edit ends.
+	const boundaryDelta = Math.abs(mask.weights[120] - mask.weights[119]);
+	assert.ok(near(boundaryDelta, shoulder(1, 10)), `the boundary step must be the Gaussian at d=1, got ${boundaryDelta}`);
+	assert.ok(boundaryDelta < 0.05, `the boundary step must be gentle, got ${boundaryDelta}`);
+	assert.ok(boundaryDelta < maxDelta, "the ramp must be steepest away from the seam, not at it");
+	// A narrow radius is steeper but still not a step.
+	const narrow = buildPreserveMask([{ startFrame: 40, endFrame: 80 }], {
+		appFps: APP_FPS,
+		genFps: GEN_FPS,
+		genFrames: 180,
+		influenceRadius: 2,
+	});
+	let narrowMax = 0;
+	for (let frame = 0; frame < narrow.weights.length - 1; frame += 1) {
+		narrowMax = Math.max(narrowMax, Math.abs(narrow.weights[frame + 1] - narrow.weights[frame]));
+	}
+	assert.ok(narrowMax < 0.5, `even a 2-frame radius must taper, max delta ${narrowMax}`);
+	pass("the boundary tapers: max per-frame delta stays well under a step");
+}
+
+// ---- influenceRadius 0 is the opt-in hard edge ----------------------------
+// The broken case from the paper is kept REACHABLE so it can be measured
+// (tools/kimodo/measure-preserve.mjs) and so a caller that smooths its own seam
+// can opt out. It is never the default, and this test documents what it costs.
+{
+	const mask = buildPreserveMask([{ startFrame: 30, endFrame: 40 }], {
+		appFps: 30,
+		genFps: 30,
+		genFrames: 90,
+		influenceRadius: 0,
+	});
+	assert.ok(
+		mask.weights.every((weight) => weight === 0 || weight === 1),
+		"radius 0 must produce a binary mask with no ramp at all"
+	);
+	assert.deepEqual(preserveMaskStats(mask), { freeFrames: 10, preservedFrames: 80, rampFrames: 0 });
+	// ...and this is exactly the full step the default radius avoids.
+	assert.equal(Math.abs(mask.weights[30] - mask.weights[29]), 1, "radius 0 steps a full 1.0 at the boundary");
+	pass("influenceRadius 0 gives the documented hard edge (caller opt-out)");
+}
+
+// ---- structural invariants the Python side relies on -----------------------
+// generate.py reads this file straight off disk; a short array or a value
+// outside [0,1] would become a blend coefficient that amplifies instead of
+// mixing, which is a silent corruption rather than a crash.
+{
+	for (const genFrames of [1, 7, 60, 181]) {
+		const mask = buildPreserveMask([{ startFrame: 0, endFrame: 1 }], { appFps: 30, genFps: 30, genFrames });
+		assert.equal(mask.weights.length, genFrames, `weights must be exactly genFrames long for ${genFrames}`);
+		assert.equal(mask.genFrames, genFrames, "the declared genFrames must match the array length");
+		assert.ok(
+			mask.weights.every((weight) => Number.isFinite(weight) && weight >= 0 && weight <= 1),
+			`every weight must be finite in [0,1] for genFrames ${genFrames}`
+		);
+	}
+	const mask = buildPreserveMask([{ startFrame: 10, endFrame: 20 }], { appFps: 20, genFps: 30, genFrames: 120 });
+	const roundTrip = JSON.parse(JSON.stringify(mask));
+	assert.deepEqual(roundTrip, mask, "the mask must survive a JSON round trip unchanged");
+	assert.deepEqual(
+		Object.keys(roundTrip).sort(),
+		["genFps", "genFrames", "version", "weights"],
+		"v1 emits exactly the C1 keys; jointWeights is reserved for v2 and must not appear"
+	);
+	pass("the emitted mask matches the C1 v1 schema and round trips through JSON");
+}
+
+// ---- preserveMaskStats reports what the run will actually do --------------
+// The UI needs to tell the user how much of their take is being regenerated. A
+// run whose ramp dwarfs its free span means the shoulders are wider than the
+// edit and the "preserved" take will drift almost everywhere.
+{
+	const mask = buildPreserveMask([{ startFrame: 100, endFrame: 110 }], {
+		appFps: 30,
+		genFps: 30,
+		genFrames: 300,
+	});
+	const stats = preserveMaskStats(mask);
+	assert.equal(stats.freeFrames, 10, "exactly the edited frames are free");
+	assert.ok(stats.rampFrames > 0, "a default-radius edit must produce a blend region");
+	assert.ok(stats.preservedFrames > 0, "frames far from the edit must stay fully preserved");
+	assert.equal(
+		stats.freeFrames + stats.rampFrames + stats.preservedFrames,
+		300,
+		"every frame must be counted exactly once"
+	);
+	// The bare array form is accepted too, so callers holding only the weights
+	// (the Python-side reader, the measurement tool) need not rebuild the object.
+	assert.deepEqual(preserveMaskStats(mask.weights), stats);
+	assert.throws(() => preserveMaskStats(null), /weights array/);
+	assert.throws(() => preserveMaskStats({ weights: [0, Number.NaN] }), /finite/);
+	pass("preserveMaskStats counts free, ramp and preserved frames");
+}
+
+// ---- every validation path fails loudly and by name ------------------------
+// A malformed mask does not crash Kimodo — it produces a plausible-looking take
+// that quietly ignores the user's edit, so bad input must never reach the file.
+{
+	const opts = { appFps: APP_FPS, genFps: GEN_FPS, genFrames: 180 };
+	const range = [{ startFrame: 10, endFrame: 20 }];
+
+	// editRanges itself
+	assert.throws(() => buildPreserveMask(undefined, opts), /editRanges must be an array/);
+	assert.throws(() => buildPreserveMask(null, opts), /editRanges must be an array/);
+	assert.throws(() => buildPreserveMask("40:80", opts), /editRanges must be an array/);
+	assert.throws(() => buildPreserveMask({ startFrame: 0, endFrame: 5 }, opts), /editRanges must be an array/);
+
+	// individual entries
+	assert.throws(() => buildPreserveMask([null], opts), /editRanges\[0\] must be an object/);
+	assert.throws(() => buildPreserveMask([{ startFrame: -1, endFrame: 5 }], opts), /startFrame/);
+	assert.throws(() => buildPreserveMask([{ startFrame: 1.5, endFrame: 5 }], opts), /startFrame/);
+	assert.throws(() => buildPreserveMask([{ startFrame: 0, endFrame: null }], opts), /endFrame/);
+	assert.throws(() => buildPreserveMask([{ startFrame: 0, endFrame: 2.5 }], opts), /endFrame/);
+	assert.throws(() => buildPreserveMask([{ startFrame: 0, endFrame: -3 }], opts), /endFrame/);
+	// inverted and empty half-open ranges edit nothing; accepting them would look
+	// like a working reconstruction while dropping the user's edit.
+	assert.throws(() => buildPreserveMask([{ startFrame: 80, endFrame: 40 }], opts), /non-empty half-open range/);
+	assert.throws(() => buildPreserveMask([{ startFrame: 40, endFrame: 40 }], opts), /non-empty half-open range/);
+
+	// a range with no overlap at all names the clip length so the caller can see
+	// it built the mask against the wrong take's duration.
+	assert.throws(
+		() => buildPreserveMask([{ startFrame: 500, endFrame: 600 }], opts),
+		/outside the 180-frame clip/
+	);
+	assert.throws(
+		() => buildPreserveMask([{ startFrame: 0, endFrame: 4 }], { appFps: 1000, genFps: 1, genFrames: 180 }),
+		/outside the 180-frame clip/
+	);
+
+	// clocks and clip length
+	assert.throws(() => buildPreserveMask(range, { ...opts, appFps: 0 }), /appFps/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, appFps: -20 }), /appFps/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, genFps: Number.NaN }), /genFps/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, genFps: "30" }), /genFps/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, genFrames: 0 }), /genFrames/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, genFrames: Number.POSITIVE_INFINITY }), /genFrames/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, genFrames: undefined }), /genFrames/);
+
+	// influence radius
+	assert.throws(() => buildPreserveMask(range, { ...opts, influenceRadius: -1 }), /influenceRadius/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, influenceRadius: 2.5 }), /influenceRadius/);
+	assert.throws(() => buildPreserveMask(range, { ...opts, influenceRadius: null }), /influenceRadius/);
+	pass("every malformed edit list, clock and radius is refused by name");
+}
+
+console.log("OK verify-kimodo-preserve");

--- a/test/verify-preserve-bridge.mjs
+++ b/test/verify-preserve-bridge.mjs
@@ -188,12 +188,20 @@ const OUTPUT = "/runs/generate-xyz/generated.npz";
 	const bridgeSource = readFileSync(new URL("tools/ardy/bridge.mjs", REPO), "utf8");
 	assert.match(bridgeSource, /const PRESERVE_SIGMA_MAX = 1000;/);
 	assert.match(bridgeSource, /const PRESERVE_SIGMA_END_CAP = 50;/);
-	assert.match(bridgeSource, /const sigmaS = Math\.round\(PRESERVE_SIGMA_MAX \* strength\);/);
+	// INVERTED mapping: a smaller sigma_s preserves MORE (alpha_time is 1 above
+	// sigma_s), measured on the box in gate G3. Full strength floors at the end
+	// cap instead of rounding sigma_s to 0, which would read as preserve-off.
+	assert.match(
+		bridgeSource,
+		/const sigmaS = Math\.max\(PRESERVE_SIGMA_END_CAP, Math\.round\(PRESERVE_SIGMA_MAX \* \(1 - strength\)\)\);/,
+	);
 	assert.match(bridgeSource, /sigmaE: Math\.min\(PRESERVE_SIGMA_END_CAP, sigmaS\)/);
-	// The contract's default: strength 0.5 -> 500/50.
-	assert.equal(Math.round(1000 * 0.5), 500);
-	assert.equal(Math.min(50, Math.round(1000 * 0.5)), 50);
-	pass("strength maps to sigma_s = round(1000*s) with sigma_e capped at 50");
+	// The contract's default is unchanged by the inversion: strength 0.5 -> 500/50.
+	assert.equal(Math.max(50, Math.round(1000 * (1 - 0.5))), 500);
+	assert.equal(Math.min(50, 500), 50);
+	// Full preserve is a step schedule, not preserve-off.
+	assert.equal(Math.max(50, Math.round(1000 * (1 - 1))), 50);
+	pass("strength maps to sigma_s = max(50, round(1000*(1-s))) with sigma_e capped at 50");
 }
 
 /* ------------------------------------------------------------------------- */

--- a/test/verify-preserve-bridge.mjs
+++ b/test/verify-preserve-bridge.mjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+
+// Scheduled inpainting, wired end to end (contract C3).
+//
+// tools/kimodo/preserve-mask.mjs owns the mask itself and is pinned by
+// verify-kimodo-preserve.mjs. THIS file pins the wiring around it: what the
+// bridge accepts and refuses, how a preserve request reaches the Kimodo box,
+// and the one arithmetic rule that decides whether the box accepts the mask at
+// all.
+//
+// The bridge's validator cannot be imported — bridge.mjs binds a socket on
+// load — so it is exercised the way a client sees it: a real sidecar on a
+// loopback port, one POST per rule, asserting the reason string names the
+// field it refused.
+
+import assert from "node:assert/strict";
+import { fork } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createKimodoRunner, nativeMotionPath, preserveMaskPath } from "../tools/kimodo/runner.mjs";
+import { cliGenFrames, generateOnBox } from "../tools/kimodo/generate.mjs";
+
+function pass(label) { console.log(`PASS ${label}`); }
+
+const REPO = new URL("..", import.meta.url);
+const HERE = dirname(fileURLToPath(import.meta.url));
+const READY_TIMEOUT_MS = 15_000;
+
+/* ------------------------------------------------------------------------- */
+/* the generated frame count the mask is sized against                        */
+/* ------------------------------------------------------------------------- */
+// kimodo/scripts/generate.py does `int(duration_sec * fps)` and then REFUSES a
+// mask whose genFrames differs by one. Rounding instead of truncating is the
+// single silent way to fail every preserve run on a clip whose length lands on
+// a half frame, so the rule is pinned against the CLI's arithmetic, not ours.
+{
+	assert.equal(cliGenFrames(5, 30), 150, "a whole number of seconds is exact either way");
+	assert.equal(cliGenFrames(119 / 24, 30), 148, "148.75 generation frames truncate to 148, not 149");
+	assert.notEqual(cliGenFrames(119 / 24, 30), Math.round((119 / 24) * 30), "rounding would disagree with the box");
+	// 196 app frames is 8.166666666666666 s, and that times 30 is
+	// 244.99999999999997 in IEEE-754 — on BOTH sides. Python's int() takes 244
+	// and Math.trunc reproduces it; rounding would ask the box for 245 frames of
+	// mask against a 244-frame clip and the run would die there.
+	assert.equal(cliGenFrames(196 / 24, 30), 244, "a product a hair below an integer truncates down on both sides");
+	assert.equal(Math.round((196 / 24) * 30), 245, "...where rounding lands one frame too high");
+	assert.equal(cliGenFrames(2, 30), 60);
+	pass("the mask is sized with the CLI's truncation, not with rounding");
+}
+
+/* ------------------------------------------------------------------------- */
+/* the runner: how preserve reaches the box, and what it keeps for next time   */
+/* ------------------------------------------------------------------------- */
+const SAVED_ENV = { ...process.env };
+const RUNNER_KEYS = ["CCLAY_KIMODO_HOST", "CCLAY_KIMODO_PRESERVE", "CCLAY_KIMODO_NATIVE_OUT"];
+function withEnv(env, body) {
+	for (const key of RUNNER_KEYS) delete process.env[key];
+	Object.assign(process.env, env);
+	try {
+		return body();
+	} finally {
+		for (const key of RUNNER_KEYS) delete process.env[key];
+		Object.assign(process.env, SAVED_ENV);
+	}
+}
+
+const PRESERVE = {
+	basePath: "/runs/generate-abc/generated.kimodo.npz",
+	sigmaS: 500,
+	sigmaE: 50,
+	editRanges: [{ startFrame: 40, endFrame: 80 }],
+};
+const OUTPUT = "/runs/generate-xyz/generated.npz";
+
+{
+	const runner = withEnv({ CCLAY_KIMODO_HOST: "user@kimodo-box" }, () => createKimodoRunner());
+
+	// The wrapper scripts' argv is a frozen contract shared with the ARDY
+	// wrappers, so preserve travels in the environment. An unknown flag would be
+	// a usage() exit, which is why this is asserted rather than assumed.
+	const preserved = runner.singleCommand({ prompt: "A person walks", durationS: 5, preserve: PRESERVE, output: OUTPUT });
+	assert.ok(!preserved.args.some((arg) => String(arg).startsWith("--preserve")), "preserve must not be smuggled onto argv");
+	const shipped = JSON.parse(preserved.env.CCLAY_KIMODO_PRESERVE);
+	assert.equal(shipped.basePath, PRESERVE.basePath);
+	assert.equal(shipped.sigmaS, 500);
+	assert.equal(shipped.sigmaE, 50);
+	assert.deepEqual(shipped.editRanges, PRESERVE.editRanges, "edit ranges reach the mask builder unchanged");
+	assert.equal(shipped.maskPath, preserveMaskPath(OUTPUT), "the mask is kept in the run directory");
+	assert.equal(shipped.maskPath, "/runs/generate-xyz/preserve-mask.json");
+	pass("a preserve request reaches the box through CCLAY_KIMODO_PRESERVE");
+
+	// Kimodo's --base_motion reads the npz its own generator wrote; the cskel27
+	// file the bridge serves is a conversion of it. Every whole-clip run keeps
+	// the native one beside its output so a LATER run can preserve from it.
+	const kept = runner.singleCommand({ prompt: "A person walks", durationS: 5, keepNative: true, output: OUTPUT });
+	assert.equal(kept.env.CCLAY_KIMODO_NATIVE_OUT, nativeMotionPath(OUTPUT));
+	assert.equal(kept.env.CCLAY_KIMODO_NATIVE_OUT, "/runs/generate-xyz/generated.kimodo.npz");
+	assert.equal(kept.env.CCLAY_KIMODO_PRESERVE, undefined, "keeping a base does not turn preservation on");
+	pass("a whole-clip run keeps Kimodo's own npz beside its take");
+
+	// An edit SPLICES its regenerated span into the source take, so the npz
+	// Kimodo wrote is not the take that comes out and must never become a base.
+	const edit = runner.editCommand({
+		source: "/runs/generate-abc/generated.npz",
+		manifest: "/runs/generate-xyz/edit-manifest.json",
+		prompt: "A person waves",
+		contextBefore: 8,
+		contextAfter: 8,
+		preserve: PRESERVE,
+		output: "/runs/generate-xyz/constrained.npz",
+	});
+	assert.equal(edit.env.CCLAY_KIMODO_NATIVE_OUT, undefined, "a spliced take must not be kept as a base motion");
+	assert.equal(JSON.parse(edit.env.CCLAY_KIMODO_PRESERVE).basePath, PRESERVE.basePath, "an edit can still preserve");
+	pass("an edit run preserves but never keeps a base of its own");
+
+	// The bridge is a long-lived sidecar: a value left over from the previous
+	// request would preserve the wrong take on this one, silently.
+	const stale = withEnv(
+		{
+			CCLAY_KIMODO_HOST: "user@kimodo-box",
+			CCLAY_KIMODO_PRESERVE: JSON.stringify(PRESERVE),
+			CCLAY_KIMODO_NATIVE_OUT: "/runs/stale/generated.kimodo.npz",
+		},
+		() => createKimodoRunner().singleCommand({ prompt: "A person walks", durationS: 5, output: OUTPUT }),
+	);
+	assert.equal(stale.env.CCLAY_KIMODO_PRESERVE, undefined, "an inherited preserve must not leak into a plain run");
+	assert.equal(stale.env.CCLAY_KIMODO_NATIVE_OUT, undefined, "an inherited native-out must not leak into a plain run");
+	pass("a plain generation clears both inherited preserve variables");
+
+	// The base clip refusal is unrelated machinery (autoregressive history) and
+	// must survive preserve landing next to it.
+	assert.throws(
+		() => runner.singleCommand({ prompt: "x", durationS: 1, basePath: "/base.npz", output: OUTPUT }),
+		/does not implement base clips/,
+		"the base-clip refusal must survive",
+	);
+	pass("preserve is supported while base clips still refuse by name");
+
+	// Resolving a take back to this backend's base motion.
+	const runDir = mkdtempSync(join(tmpdir(), "cclay-preserve-"));
+	try {
+		const take = join(runDir, "generated.npz");
+		writeFileSync(take, "cskel27");
+		assert.equal(runner.baseMotionFor(take), null, "a take with no native npz has no base motion");
+		writeFileSync(nativeMotionPath(take), "kimodo-native");
+		assert.equal(runner.baseMotionFor(take), join(runDir, "generated.kimodo.npz"));
+		pass("baseMotionFor finds the native npz beside a take, or reports none");
+	} finally {
+		rmSync(runDir, { recursive: true, force: true });
+	}
+}
+
+/* ------------------------------------------------------------------------- */
+/* generate.mjs refuses a preserve plan it cannot ship                         */
+/* ------------------------------------------------------------------------- */
+// Every one of these is caught before any ssh, so a bad plan costs nothing.
+{
+	const segments = [{ prompt: "A person walks", duration: 4 }];
+	const call = (preserve, extra = {}) =>
+		generateOnBox({ segments, host: "nobody@nowhere.invalid", preserve, ...extra });
+
+	await assert.rejects(
+		() => call({ ...PRESERVE }, { segments: [{ prompt: "A person walks", duration: 2 }, { prompt: "A person waves", duration: 2 }] }),
+		/single segment/,
+		"the box would refuse a prompt schedule; refuse it before the GPU is booked",
+	);
+	await assert.rejects(() => call({ ...PRESERVE, basePath: "" }), /basePath/);
+	await assert.rejects(() => call({ ...PRESERVE, sigmaS: 1500 }), /sigmaS must be an integer in 0\.\.1000/);
+	await assert.rejects(() => call({ ...PRESERVE, sigmaS: 12.5 }), /sigmaS must be an integer in 0\.\.1000/);
+	await assert.rejects(() => call({ ...PRESERVE, sigmaE: -1 }), /sigmaE must be an integer in 0\.\.1000/);
+	await assert.rejects(() => call({ ...PRESERVE, sigmaS: 400, sigmaE: 600 }), /must be <= preserve\.sigmaS/);
+	// A range outside the generated clip reaches the mask builder's own refusal.
+	await assert.rejects(() => call({ ...PRESERVE, editRanges: [{ startFrame: 9000, endFrame: 9100 }] }), /buildPreserveMask/);
+	pass("generate.mjs refuses an unshippable preserve plan before touching the box");
+}
+
+/* ------------------------------------------------------------------------- */
+/* the strength -> diffusion-time mapping                                      */
+/* ------------------------------------------------------------------------- */
+// Server-side by contract, and numeric: a client never speaks in diffusion-time
+// units, and the paper's recommended pair is 500/50. Reachable only through a
+// real generated take, so the formula is pinned against the source.
+{
+	const bridgeSource = readFileSync(new URL("tools/ardy/bridge.mjs", REPO), "utf8");
+	assert.match(bridgeSource, /const PRESERVE_SIGMA_MAX = 1000;/);
+	assert.match(bridgeSource, /const PRESERVE_SIGMA_END_CAP = 50;/);
+	assert.match(bridgeSource, /const sigmaS = Math\.round\(PRESERVE_SIGMA_MAX \* strength\);/);
+	assert.match(bridgeSource, /sigmaE: Math\.min\(PRESERVE_SIGMA_END_CAP, sigmaS\)/);
+	// The contract's default: strength 0.5 -> 500/50.
+	assert.equal(Math.round(1000 * 0.5), 500);
+	assert.equal(Math.min(50, Math.round(1000 * 0.5)), 50);
+	pass("strength maps to sigma_s = round(1000*s) with sigma_e capped at 50");
+}
+
+/* ------------------------------------------------------------------------- */
+/* the bridge validator, over the wire                                         */
+/* ------------------------------------------------------------------------- */
+
+function freePort() {
+	return new Promise((resolvePromise, reject) => {
+		const probe = createServer();
+		probe.once("error", reject);
+		probe.listen(0, "127.0.0.1", () => {
+			const { port } = probe.address();
+			probe.close((error) => (error ? reject(error) : resolvePromise(port)));
+		});
+	});
+}
+
+const port = await freePort();
+const bridge = fork(join(HERE, "..", "tools", "ardy", "bridge.mjs"), [], {
+	cwd: REPO,
+	env: {
+		...process.env,
+		CCLAY_MOTION_BACKEND: "kimodo",
+		CCLAY_KIMODO_HOST: "test@kimodo",
+		COZYCLAY_BRIDGE_PORT: String(port),
+	},
+	stdio: ["ignore", "ignore", "ignore", "ipc"],
+});
+
+let failures = 0;
+try {
+	const ready = await Promise.race([
+		once(bridge, "message"),
+		new Promise((_, reject) => setTimeout(() => reject(new Error("bridge did not report readiness")), READY_TIMEOUT_MS).unref()),
+	]);
+	assert.deepEqual(ready[0], { type: "cozyclay-bridge-ready", port });
+
+	// duration 5 s on the bridge's 24 fps clock = a 120-frame clip.
+	const CLIP_FRAMES = 120;
+	const MOTION = "/ardy/motions/1700000000000-abcdef";
+	const POSE = { schema: "cozyclay.pose.v1", root: [0, 0.9, 0] };
+	const FREE = { prompt: "A person walks", duration: 5, posePin: false };
+	const PINNED = { prompt: "A person walks", duration: 5, poses: [{ frame: 0, pose: POSE }] };
+	const OK_PRESERVE = { sourceMotion: MOTION, strength: 0.5, editRanges: [{ startFrame: 40, endFrame: 80 }] };
+
+	async function post(body) {
+		const response = await fetch(`http://127.0.0.1:${port}/ardy/generate`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+		// A refused request answers JSON; an accepted one opens an NDJSON stream.
+		const text = await response.text();
+		const first = text.split("\n").find(Boolean) ?? "";
+		return { status: response.status, ...JSON.parse(first) };
+	}
+
+	async function refuses(label, body, pattern) {
+		const { status, reason, message } = await post(body);
+		const said = reason ?? message ?? "";
+		try {
+			assert.equal(status, 400, `${label} must be refused with 400, got ${status} (${said})`);
+			assert.match(said, pattern, label);
+			pass(label);
+		} catch (error) {
+			failures += 1;
+			console.error(`FAIL ${error.message}`);
+		}
+	}
+
+	// ---- shape ------------------------------------------------------------
+	await refuses("preserve must be an object", { ...FREE, preserve: [] }, /field 'preserve' must be an object/);
+	await refuses("preserve must not be a string", { ...FREE, preserve: "yes" }, /field 'preserve' must be an object/);
+	await refuses("preserve must not be null", { ...FREE, preserve: null }, /field 'preserve' must be an object/);
+
+	// ---- sourceMotion: the same URL shape every other take reference uses ---
+	await refuses("sourceMotion is required", { ...FREE, preserve: { strength: 0.5, editRanges: [] } }, /'preserve\.sourceMotion'/);
+	await refuses(
+		"sourceMotion must be a motion URL",
+		{ ...FREE, preserve: { ...OK_PRESERVE, sourceMotion: "/etc/passwd" } },
+		/'preserve\.sourceMotion' must be a generated \/ardy\/motions\/<run-id> URL/,
+	);
+	await refuses(
+		"sourceMotion must carry a well-formed run id",
+		{ ...FREE, preserve: { ...OK_PRESERVE, sourceMotion: "/ardy/motions/../../etc" } },
+		/'preserve\.sourceMotion'/,
+	);
+
+	// ---- strength ---------------------------------------------------------
+	await refuses("strength is required", { ...FREE, preserve: { sourceMotion: MOTION, editRanges: [] } }, /'preserve\.strength'/);
+	await refuses("strength 0 means omit the field", { ...FREE, preserve: { ...OK_PRESERVE, strength: 0 } }, /'preserve\.strength'/);
+	await refuses("strength above 1", { ...FREE, preserve: { ...OK_PRESERVE, strength: 1.5 } }, /'preserve\.strength'/);
+	await refuses("strength must be a number", { ...FREE, preserve: { ...OK_PRESERVE, strength: "0.5" } }, /'preserve\.strength'/);
+	await refuses("strength must be finite", { ...FREE, preserve: { ...OK_PRESERVE, strength: Number.NaN } }, /'preserve\.strength'/);
+
+	// ---- editRanges -------------------------------------------------------
+	await refuses("editRanges is required", { ...FREE, preserve: { sourceMotion: MOTION, strength: 0.5 } }, /'preserve\.editRanges' must be an array/);
+	await refuses("editRanges must be an array", { ...FREE, preserve: { ...OK_PRESERVE, editRanges: {} } }, /'preserve\.editRanges' must be an array/);
+	await refuses(
+		"a range must be an object",
+		{ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [40] } },
+		/'preserve\.editRanges\[0\]' must be an object/,
+	);
+	await refuses(
+		"range frames must be integers",
+		{ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [{ startFrame: 40.5, endFrame: 80 }] } },
+		/'preserve\.editRanges\[0\]' startFrame and endFrame must be integers/,
+	);
+	await refuses(
+		"a range must be non-empty",
+		{ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [{ startFrame: 40, endFrame: 40 }] } },
+		/'preserve\.editRanges\[0\]' must be a non-empty half-open range inside 0\.\.120/,
+	);
+	await refuses(
+		"a range must not be inverted",
+		{ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [{ startFrame: 80, endFrame: 40 }] } },
+		/'preserve\.editRanges\[0\]'/,
+	);
+	await refuses(
+		"a range must not start before the clip",
+		{ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [{ startFrame: -1, endFrame: 40 }] } },
+		/'preserve\.editRanges\[0\]'/,
+	);
+	await refuses(
+		"a range must not run past the clip",
+		{ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [{ startFrame: 100, endFrame: 121 }] } },
+		/'preserve\.editRanges\[0\]' must be a non-empty half-open range inside 0\.\.120/,
+	);
+	await refuses(
+		"the offending range is named by index",
+		{ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [{ startFrame: 0, endFrame: 10 }, { startFrame: 10, endFrame: 10 }] } },
+		/'preserve\.editRanges\[1\]'/,
+	);
+
+	// ---- exclusivity ------------------------------------------------------
+	await refuses(
+		"preserve cannot ride with a prompt schedule",
+		{
+			...FREE,
+			segments: [
+				{ startFrame: 0, endFrame: 60, prompt: "A person walks" },
+				{ startFrame: 60, endFrame: CLIP_FRAMES, prompt: "A person waves" },
+			],
+			preserve: OK_PRESERVE,
+		},
+		/scheduled inpainting v1 supports a single segment/,
+	);
+	await refuses(
+		"preserve cannot ride with waypoints",
+		{
+			...FREE,
+			waypoints: [
+				{ frame: 0, x: 0, z: 0, heading: null },
+				{ frame: 60, x: 3, z: 0, heading: null },
+			],
+			preserve: OK_PRESERVE,
+		},
+		/'preserve' cannot be combined with waypoints/,
+	);
+	await refuses(
+		"preserve cannot ride with regenerateSegments",
+		{
+			...PINNED,
+			sourceMotion: MOTION,
+			regenerateSegments: [{ startFrame: 0, endFrame: 60, prompt: "A person walks" }],
+			preserve: OK_PRESERVE,
+		},
+		/'preserve' cannot be combined with regenerateSegments/,
+	);
+
+	// ---- accepted ---------------------------------------------------------
+	// Validation passing is proved by WHICH refusal comes next: the request gets
+	// past validateGenerate and dies resolving the take it names, which no
+	// synthetic run id can satisfy.
+	{
+		const { status, reason } = await post({ ...FREE, preserve: OK_PRESERVE });
+		assert.equal(status, 400);
+		assert.match(reason, /field 'preserve\.sourceMotion': unknown or expired motion "1700000000000-abcdef"/);
+		pass("a well-formed preserve passes validation and is resolved against the motion allowlist");
+	}
+	{
+		// An empty edit list is the whole-take reconstruction case (gate G1) and
+		// must not be mistaken for a missing field.
+		const { status, reason } = await post({ ...FREE, preserve: { ...OK_PRESERVE, editRanges: [] } });
+		assert.equal(status, 400);
+		assert.match(reason, /unknown or expired motion/);
+		pass("an empty edit list is valid: preserve the whole take");
+	}
+	{
+		// Overlapping ranges are legal; the mask combines them by minimum.
+		const overlapping = [{ startFrame: 20, endFrame: 60 }, { startFrame: 40, endFrame: 80 }];
+		const { reason } = await post({ ...FREE, preserve: { ...OK_PRESERVE, editRanges: overlapping } });
+		assert.match(reason, /unknown or expired motion/);
+		pass("overlapping edit ranges are accepted");
+	}
+	{
+		// The one combination the contract explicitly allows: an IK edit
+		// regenerates a span of the very take preserve is reconstructing.
+		const { status, reason } = await post({
+			...PINNED,
+			poses: undefined,
+			motionEdit: {
+				sourceMotion: MOTION,
+				startFrame: 10,
+				endFrame: 40,
+				contextBefore: 8,
+				contextAfter: 8,
+				edits: [{ frame: 20, tracks: ["hips"], pose: POSE }],
+			},
+			preserve: OK_PRESERVE,
+		});
+		assert.equal(status, 400);
+		assert.doesNotMatch(reason, /cannot be combined/, "motionEdit + preserve is the combination the feature exists for");
+		assert.match(reason, /unknown or expired motion/);
+		pass("preserve rides with motionEdit");
+	}
+	{
+		// Nothing above may have disturbed a request that carries no preserve.
+		const { status, reason } = await post({ ...FREE, duration: 0.05 });
+		assert.equal(status, 400);
+		assert.match(reason, /field 'duration' must be in /, "unrelated validation is unchanged");
+		pass("requests without preserve validate exactly as before");
+	}
+} finally {
+	bridge.kill("SIGTERM");
+}
+
+if (failures > 0) {
+	console.error(`${failures} preserve bridge check(s) failed`);
+	process.exit(1);
+}
+console.log("OK verify-preserve-bridge");

--- a/tools/ardy/bridge.mjs
+++ b/tools/ardy/bridge.mjs
@@ -22,6 +22,8 @@
  *  - every request field is validated before use: prompt length-capped,
  *    duration/dstFrame range-checked, base matched against the list the box
  *    actually reported, waypoints bounds/order-checked, body size-capped;
+ *    preserve object/range-checked against the clip and refused alongside the
+ *    modes it cannot mean anything with;
  *    posePin boolean-checked (default true = full-body pose constraint;
  *    false = path/prompt only, pose ignored, base optional - with waypoints
  *    and no base the box free-generates the base clip first, two-pass);
@@ -70,6 +72,18 @@ const MOTION_ALLOWLIST_MAX = 64; // newest runs only; evicted ids become stale 4
 // motions URL id to that shape keeps /ardy/motions/<run-id> predictable and
 // path-free (the id is a lookup key, never a path).
 const MOTION_ID = /^[0-9]+-[0-9a-f]{6}$/;
+// The same id embedded in the URL a client hands back to address a take it was
+// given. Every field that names an earlier take (motionEdit.sourceMotion,
+// regenerateSegments' sourceMotion, preserve.sourceMotion) matches THIS, so a
+// take that is addressable by one of them is addressable by all of them.
+const MOTION_URL = /^\/ardy\/motions\/[0-9]+-[0-9a-f]{6}$/;
+// Scheduled inpainting, contract C3: strength s in (0,1] maps to the diffusion
+// -time schedule the box blends over. sigma_s is where blending starts (high
+// noise, so the base's structure dominates) and sigma_e where the model is
+// left alone to finish; the end cap generalises the paper's recommended
+// 500/50 pair to any strength.
+const PRESERVE_SIGMA_MAX = 1000;
+const PRESERVE_SIGMA_END_CAP = 50;
 
 // The runner is the ONLY part of the bridge that knows where generation
 // actually happens. Selection (runners/index.mjs) is Kimodo-only; everything
@@ -235,7 +249,7 @@ function validateGenerate(body) {
 		if (body.segments !== undefined || body.waypoints !== undefined) {
 			return "field 'regenerateSegments' cannot be combined with segments or waypoints";
 		}
-		if (typeof body.sourceMotion !== "string" || !/^\/ardy\/motions\/[0-9]+-[0-9a-f]{6}$/.test(body.sourceMotion)) {
+		if (typeof body.sourceMotion !== "string" || !MOTION_URL.test(body.sourceMotion)) {
 			return "field 'sourceMotion' must be a generated /ardy/motions/<run-id> URL";
 		}
 	}
@@ -246,7 +260,7 @@ function validateGenerate(body) {
 		if (body.segments !== undefined || body.regenerateSegments !== undefined || body.waypoints !== undefined) {
 			return "field 'motionEdit' cannot be combined with segments, regenerateSegments, or waypoints";
 		}
-		if (typeof edit.sourceMotion !== "string" || !/^\/ardy\/motions\/[0-9]+-[0-9a-f]{6}$/.test(edit.sourceMotion)) {
+		if (typeof edit.sourceMotion !== "string" || !MOTION_URL.test(edit.sourceMotion)) {
 			return "field 'motionEdit.sourceMotion' must be a generated /ardy/motions/<run-id> URL";
 		}
 		if (
@@ -275,6 +289,10 @@ function validateGenerate(body) {
 	}
 	if (body.waypoints !== undefined) {
 		const error = validateWaypoints(body.waypoints, clipFrames);
+		if (error) return error;
+	}
+	if (body.preserve !== undefined) {
+		const error = validatePreserve(body, clipFrames);
 		if (error) return error;
 	}
 	if (body.seed !== undefined && (!Number.isInteger(body.seed) || body.seed < 0 || body.seed > SEED_MAX)) return `field 'seed' must be an integer in 0..${SEED_MAX}`;
@@ -325,6 +343,84 @@ function validateRegenerateSegments(segments, clipFrames) {
 		previousEnd = segment.endFrame;
 	}
 	return null;
+}
+
+// Scheduled inpainting (contract C3): reconstruct an existing take everywhere
+// the user did NOT edit, and regenerate only the edited spans.
+//
+// The bridge validates the request and maps `strength` onto the diffusion-time
+// schedule; it deliberately does NOT build the per-frame mask. That happens in
+// tools/kimodo/generate.mjs, the only layer that knows how many frames Kimodo
+// will actually produce (see preserveSigmas below and the note there).
+//
+// Returns an error message naming the offending field, or null when valid.
+function validatePreserve(body, clipFrames) {
+	const preserve = body.preserve;
+	if (!preserve || typeof preserve !== "object" || Array.isArray(preserve)) {
+		return "field 'preserve' must be an object";
+	}
+	if (typeof preserve.sourceMotion !== "string" || !MOTION_URL.test(preserve.sourceMotion)) {
+		return "field 'preserve.sourceMotion' must be a generated /ardy/motions/<run-id> URL";
+	}
+	// 0 is not "preserve nothing", it is "do not preserve": the field carries a
+	// base motion the backend would still load and blend at sigma_s 0. The
+	// caller drops the whole field instead, so the request says what it means.
+	if (
+		typeof preserve.strength !== "number" ||
+		!Number.isFinite(preserve.strength) ||
+		preserve.strength <= 0 ||
+		preserve.strength > 1
+	) {
+		return "field 'preserve.strength' must be a number greater than 0 and at most 1 (strength 0 is preserve off: omit 'preserve')";
+	}
+	if (!Array.isArray(preserve.editRanges)) {
+		return "field 'preserve.editRanges' must be an array (an EMPTY array means preserve the whole take)";
+	}
+	for (let i = 0; i < preserve.editRanges.length; i += 1) {
+		const range = preserve.editRanges[i];
+		if (!range || typeof range !== "object" || Array.isArray(range)) {
+			return `field 'preserve.editRanges[${i}]' must be an object`;
+		}
+		if (!Number.isInteger(range.startFrame) || !Number.isInteger(range.endFrame)) {
+			return `field 'preserve.editRanges[${i}]' startFrame and endFrame must be integers`;
+		}
+		// Half-open, non-empty and inside the clip. That last bound is also what
+		// makes every range intersect the clip: a range the take does not contain
+		// cannot be scaled onto the generation clock without freeing frames at one
+		// end that the user never edited, so the mask builder refuses it too.
+		// Overlaps between ranges are NOT refused — the mask combines them by
+		// minimum, so two overlapping edits mean the same thing as one.
+		if (range.startFrame < 0 || range.endFrame <= range.startFrame || range.endFrame > clipFrames) {
+			return `field 'preserve.editRanges[${i}]' must be a non-empty half-open range inside 0..${clipFrames}`;
+		}
+	}
+	// Exclusivity. `motionEdit` is deliberately absent from this list: an IK edit
+	// regenerates a span of the take preserve is reconstructing, which is exactly
+	// the combination scheduled inpainting exists for.
+	if (body.regenerateSegments !== undefined) {
+		return "field 'preserve' cannot be combined with regenerateSegments: a regenerated block set replaces the take preserve would reconstruct";
+	}
+	if (body.waypoints !== undefined) {
+		return "field 'preserve' cannot be combined with waypoints: an authored root path re-plans the whole rollout, leaving nothing to preserve";
+	}
+	// The box refuses this pairing too ("scheduled inpainting v1 supports a
+	// single segment"), after loading a model and a base motion. Failing here
+	// costs nothing and can name the version limit instead of a stack trace.
+	if (body.segments !== undefined) {
+		return "field 'preserve' cannot be combined with a prompt schedule: scheduled inpainting v1 supports a single segment";
+	}
+	return null;
+}
+
+// strength -> the (sigma_s, sigma_e) pair the backend blends between. This
+// mapping is server-side by contract so a client never speaks in diffusion-time
+// units. sigma_e is capped rather than scaled: below it the model must always
+// be free to finish, or the take is frozen onto the base and the edit cannot
+// happen. A strength small enough to round sigma_s to 0 is preserve fully off,
+// which the contract names explicitly.
+function preserveSigmas(strength) {
+	const sigmaS = Math.round(PRESERVE_SIGMA_MAX * strength);
+	return { sigmaS, sigmaE: Math.min(PRESERVE_SIGMA_END_CAP, sigmaS) };
 }
 
 // Returns an error message naming the offending field, or null when valid.
@@ -587,6 +683,43 @@ async function handleGenerate(req, res) {
 			return;
 		}
 	}
+	// Scheduled inpainting needs the BACKEND's own artifact of the take being
+	// preserved: Kimodo's --base_motion reads the npz its generator wrote, and
+	// the cskel27 file served at /ardy/motions/<id> is a lossy conversion of it,
+	// not that file. Which artifact that is stays a backend question, so the
+	// runner answers it and the bridge stays backend-neutral.
+	let preserveParams = null;
+	let preserveSkipped = null;
+	if (body.preserve) {
+		const preserveId = body.preserve.sourceMotion.slice("/ardy/motions/".length);
+		const takePath = motionAllowlist.get(preserveId) || null;
+		if (!takePath || !existsSync(takePath)) {
+			sendJson(res, 400, { ok: false, reason: `field 'preserve.sourceMotion': unknown or expired motion "${preserveId}"` });
+			finish(400);
+			return;
+		}
+		const basePath = runner.baseMotionFor ? runner.baseMotionFor(takePath) : null;
+		if (basePath) {
+			preserveParams = {
+				basePath,
+				...preserveSigmas(body.preserve.strength),
+				editRanges: body.preserve.editRanges,
+			};
+		} else {
+			// The take is real, but this backend kept no base motion for it:
+			// motion edits and regenerated block sets are SPLICED from two
+			// motions, so the backend's own artifact is not what the user is
+			// looking at, and takes generated before scheduled inpainting landed
+			// kept nothing at all. Preservation is a best-effort quality knob
+			// that is ON by default, so a missing base degrades to the plain
+			// generation this request would have been before the feature existed
+			// — loudly, on the status stream the App logs — instead of failing a
+			// run the operator did ask for.
+			preserveSkipped =
+				`[bridge] preserve SKIPPED: take "${preserveId}" has no ${runner.mode} base motion on disk ` +
+				"(edited and spliced takes keep none); generating WITHOUT scheduled inpainting";
+		}
+	}
 	if (body.base !== undefined) {
 		let bases;
 		try {
@@ -623,6 +756,10 @@ async function handleGenerate(req, res) {
 		send({ event: "error", message });
 		res.end();
 	};
+	if (preserveSkipped) {
+		console.error(preserveSkipped);
+		sendStatus(preserveSkipped);
+	}
 
 	// Children spawned for THIS request, killed on client disconnect or any
 	// terminal error. Detached groups, so killGroup takes down the whole tree
@@ -717,6 +854,12 @@ async function handleGenerate(req, res) {
 				contextAfter: body.motionEdit.contextAfter,
 				seed: body.seed,
 				poseNpzPaths,
+				// An edit run regenerates the whole clip and splices only the
+				// edited span back in, so its backend artifact is NOT the take the
+				// user ends up with — it keeps no base motion of its own. It can
+				// still PRESERVE one: reconstructing the source outside the edit is
+				// what makes the regenerated span line up with it.
+				preserve: preserveParams,
 				output: outNpzPath,
 			});
 			sendStatus(
@@ -772,6 +915,11 @@ async function handleGenerate(req, res) {
 				rootMargin: body.rootMargin,
 				contactThreshold: body.contactThreshold,
 				historyFrames: body.historyFrames,
+				// The written take IS this run's generation, retimed — so keep the
+				// backend's own npz beside it as a base a later preserve run can
+				// reconstruct. (A prompt schedule can never itself preserve: v1 is
+				// single-segment. Being preserved FROM is unrestricted.)
+				keepNative: true,
 				output: outNpzPath,
 			});
 			sendStatus(
@@ -841,6 +989,11 @@ async function handleGenerate(req, res) {
 				rootMargin: body.rootMargin,
 				contactThreshold: body.contactThreshold,
 				historyFrames: body.historyFrames,
+				preserve: preserveParams,
+				// regenerateSegments calls this once per block and splices the
+				// results into the source take, so no single block's backend npz is
+				// the delivered take; only a whole-clip run keeps a base motion.
+				keepNative: body.regenerateSegments === undefined,
 				output: outputPath,
 			});
 			sendStatus(`[bridge] generating frames ${segment.startFrame}..${segment.endFrame - 1}`);

--- a/tools/ardy/bridge.mjs
+++ b/tools/ardy/bridge.mjs
@@ -414,12 +414,19 @@ function validatePreserve(body, clipFrames) {
 
 // strength -> the (sigma_s, sigma_e) pair the backend blends between. This
 // mapping is server-side by contract so a client never speaks in diffusion-time
-// units. sigma_e is capped rather than scaled: below it the model must always
-// be free to finish, or the take is frozen onto the base and the edit cannot
-// happen. A strength small enough to round sigma_s to 0 is preserve fully off,
-// which the contract names explicitly.
+// units. The mapping is INVERTED against sigma_s on purpose: alpha_time is 1
+// ABOVE sigma_s and fades to 0 at sigma_e, so a SMALLER sigma_s keeps the base
+// blended deeper into the low-noise steps and preserves more. Measured on the
+// box (gate G3, all-ones mask, seed 5678): sigma_s 200 -> L2P 0.00455,
+// 500 -> 0.00467, 800 -> 0.00480, 1000 -> 0.00487 — strictly looser as sigma_s
+// rises. The first draft mapped strength straight onto sigma_s and made the
+// slider work backwards. sigma_e is capped rather than scaled: below it the
+// model must always be free to finish, or the take is frozen onto the base and
+// the edit cannot happen. The floor at the cap keeps full strength a step
+// schedule (blend until sigma_e) instead of rounding sigma_s to 0, which the
+// backend reads as preserve fully off.
 function preserveSigmas(strength) {
-	const sigmaS = Math.round(PRESERVE_SIGMA_MAX * strength);
+	const sigmaS = Math.max(PRESERVE_SIGMA_END_CAP, Math.round(PRESERVE_SIGMA_MAX * (1 - strength)));
 	return { sigmaS, sigmaE: Math.min(PRESERVE_SIGMA_END_CAP, sigmaS) };
 }
 

--- a/tools/kimodo/generate.mjs
+++ b/tools/kimodo/generate.mjs
@@ -12,14 +12,23 @@
  * splits the prompt on sentence boundaries and pairs them with the durations
  * in order, so a prompt containing its own period would silently shift every
  * later segment onto the wrong duration. joinPrompts refuses that instead.
+ *
+ * SCHEDULED INPAINTING lands here rather than in the bridge because this is the
+ * only layer that knows the GENERATION clock. The bridge speaks the app's 24 fps
+ * clip frames; the wrapper scripts speak seconds; genFps and the generated frame
+ * count are resolved below, for buildRoot2dConstraints, and the preserve mask is
+ * built from the same pair. Computing the frame count a second time upstream is
+ * exactly how the two would drift, and a mask whose length disagrees with the
+ * clip by one frame is a hard error on the box.
  */
 
 import { spawn } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildRoot2dConstraints } from "./constraints.mjs";
 import { buildFullBodyConstraints } from "./pose-constraints.mjs";
+import { buildPreserveMask, preserveMaskStats } from "./preserve-mask.mjs";
 import { readKimodoMotion } from "./read-npz.mjs";
 import { soma77ToCskel27Motion } from "./soma77-to-cskel27.mjs";
 
@@ -81,6 +90,52 @@ export function joinPrompts(segments) {
 	return { prompt: prompts.join(" "), duration: durations.join(" ") };
 }
 
+/**
+ * How many frames kimodo_gen will ACTUALLY generate for a single-segment
+ * `--duration` string.
+ *
+ * scripts/generate.py computes `int(duration_sec * fps)` — truncation, not
+ * rounding — and then refuses a preserve mask whose `genFrames` differs from
+ * that by even one ("Preserve mask ... declares genFrames=N but generation uses
+ * M"). The constraint builders take the ROUNDED count below, which disagrees for
+ * durations that land on a half frame (119 app frames at 24 fps = 4.9583 s =
+ * 148.75 generation frames: 148 generated, 149 rounded). For a constraint index
+ * that overshoot is harmless clamping; for a mask length it is a failed run. So
+ * the mask, and only the mask, is sized with the CLI's own arithmetic — and the
+ * rounded count is left exactly as it was, because changing it would move every
+ * measured waypoint index.
+ *
+ * Both sides are IEEE-754 doubles, so Math.trunc reproduces Python's int()
+ * including the cases where the product lands a hair below a whole number:
+ * 196 app frames is 8.166666666666666 s and that times 30 is
+ * 244.99999999999997 in Node AND in Python, so both take 244 while rounding
+ * would ask the box for a 245-frame mask over a 244-frame clip.
+ */
+export function cliGenFrames(durationSeconds, genFps) {
+	return Math.trunc(Number(durationSeconds) * Number(genFps));
+}
+
+/**
+ * This run's scheduled-inpainting inputs, as tools/kimodo/runner.mjs passes
+ * them. They arrive in the environment because the wrapper scripts between the
+ * bridge and this module have a frozen argv shared with the ARDY wrappers, and
+ * because every other Kimodo tunable already arrives the same way.
+ */
+function preserveFromEnv() {
+	const raw = process.env.CCLAY_KIMODO_PRESERVE;
+	if (!raw) return null;
+	let parsed;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw new Error(`CCLAY_KIMODO_PRESERVE is not valid JSON: ${error.message}`);
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("CCLAY_KIMODO_PRESERVE must be a JSON object");
+	}
+	return parsed;
+}
+
 /** Largest and mean per-frame root displacement, the same shape of number
  * cclay_sequence_generate.py's continuity gate reports for ARDY, so the two
  * backends can be compared on one metric. */
@@ -135,6 +190,12 @@ export async function generateOnBox({
 	// smaller the encoder has to run on the CPU, which the upstream docs give
 	// as the supported way to fit under 3 GB.
 	textEncoderDevice = process.env.CCLAY_KIMODO_TEXT_ENCODER_DEVICE || "cpu",
+	// Scheduled inpainting for THIS run (contracts C1/C3):
+	// {basePath, sigmaS, sigmaE, editRanges, maskPath}. null = the CLI is invoked
+	// exactly as before, which is the contract's regression invariant.
+	preserve = preserveFromEnv(),
+	// Where to keep Kimodo's own npz so a LATER run can preserve from this take.
+	nativeOut = process.env.CCLAY_KIMODO_NATIVE_OUT || "",
 	onLine,
 } = {}) {
 	if (!host) {
@@ -196,26 +257,106 @@ export async function generateOnBox({
 	const fullBody = buildFullBodyConstraints(poseEntries, { genFrames });
 	const constraints = [...root2d, ...fullBody];
 
+	// --- scheduled inpainting plan (contracts C1/C3) --------------------------
+	// Built here and nowhere else: see the file header. Everything that reaches a
+	// remote shell string below (the two sigmas) is re-checked as an integer even
+	// though the bridge already validated it, because this module is also driven
+	// straight from the environment.
+	let preservePlan = null;
+	if (preserve) {
+		if (segments.length > 1) {
+			throw new Error(
+				`scheduled inpainting v1 supports a single segment; this take has ${segments.length} prompt segments`
+			);
+		}
+		if (typeof preserve.basePath !== "string" || !preserve.basePath) {
+			throw new Error("preserve.basePath must be the path of a kimodo-native npz to reconstruct");
+		}
+		const sigma = (value, label) => {
+			const number = Number(value);
+			if (!Number.isInteger(number) || number < 0 || number > 1000) {
+				throw new Error(`preserve.${label} must be an integer in 0..1000, got ${JSON.stringify(value)}`);
+			}
+			return number;
+		};
+		const sigmaS = sigma(preserve.sigmaS, "sigmaS");
+		const sigmaE = sigma(preserve.sigmaE, "sigmaE");
+		if (sigmaE > sigmaS) {
+			throw new Error(`preserve.sigmaE (${sigmaE}) must be <= preserve.sigmaS (${sigmaS})`);
+		}
+		// The CLI's own frame count, not the rounded one the constraints use.
+		const maskFrames = cliGenFrames(duration, genFps);
+		if (!Number.isInteger(maskFrames) || maskFrames < 1) {
+			throw new Error(`preserve: ${duration}s at ${genFps} fps generates ${maskFrames} frames, nothing to preserve`);
+		}
+		const mask = buildPreserveMask(preserve.editRanges || [], {
+			appFps,
+			genFps,
+			genFrames: maskFrames,
+			...(preserve.influenceRadius === undefined ? {} : { influenceRadius: preserve.influenceRadius }),
+		});
+		preservePlan = {
+			basePath: preserve.basePath,
+			maskPath: preserve.maskPath || null,
+			sigmaS,
+			sigmaE,
+			mask,
+			stats: preserveMaskStats(mask),
+		};
+	}
+
 	const remoteStem = `/tmp/cclay-kimodo-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 	// `repo` may hold an unexpanded $HOME for the REMOTE shell to expand, so it
 	// is quoted rather than escaped: unquoted it word-splits and `cd` sees two
 	// arguments the moment the path contains a space.
 	const localDir = await mkdtemp(join(tmpdir(), "cclay-kimodo-"));
 	try {
-		// The constraints file has to exist on the BOX, so it is written locally
-		// and copied up before generation rather than passed on the command line.
-		const remoteConstraints = `${remoteStem}/constraints.json`;
-		if (constraints.length > 0) {
-			const localConstraints = join(localDir, "constraints.json");
-			await writeFile(localConstraints, JSON.stringify(constraints));
+		// Everything the CLI reads as a FILE has to exist on the BOX, so it is
+		// written locally and copied up before generation rather than passed on
+		// the command line. The remote directory is made once, on demand.
+		let remoteDirReady = false;
+		const ensureRemoteDir = async () => {
+			if (remoteDirReady) return;
 			const madeDir = await run(["ssh", ...SSH_OPTS, host, `mkdir -p ${remoteStem}`]);
 			if (madeDir.code !== 0) {
 				throw new Error(`could not create ${remoteStem} on ${host}: ${madeDir.stderr.trim()}`);
 			}
-			const pushed = await run(["scp", ...SSH_OPTS, localConstraints, `${host}:${remoteConstraints}`]);
+			remoteDirReady = true;
+		};
+		// Local paths travel as scp ARGV entries, never inside a shell string;
+		// the remote side of each pair is built from remoteStem, which this
+		// process generated.
+		const push = async (localPath, remotePath, label) => {
+			await ensureRemoteDir();
+			const pushed = await run(["scp", ...SSH_OPTS, localPath, `${host}:${remotePath}`]);
 			if (pushed.code !== 0) {
-				throw new Error(`could not copy constraints to ${host} (exit ${pushed.code}): ${pushed.stderr.trim()}`);
+				throw new Error(`could not copy ${label} to ${host} (exit ${pushed.code}): ${pushed.stderr.trim()}`);
 			}
+		};
+
+		const remoteConstraints = `${remoteStem}/constraints.json`;
+		if (constraints.length > 0) {
+			const localConstraints = join(localDir, "constraints.json");
+			await writeFile(localConstraints, JSON.stringify(constraints));
+			await push(localConstraints, remoteConstraints, "constraints");
+		}
+
+		// The base motion and its mask ride up the same way. The mask is written
+		// to the RUN directory when the caller named one, so a finished take keeps
+		// the exact weights it was generated against next to it.
+		const remoteBase = `${remoteStem}/base.npz`;
+		const remoteMask = `${remoteStem}/preserve-mask.json`;
+		if (preservePlan) {
+			const localMask = preservePlan.maskPath || join(localDir, "preserve-mask.json");
+			await writeFile(localMask, `${JSON.stringify(preservePlan.mask)}\n`, { mode: 0o600 });
+			await push(preservePlan.basePath, remoteBase, "the preserved base motion");
+			await push(localMask, remoteMask, "the preserve mask");
+			const { freeFrames, rampFrames, preservedFrames } = preservePlan.stats;
+			console.log(
+				`kimodo-preserve: base=${preservePlan.basePath} sigma_s=${preservePlan.sigmaS} ` +
+					`sigma_e=${preservePlan.sigmaE} mask=${preservePlan.mask.genFrames} generation frames ` +
+					`(free ${freeFrames}, ramp ${rampFrames}, preserved ${preservedFrames})`
+			);
 		}
 
 		// One `kimodo_gen` invocation: the env assignment and every flag are one
@@ -230,6 +371,13 @@ export async function generateOnBox({
 			`--diffusion_steps ${diffusionSteps}`,
 			seed === undefined ? "" : `--seed ${Number(seed)}`,
 			constraints.length > 0 ? `--constraints ${remoteConstraints}` : "",
+			// Contract C2. All four are omitted together when nothing is being
+			// preserved, which is what keeps a no-preserve run bit-identical to
+			// the pre-inpainting code path for a given seed.
+			preservePlan ? `--base_motion ${remoteBase}` : "",
+			preservePlan ? `--preserve_start ${preservePlan.sigmaS}` : "",
+			preservePlan ? `--preserve_end ${preservePlan.sigmaE}` : "",
+			preservePlan ? `--preserve_mask ${remoteMask}` : "",
 			`--output ${remoteStem}/take`,
 		]
 			.filter(Boolean)
@@ -248,6 +396,17 @@ export async function generateOnBox({
 		if (copied.code !== 0) {
 			throw new Error(`scp of the generated npz failed (exit ${copied.code}): ${copied.stderr.trim()}`);
 		}
+		// A later run can only preserve THIS take if Kimodo's own npz survives:
+		// --base_motion reads that format and the cskel27 file the caller writes
+		// is a lossy conversion of it. Best-effort on purpose — a failed local
+		// copy must not throw away a finished GPU take.
+		if (nativeOut) {
+			try {
+				await copyFile(localNpz, nativeOut);
+			} catch (error) {
+				console.error(`kimodo-preserve: could not keep the base motion at ${nativeOut}: ${error.message}`);
+			}
+		}
 		const loaded = readKimodoMotion(localNpz);
 		const fps = loaded.fps ?? 30;
 		const motion = soma77ToCskel27Motion({
@@ -261,6 +420,19 @@ export async function generateOnBox({
 			metrics: continuityMetrics(motion),
 			raw: { frames: loaded.frames, joints: loaded.joints, fps },
 			constraints,
+			// What this run preserved, and where its own base motion was kept for
+			// the next one. Both null on a plain generation.
+			preserve: preservePlan
+				? {
+					basePath: preservePlan.basePath,
+					maskPath: preservePlan.maskPath,
+					sigmaS: preservePlan.sigmaS,
+					sigmaE: preservePlan.sigmaE,
+					genFrames: preservePlan.mask.genFrames,
+					...preservePlan.stats,
+				}
+				: null,
+			nativeNpz: nativeOut || null,
 			npzBytes: (await readFile(localNpz)).length,
 		};
 	} finally {

--- a/tools/kimodo/measure-preserve.mjs
+++ b/tools/kimodo/measure-preserve.mjs
@@ -1,0 +1,678 @@
+#!/usr/bin/env node
+/**
+ * measure-preserve.mjs — how much of a base take survived a regeneration?
+ *
+ * This is the measuring stick for the scheduled-inpainting acceptance gates
+ * (.omo/plans/scheduled-inpainting.md, G1–G4): it compares two cclay motion
+ * npz files — the take the user already had, and the take that came back out
+ * of a preserve-enabled generation — and reports how far apart they are.
+ *
+ * GPU-free and dependency-free on purpose: the gates are run over artefacts
+ * pulled back from the box, so this has to work from a laptop with nothing but
+ * node and the two files.
+ *
+ * WHY ROOT-RELATIVE POSITIONS ARE THE HEADLINE NUMBER. Kimodo generates in a
+ * canonicalised space and the take is re-anchored afterwards, so two takes that
+ * hold the SAME pose can sit metres apart in world coordinates. A raw
+ * posed_joints difference is then dominated by root drift and says nothing about
+ * whether the body was preserved, which is the thing the gates are about. So the
+ * headline L2P subtracts each frame's Hips position from every joint of that
+ * frame before differencing, and the undrifted figure is still reported
+ * separately as globalL2P because a take that preserves the pose but walks off
+ * in a different direction is its own kind of failure and must stay visible.
+ *
+ * WHY ROTATION IS MEASURED GEODESICALLY. Per-element matrix differences are not
+ * a metric on SO(3) — the same 10° error scores differently depending on where
+ * on the sphere it sits. The geodesic angle acos((tr(Rᵀ_a R_b) - 1)/2) is the
+ * actual rotation you would have to apply to get from one to the other, in
+ * radians, and is directly comparable between joints and between clips.
+ *
+ * WHY FOOT SLIDING IS MEASURED PER CLIP, NOT AS A DIFFERENCE. G4 asks whether
+ * preservation introduced skating, and skating is a property of ONE clip (a
+ * planted foot that translates), not of the pair. So each clip is measured on
+ * its own timeline with its own floor, and only then are the two numbers
+ * subtracted.
+ *
+ * usage:
+ *   measure-preserve.mjs <base.npz> <candidate.npz> [--ranges 40:80,120:150]
+ *                        [--json] [--max-l2p M] [--max-l2r RAD] [--max-foot-delta M]
+ *
+ * `--ranges` are APP frames, half-open [start,end), in the BASE clip's frame
+ * space — the same space C3's `editRanges` are authored in. Frames inside any
+ * range are the ones the edit was allowed to change; everything else is what
+ * G2 says must stay pinned to the base.
+ *
+ * Any --max-* flag turns this into a gate: exceeding it exits 1. With no
+ * threshold flag the tool only reports and exits 0.
+ */
+
+import { readNpz } from "./read-npz.mjs";
+import { CSKEL27_JOINTS } from "../../src/ardy/cskel27.js";
+
+const JOINTS = 27;
+
+/** Joint 0 is the root in cskel27; asserted rather than assumed because every
+ * root-relative number below silently changes meaning if the order ever moves. */
+const HIPS = 0;
+if (CSKEL27_JOINTS[HIPS] !== "Hips") {
+	throw new Error(`measure-preserve: cskel27 joint 0 is ${CSKEL27_JOINTS[HIPS]}, expected Hips`);
+}
+
+/** The joints whose contact with the floor defines sliding. Toes are included
+ * because a heel-planted foot pivoting on the toe is not skating, but a toe
+ * that translates while down is. */
+const FOOT_JOINTS = ["LeftFoot", "LeftToeBase", "RightFoot", "RightToeBase"];
+const FOOT_INDICES = FOOT_JOINTS.map((name) => {
+	const index = CSKEL27_JOINTS.indexOf(name);
+	if (index < 0) throw new Error(`measure-preserve: cskel27 has no joint ${name}`);
+	return index;
+});
+
+/**
+ * Contact heuristic, deliberately crude and deliberately per-joint-per-clip.
+ *
+ * A joint counts as planted on a frame when its height is within 5 cm of THAT
+ * JOINT's own minimum height across THAT clip. Per-joint because the toe sits
+ * lower than the ankle and a shared threshold would call the ankle airborne for
+ * the whole clip; per-clip because soma77ToCskel27Motion floor-shifts each take
+ * by its own lowest sample, so "y == 0" is not a shared floor between two files.
+ *
+ * The honest caveat: for a clip with no ground contact at all (a jump loop, a
+ * lying-down take) the minimum is not the floor and this will report the slide
+ * of whatever was lowest. That is acceptable here because G4 compares the SAME
+ * motion before and after preservation, so the bias is identical on both sides
+ * and cancels in the delta. Do not lift this number into an absolute
+ * "does this clip skate" claim without checking the clip has real contacts.
+ */
+const CONTACT_BAND_M = 0.05;
+
+/* ------------------------------------------------------------------ loading */
+
+function requireMember(members, name, path) {
+	const member = members[name];
+	if (!member) {
+		throw new Error(
+			`measure-preserve: ${path} is missing the '${name}' member — is this a cclay motion npz? ` +
+				`(found: ${Object.keys(members).join(", ") || "nothing"})`
+		);
+	}
+	if (member.unsupported || !member.data) {
+		throw new Error(
+			`measure-preserve: ${path} stores '${name}' as unsupported dtype ${member.dtype}`
+		);
+	}
+	return member;
+}
+
+/** Count non-finite entries so a NaN in the source is reported by name instead
+ * of quietly turning every aggregate into NaN. */
+function countNonFinite(data) {
+	let count = 0;
+	for (let index = 0; index < data.length; index += 1) {
+		if (!Number.isFinite(data[index])) count += 1;
+	}
+	return count;
+}
+
+/**
+ * Load a cclay motion npz down to the arrays this tool compares.
+ * @returns {{path:string, frames:number, fps:number, fpsAssumed:boolean,
+ *            rot:Float32Array, posed:Float32Array, nonFinite:object}}
+ */
+export function loadMotion(path, { defaultFps = 20 } = {}) {
+	const members = readNpz(path);
+	const rot = requireMember(members, "local_rot_mats", path);
+	const posed = requireMember(members, "posed_joints", path);
+
+	if (rot.shape.length !== 4 || rot.shape[1] !== JOINTS || rot.shape[2] !== 3 || rot.shape[3] !== 3) {
+		throw new Error(
+			`measure-preserve: ${path} local_rot_mats must be [T,${JOINTS},3,3], got [${rot.shape}]`
+		);
+	}
+	if (posed.shape.length !== 3 || posed.shape[1] !== JOINTS || posed.shape[2] !== 3) {
+		throw new Error(
+			`measure-preserve: ${path} posed_joints must be [T,${JOINTS},3], got [${posed.shape}]`
+		);
+	}
+	const frames = rot.shape[0];
+	if (posed.shape[0] !== frames) {
+		throw new Error(
+			`measure-preserve: ${path} local_rot_mats has ${frames} frames but posed_joints has ${posed.shape[0]}`
+		);
+	}
+	if (frames < 1) throw new Error(`measure-preserve: ${path} has no frames`);
+
+	// fps is optional in the wild: ARDY-generated takes write it as <i4 and
+	// ARDY-Core demos as <i8, but a hand-built or trimmed file may omit it. A
+	// missing fps is assumed, never guessed silently — it changes the resampling.
+	let fps = null;
+	let fpsAssumed = false;
+	if (members.fps && members.fps.data && !members.fps.unsupported) {
+		fps = Math.round(members.fps.data[0]);
+		if (!Number.isInteger(fps) || fps < 1) {
+			throw new Error(`measure-preserve: ${path} has a non-positive fps member (${fps})`);
+		}
+	} else {
+		fps = defaultFps;
+		fpsAssumed = true;
+	}
+
+	return {
+		path,
+		frames,
+		fps,
+		fpsAssumed,
+		rot: rot.data,
+		posed: posed.data,
+		nonFinite: {
+			local_rot_mats: countNonFinite(rot.data),
+			posed_joints: countNonFinite(posed.data),
+		},
+	};
+}
+
+/* -------------------------------------------------------------- comparison */
+
+/**
+ * Map every base frame onto a candidate frame by NEAREST sample in time.
+ *
+ * Nearest, not interpolated, because interpolating rotation matrices
+ * element-wise leaves SO(3) and would make L2R measure the interpolation error
+ * instead of the generation's. Nearest is exact when the clocks match (the
+ * normal case) and is an honest, reportable approximation when they do not.
+ *
+ * Base frames whose time falls past the end of the candidate are dropped rather
+ * than clamped: clamping would compare the whole tail of the base against one
+ * repeated candidate frame and invent an error that is really just a length
+ * mismatch. The count of dropped frames is reported as a truncation warning.
+ */
+export function buildFrameMap(base, candidate) {
+	const map = new Int32Array(base.frames);
+	let compared = 0;
+	for (let frame = 0; frame < base.frames; frame += 1) {
+		const index = Math.round((frame * candidate.fps) / base.fps);
+		if (index > candidate.frames - 1) break;
+		map[frame] = index;
+		compared += 1;
+	}
+	if (compared === 0) {
+		throw new Error(
+			`measure-preserve: no overlapping frames between ${base.path} ` +
+				`(${base.frames}@${base.fps}) and ${candidate.path} (${candidate.frames}@${candidate.fps})`
+		);
+	}
+	return { map, compared };
+}
+
+/** Accumulator for a mean over per-sample values, NaN-skipping and counting. */
+function accumulator() {
+	return { sum: 0, count: 0, skipped: 0, max: 0 };
+}
+
+function add(acc, value) {
+	if (!Number.isFinite(value)) {
+		acc.skipped += 1;
+		return;
+	}
+	acc.sum += value;
+	acc.count += 1;
+	if (value > acc.max) acc.max = value;
+}
+
+function mean(acc) {
+	return acc.count > 0 ? acc.sum / acc.count : null;
+}
+
+function summarize(acc) {
+	return { mean: mean(acc), max: acc.count > 0 ? acc.max : null, samples: acc.count, skipped: acc.skipped };
+}
+
+/**
+ * Geodesic angle between two rotation matrices, in radians.
+ *
+ * The textbook form is acos((tr(Rᵀ_a R_b) - 1) / 2), and it is a TRAP at the
+ * small angles this tool exists to measure. acos has infinite slope at 1, so it
+ * amplifies error like sqrt: the npz stores float32, whose matrices are only
+ * orthonormal to ~1e-7, and acos turns that 1e-7 into ~3e-4 rad of phantom
+ * rotation error. Measured, not theorised — the first cut of this file scored a
+ * fixture against ITSELF at 1.04e-4 rad mean / 7.6e-4 max, which is the same
+ * order as a real preservation difference and would have made G1 unreadable.
+ *
+ * So the angle comes from atan2(sin, cos) instead, where sin is read off the
+ * skew-symmetric part of Rᵀ_a R_b. Near zero, sin IS the angle to first order
+ * and is built from DIFFERENCES that vanish when the matrices agree, so the
+ * float32 noise stays 1e-7 instead of being square-rooted up.
+ *
+ * The bitwise fast path on top is not an optimisation dodge: two identical
+ * float32 blocks are the same rotation, and the geodesic distance from a
+ * rotation to itself is exactly 0. Any nonzero result there is arithmetic
+ * noise, and reporting it would be wrong, not precise.
+ *
+ * Neither the transpose nor the product is materialised — the six entries and
+ * the trace are read straight out of the two flat blocks.
+ */
+function geodesicAngle(rot, aBase, bBase) {
+	const a = rot.a;
+	const b = rot.b;
+	let identical = true;
+	for (let element = 0; element < 9; element += 1) {
+		if (a[aBase + element] !== b[bBase + element]) {
+			identical = false;
+			break;
+		}
+	}
+	if (identical) return 0;
+
+	// R = Aᵀ B, so R[i][j] = sum_k A[k][i] * B[k][j]; A[r][c] is flat[base+r*3+c].
+	let trace = 0;
+	for (let element = 0; element < 9; element += 1) trace += a[aBase + element] * b[bBase + element];
+
+	let r21 = 0, r12 = 0, r02 = 0, r20 = 0, r10 = 0, r01 = 0;
+	for (let k = 0; k < 3; k += 1) {
+		const ak = aBase + k * 3;
+		const bk = bBase + k * 3;
+		r21 += a[ak + 2] * b[bk + 1];
+		r12 += a[ak + 1] * b[bk + 2];
+		r02 += a[ak + 0] * b[bk + 2];
+		r20 += a[ak + 2] * b[bk + 0];
+		r10 += a[ak + 1] * b[bk + 0];
+		r01 += a[ak + 0] * b[bk + 1];
+	}
+	const sin = 0.5 * Math.hypot(r21 - r12, r02 - r20, r10 - r01);
+	const cos = (trace - 1) / 2;
+	// atan2 needs no clamping: it is defined for any (sin, cos) pair, including
+	// the slightly-off-unit-circle pairs a non-exactly-orthonormal input gives.
+	return Math.atan2(sin, cos);
+}
+
+/**
+ * Parse `--ranges 40:80,120:150` into half-open [start,end) app-frame ranges.
+ */
+export function parseRanges(text) {
+	const ranges = [];
+	for (const part of text.split(",")) {
+		const trimmed = part.trim();
+		if (!trimmed) continue;
+		const bits = trimmed.split(":");
+		if (bits.length !== 2) {
+			throw new Error(`measure-preserve: bad range '${trimmed}', expected start:end`);
+		}
+		const start = Number(bits[0]);
+		const end = Number(bits[1]);
+		if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end <= start) {
+			throw new Error(
+				`measure-preserve: bad range '${trimmed}' — start and end must be integers with 0 <= start < end`
+			);
+		}
+		ranges.push({ startFrame: start, endFrame: end });
+	}
+	return ranges;
+}
+
+/** Per-frame membership of the union of the edited ranges, in base frame space. */
+function rangeMembership(ranges, frames) {
+	const inside = new Uint8Array(frames);
+	for (const range of ranges) {
+		const from = Math.max(0, range.startFrame);
+		const to = Math.min(frames, range.endFrame);
+		for (let frame = from; frame < to; frame += 1) inside[frame] = 1;
+	}
+	return inside;
+}
+
+/**
+ * Foot sliding for ONE clip, in metres of XZ travel per frame.
+ *
+ * Headline number is the TOTAL slide accumulated across all four foot joints
+ * divided by the clip's frame transitions, so a clip where both feet skate
+ * scores twice a clip where one does. Per-joint figures are reported alongside
+ * because a single skating toe is a different bug from a whole body gliding.
+ */
+export function footSliding(motion) {
+	const { frames, posed } = motion;
+	const transitions = Math.max(1, frames - 1);
+	const perJoint = [];
+	let total = 0;
+	let contactFrames = 0;
+
+	for (let slot = 0; slot < FOOT_INDICES.length; slot += 1) {
+		const joint = FOOT_INDICES[slot];
+		let minY = Infinity;
+		for (let frame = 0; frame < frames; frame += 1) {
+			const y = posed[(frame * JOINTS + joint) * 3 + 1];
+			if (Number.isFinite(y) && y < minY) minY = y;
+		}
+		let slide = 0;
+		let contacts = 0;
+		if (Number.isFinite(minY)) {
+			const ceiling = minY + CONTACT_BAND_M;
+			for (let frame = 0; frame < frames - 1; frame += 1) {
+				const here = (frame * JOINTS + joint) * 3;
+				const next = ((frame + 1) * JOINTS + joint) * 3;
+				if (!(posed[here + 1] <= ceiling)) continue; // airborne, or NaN
+				const dx = posed[next] - posed[here];
+				const dz = posed[next + 2] - posed[here + 2];
+				const step = Math.hypot(dx, dz);
+				if (!Number.isFinite(step)) continue;
+				slide += step;
+				contacts += 1;
+			}
+		}
+		total += slide;
+		contactFrames += contacts;
+		perJoint.push({
+			joint: CSKEL27_JOINTS[joint],
+			minHeight_m: Number.isFinite(minY) ? minY : null,
+			contactFrames: contacts,
+			slide_m: slide,
+			slide_m_per_frame: slide / transitions,
+		});
+	}
+
+	return {
+		contactBand_m: CONTACT_BAND_M,
+		frames,
+		contactFrames,
+		total_slide_m: total,
+		slide_m_per_frame: total / transitions,
+		perJoint,
+	};
+}
+
+/**
+ * Compare a base take against a candidate.
+ * @param {object} base      from loadMotion
+ * @param {object} candidate from loadMotion
+ * @param {Array<{startFrame:number,endFrame:number}>} ranges edited app-frame ranges
+ */
+export function measurePreserve(base, candidate, ranges = []) {
+	const warnings = [];
+	for (const motion of [base, candidate]) {
+		for (const [member, count] of Object.entries(motion.nonFinite)) {
+			if (count > 0) warnings.push(`${motion.path}: ${count} non-finite values in ${member}`);
+		}
+		if (motion.fpsAssumed) warnings.push(`${motion.path}: no fps member, assumed ${motion.fps}`);
+	}
+
+	// Resampling and truncation are reported separately because they are
+	// different accusations: a clock mismatch means the numbers below carry a
+	// nearest-frame approximation, whereas an equal-clock length mismatch means
+	// the candidate is simply shorter and nothing was approximated.
+	const resampled = base.fps !== candidate.fps;
+	const { map, compared } = buildFrameMap(base, candidate);
+	if (resampled) {
+		warnings.push(
+			`candidate resampled onto the base timeline by nearest frame ` +
+				`(base ${base.frames}f@${base.fps} vs candidate ${candidate.frames}f@${candidate.fps})`
+		);
+	}
+	const truncated = compared < base.frames;
+	if (truncated) {
+		warnings.push(
+			`candidate is short: only ${compared} of ${base.frames} base frames have a candidate sample; ` +
+				`the remaining ${base.frames - compared} were dropped, not clamped`
+		);
+	}
+	for (const range of ranges) {
+		// The classic mix-up is handing this tool GENERATION-space frames (30 fps)
+		// for an app-space (20 fps) clip, which silently lands the range past the
+		// end and reports a flawless out-of-range score over the whole take.
+		if (range.startFrame >= compared) {
+			warnings.push(
+				`range [${range.startFrame},${range.endFrame}) starts past the last compared frame ` +
+					`(${compared}) — are these app frames in the BASE clip's fps space?`
+			);
+		} else if (range.endFrame > compared) {
+			warnings.push(
+				`range [${range.startFrame},${range.endFrame}) is clipped to the compared span (${compared} frames)`
+			);
+		}
+	}
+
+	const inside = rangeMembership(ranges, base.frames);
+	const rot = { a: base.rot, b: candidate.rot };
+
+	// Three buckets per metric: everything, inside the edited ranges, outside.
+	const buckets = {
+		l2p: { all: accumulator(), inRange: accumulator(), outOfRange: accumulator() },
+		globalL2p: { all: accumulator(), inRange: accumulator(), outOfRange: accumulator() },
+		l2r: { all: accumulator(), inRange: accumulator(), outOfRange: accumulator() },
+	};
+	const perFrame = { l2p: new Float64Array(compared), l2r: new Float64Array(compared) };
+
+	for (let frame = 0; frame < compared; frame += 1) {
+		const other = map[frame];
+		const baseFrameBase = frame * JOINTS * 3;
+		const candFrameBase = other * JOINTS * 3;
+		const baseHips = baseFrameBase + HIPS * 3;
+		const candHips = candFrameBase + HIPS * 3;
+		const bucket = inside[frame] ? "inRange" : "outOfRange";
+
+		let frameL2p = 0;
+		let frameL2r = 0;
+		for (let joint = 0; joint < JOINTS; joint += 1) {
+			const p = baseFrameBase + joint * 3;
+			const q = candFrameBase + joint * 3;
+
+			// Root-relative: each side is expressed against its OWN hips, so a
+			// clip that is the same pose translated scores zero here.
+			const rdx = base.posed[p] - base.posed[baseHips] - (candidate.posed[q] - candidate.posed[candHips]);
+			const rdy = base.posed[p + 1] - base.posed[baseHips + 1] - (candidate.posed[q + 1] - candidate.posed[candHips + 1]);
+			const rdz = base.posed[p + 2] - base.posed[baseHips + 2] - (candidate.posed[q + 2] - candidate.posed[candHips + 2]);
+			const local = Math.hypot(rdx, rdy, rdz);
+			add(buckets.l2p.all, local);
+			add(buckets.l2p[bucket], local);
+			frameL2p += Number.isFinite(local) ? local : 0;
+
+			const global = Math.hypot(
+				base.posed[p] - candidate.posed[q],
+				base.posed[p + 1] - candidate.posed[q + 1],
+				base.posed[p + 2] - candidate.posed[q + 2]
+			);
+			add(buckets.globalL2p.all, global);
+			add(buckets.globalL2p[bucket], global);
+
+			const angle = geodesicAngle(rot, (frame * JOINTS + joint) * 9, (other * JOINTS + joint) * 9);
+			add(buckets.l2r.all, angle);
+			add(buckets.l2r[bucket], angle);
+			frameL2r += Number.isFinite(angle) ? angle : 0;
+		}
+		perFrame.l2p[frame] = frameL2p / JOINTS;
+		perFrame.l2r[frame] = frameL2r / JOINTS;
+	}
+
+	// Per-range breakdown: a union aggregate hides an edit that only moved one
+	// of two ranges, which is exactly the G2 failure mode.
+	const perRange = ranges.map((range) => {
+		const l2p = accumulator();
+		const l2r = accumulator();
+		const from = Math.max(0, range.startFrame);
+		const to = Math.min(compared, range.endFrame);
+		for (let frame = from; frame < to; frame += 1) {
+			add(l2p, perFrame.l2p[frame]);
+			add(l2r, perFrame.l2r[frame]);
+		}
+		return {
+			startFrame: range.startFrame,
+			endFrame: range.endFrame,
+			comparedFrames: Math.max(0, to - from),
+			l2p_m: mean(l2p),
+			l2r_rad: mean(l2r),
+		};
+	});
+
+	const baseFeet = footSliding(base);
+	const candidateFeet = footSliding(candidate);
+
+	return {
+		base: { path: base.path, frames: base.frames, fps: base.fps },
+		candidate: { path: candidate.path, frames: candidate.frames, fps: candidate.fps },
+		resampled,
+		truncated,
+		comparedFrames: compared,
+		ranges,
+		jointCount: JOINTS,
+		l2p_m: summarize(buckets.l2p.all),
+		l2p_inRange_m: ranges.length ? summarize(buckets.l2p.inRange) : null,
+		l2p_outOfRange_m: ranges.length ? summarize(buckets.l2p.outOfRange) : null,
+		globalL2p_m: summarize(buckets.globalL2p.all),
+		globalL2p_inRange_m: ranges.length ? summarize(buckets.globalL2p.inRange) : null,
+		globalL2p_outOfRange_m: ranges.length ? summarize(buckets.globalL2p.outOfRange) : null,
+		l2r_rad: summarize(buckets.l2r.all),
+		l2r_inRange_rad: ranges.length ? summarize(buckets.l2r.inRange) : null,
+		l2r_outOfRange_rad: ranges.length ? summarize(buckets.l2r.outOfRange) : null,
+		perRange,
+		footSliding: {
+			base: baseFeet,
+			candidate: candidateFeet,
+			// Positive = the candidate skates more than the base. G4's budget.
+			delta_m_per_frame: candidateFeet.slide_m_per_frame - baseFeet.slide_m_per_frame,
+		},
+		warnings,
+	};
+}
+
+/* -------------------------------------------------------------------- CLI */
+
+function formatMetres(value) {
+	return value === null ? "  n/a    " : value.toFixed(6);
+}
+
+function formatRadians(value) {
+	return value === null ? "  n/a   " : `${value.toFixed(6)} (${((value * 180) / Math.PI).toFixed(3)}°)`;
+}
+
+function printReport(report) {
+	console.log(`base      : ${report.base.path}  ${report.base.frames} frames @ ${report.base.fps} fps`);
+	console.log(`candidate : ${report.candidate.path}  ${report.candidate.frames} frames @ ${report.candidate.fps} fps`);
+	console.log(
+		`compared  : ${report.comparedFrames} frames x ${report.jointCount} joints` +
+			(report.resampled ? "  (candidate RESAMPLED to base timeline, nearest frame)" : "") +
+			(report.truncated ? "  (TRUNCATED to the candidate's length)" : "")
+	);
+	for (const warning of report.warnings) console.log(`WARN: ${warning}`);
+
+	console.log("");
+	console.log("  position error (root-relative, metres)");
+	console.log(`    all         : mean ${formatMetres(report.l2p_m.mean)}   max ${formatMetres(report.l2p_m.max)}`);
+	if (report.l2p_inRange_m) {
+		console.log(`    inRange     : mean ${formatMetres(report.l2p_inRange_m.mean)}   max ${formatMetres(report.l2p_inRange_m.max)}   (${report.l2p_inRange_m.samples} samples)`);
+		console.log(`    outOfRange  : mean ${formatMetres(report.l2p_outOfRange_m.mean)}   max ${formatMetres(report.l2p_outOfRange_m.max)}   (${report.l2p_outOfRange_m.samples} samples)`);
+	}
+	console.log("  position error (global / world, metres)");
+	console.log(`    all         : mean ${formatMetres(report.globalL2p_m.mean)}   max ${formatMetres(report.globalL2p_m.max)}`);
+	if (report.globalL2p_inRange_m) {
+		console.log(`    inRange     : mean ${formatMetres(report.globalL2p_inRange_m.mean)}`);
+		console.log(`    outOfRange  : mean ${formatMetres(report.globalL2p_outOfRange_m.mean)}`);
+	}
+	console.log("  rotation error (geodesic, radians)");
+	console.log(`    all         : mean ${formatRadians(report.l2r_rad.mean)}   max ${formatRadians(report.l2r_rad.max)}`);
+	if (report.l2r_inRange_rad) {
+		console.log(`    inRange     : mean ${formatRadians(report.l2r_inRange_rad.mean)}`);
+		console.log(`    outOfRange  : mean ${formatRadians(report.l2r_outOfRange_rad.mean)}`);
+	}
+
+	if (report.perRange.length) {
+		console.log("  per edited range");
+		for (const range of report.perRange) {
+			console.log(
+				`    [${range.startFrame},${range.endFrame})  ${String(range.comparedFrames).padStart(4)} frames  ` +
+					`L2P ${formatMetres(range.l2p_m)}  L2R ${formatRadians(range.l2r_rad)}`
+			);
+		}
+	}
+
+	const feet = report.footSliding;
+	console.log("  foot sliding (m per frame, contact = within 5 cm of that joint's own minimum)");
+	console.log(`    base        : ${feet.base.slide_m_per_frame.toFixed(6)}   (${feet.base.contactFrames} contact frames)`);
+	console.log(`    candidate   : ${feet.candidate.slide_m_per_frame.toFixed(6)}   (${feet.candidate.contactFrames} contact frames)`);
+	console.log(`    delta       : ${feet.delta_m_per_frame >= 0 ? "+" : ""}${feet.delta_m_per_frame.toFixed(6)}`);
+
+	console.log("");
+	// Flat, greppable keys, same shape as measure-waypoints.mjs's WORST_ERROR_M,
+	// so a gate script can pull one number without parsing the whole report.
+	console.log(`L2P_M=${report.l2p_m.mean === null ? "nan" : report.l2p_m.mean.toFixed(6)}`);
+	console.log(`GLOBAL_L2P_M=${report.globalL2p_m.mean === null ? "nan" : report.globalL2p_m.mean.toFixed(6)}`);
+	console.log(`L2R_RAD=${report.l2r_rad.mean === null ? "nan" : report.l2r_rad.mean.toFixed(6)}`);
+	if (report.l2p_outOfRange_m) {
+		console.log(`L2P_OUT_M=${report.l2p_outOfRange_m.mean === null ? "nan" : report.l2p_outOfRange_m.mean.toFixed(6)}`);
+		console.log(`L2P_IN_M=${report.l2p_inRange_m.mean === null ? "nan" : report.l2p_inRange_m.mean.toFixed(6)}`);
+	}
+	console.log(`FOOT_SLIDE_DELTA_M=${feet.delta_m_per_frame.toFixed(6)}`);
+}
+
+function parseArgs(argv) {
+	const positional = [];
+	const options = { ranges: [], json: false, maxL2p: null, maxL2r: null, maxFootDelta: null };
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--json") options.json = true;
+		else if (arg === "--ranges") options.ranges = parseRanges(argv[++index] ?? "");
+		else if (arg.startsWith("--ranges=")) options.ranges = parseRanges(arg.slice("--ranges=".length));
+		else if (arg === "--max-l2p") options.maxL2p = Number(argv[++index]);
+		else if (arg === "--max-l2r") options.maxL2r = Number(argv[++index]);
+		else if (arg === "--max-foot-delta") options.maxFootDelta = Number(argv[++index]);
+		else if (arg.startsWith("--")) throw new Error(`measure-preserve: unknown flag ${arg}`);
+		else positional.push(arg);
+	}
+	for (const [flag, value] of [["--max-l2p", options.maxL2p], ["--max-l2r", options.maxL2r], ["--max-foot-delta", options.maxFootDelta]]) {
+		if (value !== null && !Number.isFinite(value)) {
+			throw new Error(`measure-preserve: ${flag} needs a finite number`);
+		}
+	}
+	return { positional, options };
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].endsWith("measure-preserve.mjs");
+if (invokedDirectly) {
+	let parsed;
+	try {
+		parsed = parseArgs(process.argv.slice(2));
+	} catch (error) {
+		console.error(error.message);
+		process.exit(2);
+	}
+	const [basePath, candidatePath] = parsed.positional;
+	if (!basePath || !candidatePath) {
+		console.error(
+			"usage: measure-preserve.mjs <base.npz> <candidate.npz> [--ranges 40:80,120:150] [--json]\n" +
+				"                            [--max-l2p M] [--max-l2r RAD] [--max-foot-delta M]"
+		);
+		process.exit(2);
+	}
+
+	let report;
+	try {
+		const base = loadMotion(basePath);
+		// The candidate inherits the base's fps when it carries none: the two are
+		// the same take before and after regeneration, so silently assuming a
+		// different default would fake a resample.
+		const candidate = loadMotion(candidatePath, { defaultFps: base.fps });
+		report = measurePreserve(base, candidate, parsed.options.ranges);
+	} catch (error) {
+		console.error(error.message);
+		process.exit(2);
+	}
+
+	// Gates are evaluated before printing so the failures can ride along in the
+	// JSON, which is the form the acceptance harness consumes.
+	const failures = [];
+	const { maxL2p, maxL2r, maxFootDelta } = parsed.options;
+	if (maxL2p !== null && !(report.l2p_m.mean <= maxL2p)) {
+		failures.push(`L2P ${report.l2p_m.mean} > --max-l2p ${maxL2p}`);
+	}
+	if (maxL2r !== null && !(report.l2r_rad.mean <= maxL2r)) {
+		failures.push(`L2R ${report.l2r_rad.mean} > --max-l2r ${maxL2r}`);
+	}
+	if (maxFootDelta !== null && !(report.footSliding.delta_m_per_frame <= maxFootDelta)) {
+		failures.push(`foot slide delta ${report.footSliding.delta_m_per_frame} > --max-foot-delta ${maxFootDelta}`);
+	}
+
+	if (parsed.options.json) {
+		console.log(JSON.stringify({ ...report, failures }, null, 2));
+	} else {
+		printReport(report);
+		for (const failure of failures) console.error(`FAIL: ${failure}`);
+	}
+	process.exit(failures.length ? 1 : 0);
+}

--- a/tools/kimodo/preserve-mask.mjs
+++ b/tools/kimodo/preserve-mask.mjs
@@ -1,0 +1,235 @@
+/**
+ * preserve-mask.mjs — user edit ranges → Kimodo's `--preserve_mask` JSON (C1 v1).
+ *
+ * Scheduled inpainting (Disney, "Interactive Generative Motion Editing via
+ * Scheduled Inpainting", 2026) blends a preserved base take back into the
+ * evolving sample inside the denoising loop:
+ *
+ *   x_blended = alpha_t * noise(base, t) + (1 - alpha_t) * x_gen
+ *   alpha_t   = alpha_time(t) * alpha_mask(frame)
+ *
+ * This file builds ONLY alpha_mask: one float per GENERATION frame, 1 = keep the
+ * base take exactly, 0 = let the model generate freely. Everything about
+ * diffusion time (sigma_s / sigma_e) lives on the Python side; the mask is a
+ * pure function of "which frames did the user edit".
+ *
+ * Three things are silent-bug shaped here, so each is pinned by
+ * test/verify-kimodo-preserve.mjs:
+ *
+ * 1. FRAME SPACE. Edit ranges arrive in the app's clip space, which runs at
+ *    ARDY's 20 fps (src/App.jsx ARDY_FPS). Kimodo generates at 30. An unscaled
+ *    range would free the wrong 2/3 of the clip — the user edits seconds 2..4
+ *    and the model regenerates seconds 1.33..2.67. The scaling rule is copied
+ *    verbatim from buildRoot2dConstraints in ./constraints.mjs (frame * genFps /
+ *    appFps, Math.round, clamped into the generated clip) so a waypoint and an
+ *    edit range authored on the same app frame always land on the same
+ *    generation frame. If that rule ever changes, it must change in both files.
+ *
+ * 2. THE FALLOFF MUST NOT BE A STEP. The paper's own ablation is explicit: a
+ *    square (hard-edged) kernel breaks motion at the seam — the preserved side
+ *    is frozen on the base pose and the free side is generated with no knowledge
+ *    of it, so the character snaps. The edit's influence therefore decays as a
+ *    Gaussian shoulder over `influenceRadius` generation frames:
+ *
+ *      weight(f) = 1 - exp( -(d^2) / (2 * sigma^2) ),  sigma = influenceRadius/2
+ *
+ *    where d is the distance in generation frames from f to the NEAREST frame of
+ *    the edit range (so d = 0 anywhere inside it, giving weight 0 = fully free).
+ *    sigma = radius/2 is chosen so the named radius is 2 sigma: weight is ~0.86
+ *    at exactly `influenceRadius` frames out and reaches float-exact 1.0 around
+ *    4.3 radii, i.e. "the radius is where the edit has mostly stopped mattering",
+ *    not where it is cut off. The first step away from a boundary is only
+ *    1 - exp(-1/(2*sigma^2)) (0.0198 for the default radius 10), which is the
+ *    smoothness the tests assert.
+ *
+ * 3. OVERLAPS TAKE THE MINIMUM. Two edits whose shoulders meet must not add up
+ *    to MORE preservation in the gap between them than either edit asked for on
+ *    its own. Combining by min means "any edit that wants this frame free wins",
+ *    which is the only rule that keeps the mask monotone in the number of edits:
+ *    adding an edit can never preserve a frame harder than before.
+ *
+ * Reserved for v2 and deliberately NOT emitted: `jointWeights` (per-joint
+ * masking). Kimodo's denoiser input contract is per-frame in v1.
+ */
+
+export const PRESERVE_MASK_VERSION = 1;
+
+/** Default shoulder width in GENERATION frames (~0.33 s at 30 fps). */
+export const DEFAULT_INFLUENCE_RADIUS = 10;
+
+function requireFinite(value, label) {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error(`buildPreserveMask: ${label} must be a finite number, got ${JSON.stringify(value)}`);
+	}
+	return value;
+}
+
+function requirePositive(value, label) {
+	requireFinite(value, label);
+	if (value <= 0) {
+		throw new Error(`buildPreserveMask: ${label} must be greater than 0, got ${JSON.stringify(value)}`);
+	}
+	return value;
+}
+
+/**
+ * Turn APP-space edit ranges into the dense per-frame preserve mask (C1 v1).
+ *
+ * @param {Array<{startFrame:number,endFrame:number}>} editRanges
+ *   Half-open [startFrame, endFrame) ranges in APP frame space (20 fps clip).
+ *   An EMPTY array is valid and means "nothing was edited": the result is all
+ *   ones, i.e. pure reconstruction of the base take. That case is the project's
+ *   G1 acceptance gate, so it must be expressible, not an error.
+ * @param {{appFps:number, genFps:number, genFrames:number, influenceRadius?:number}} options
+ * @returns {{version:1, genFps:number, genFrames:number, weights:number[]}}
+ */
+export function buildPreserveMask(
+	editRanges,
+	{ appFps, genFps, genFrames, influenceRadius = DEFAULT_INFLUENCE_RADIUS } = {}
+) {
+	if (!Array.isArray(editRanges)) {
+		throw new Error(`buildPreserveMask: editRanges must be an array, got ${JSON.stringify(editRanges)}`);
+	}
+	requirePositive(appFps, "appFps");
+	requirePositive(genFps, "genFps");
+	requirePositive(genFrames, "genFrames");
+	if (genFrames < 1) throw new Error(`buildPreserveMask: genFrames must be >= 1, got ${genFrames}`);
+	// influenceRadius 0 is EXPLICITLY ALLOWED and means a hard-edged square
+	// kernel. The paper measured that as the broken case, so it is never the
+	// default — but a caller that has already smoothed its own seam (or is
+	// measuring the ablation, tools/kimodo/measure-preserve.mjs) needs the opt
+	// out, and silently substituting a ramp would falsify their measurement.
+	if (!Number.isInteger(influenceRadius) || influenceRadius < 0) {
+		throw new Error(
+			`buildPreserveMask: influenceRadius must be a non-negative integer, got ${JSON.stringify(influenceRadius)}`
+		);
+	}
+
+	const scale = genFps / appFps;
+	const frameCount = Math.round(genFrames);
+	const lastFrame = frameCount - 1;
+
+	// Validate and scale every range in author order first, so a bad edit list is
+	// refused before any of it shapes the mask.
+	const scaled = editRanges.map((range, index) => {
+		if (!range || typeof range !== "object") {
+			throw new Error(`buildPreserveMask: editRanges[${index}] must be an object`);
+		}
+		const { startFrame, endFrame } = range;
+		if (!Number.isInteger(startFrame) || startFrame < 0) {
+			throw new Error(
+				`buildPreserveMask: editRanges[${index}].startFrame must be a non-negative integer, got ${JSON.stringify(startFrame)}`
+			);
+		}
+		if (!Number.isInteger(endFrame) || endFrame < 0) {
+			throw new Error(
+				`buildPreserveMask: editRanges[${index}].endFrame must be a non-negative integer, got ${JSON.stringify(endFrame)}`
+			);
+		}
+		// Ranges are half-open, so an empty or inverted one edits nothing. It is
+		// almost always an off-by-one in the caller rather than intent, and
+		// accepting it would produce an all-ones mask that looks like a working
+		// reconstruction while silently ignoring the user's edit.
+		if (endFrame <= startFrame) {
+			throw new Error(
+				`buildPreserveMask: editRanges[${index}] must be a non-empty half-open range, got [${startFrame}, ${endFrame})`
+			);
+		}
+
+		const rawStart = Math.round(startFrame * scale);
+		const rawEnd = Math.round(endFrame * scale);
+		// A range that misses the generated clip entirely cannot be clamped into
+		// anything meaningful — clamping it would free a frame at one end that the
+		// user never touched. Refuse it by name, quoting the clip length, because
+		// the usual cause is a mask built against a different take's duration.
+		if (rawStart >= frameCount || rawEnd <= 0) {
+			throw new Error(
+				`buildPreserveMask: editRanges[${index}] [${startFrame}, ${endFrame}) scales to generation frames [${rawStart}, ${rawEnd}) which lies outside the ${frameCount}-frame clip`
+			);
+		}
+
+		// Partial overlap CLAMPS rather than throwing: an edit that runs off the
+		// end of the clip still asks for the frames it shares with it.
+		const start = Math.min(lastFrame, Math.max(0, rawStart));
+		// The exclusive end clamps to frameCount, not frameCount - 1: the last
+		// index this frees is end - 1, which is still inside [0, frameCount - 1].
+		// Clamping the END index itself would silently preserve the clip's final
+		// frame even when the user edited right up to it.
+		// A downscale (e.g. 60 fps app -> 30 fps generation) can also round both
+		// ends onto one frame; forcing at least one free frame keeps the edit
+		// visible instead of collapsing it to nothing.
+		const end = Math.min(frameCount, Math.max(start + 1, rawEnd));
+		return { start, end };
+	});
+
+	// 1.0 everywhere = preserve the whole base take. Edits only ever subtract.
+	const weights = new Array(frameCount).fill(1);
+	// sigma = radius/2; see the header for why the named radius is 2 sigma.
+	const sigma = influenceRadius / 2;
+	const twoSigmaSquared = 2 * sigma * sigma;
+
+	for (const { start, end } of scaled) {
+		for (let frame = 0; frame < frameCount; frame += 1) {
+			// Distance to the NEAREST frame of the range. `end` is exclusive, so the
+			// last free frame is end - 1 and the first frame past the range is one
+			// step away from it, not zero — getting this wrong would shift the whole
+			// trailing shoulder by a frame.
+			let distance = 0;
+			if (frame < start) distance = start - frame;
+			else if (frame > end - 1) distance = frame - (end - 1);
+
+			let weight;
+			if (distance === 0) {
+				weight = 0; // inside the edit: fully free generation
+			} else if (influenceRadius === 0) {
+				weight = 1; // opt-in hard edge: no shoulder at all
+			} else {
+				weight = 1 - Math.exp(-(distance * distance) / twoSigmaSquared);
+			}
+
+			// MIN, not sum or product: any edit that wants this frame free wins, so
+			// adding an edit can never preserve a frame harder than before.
+			if (weight < weights[frame]) weights[frame] = weight;
+		}
+	}
+
+	// Clamp defensively. The Gaussian is analytically inside [0, 1), but the mask
+	// is fed straight into a blend coefficient and a value outside [0, 1] there
+	// would amplify rather than mix, so the invariant is enforced, not assumed.
+	for (let frame = 0; frame < frameCount; frame += 1) {
+		weights[frame] = Math.min(1, Math.max(0, weights[frame]));
+	}
+
+	return { version: PRESERVE_MASK_VERSION, genFps, genFrames: frameCount, weights };
+}
+
+/**
+ * Summarise a mask for the UI and for run reporting: how much of the take is
+ * being regenerated, how much is held, and how much is the blend in between.
+ * A run whose rampFrames dwarf its freeFrames is a warning sign — the shoulders
+ * are wider than the edit, so the "preserved" take will drift almost everywhere.
+ *
+ * Accepts either the mask object from buildPreserveMask or a bare weights array.
+ *
+ * @param {{weights:number[]}|number[]} mask
+ * @returns {{freeFrames:number, preservedFrames:number, rampFrames:number}}
+ */
+export function preserveMaskStats(mask) {
+	const weights = Array.isArray(mask) ? mask : mask && mask.weights;
+	if (!Array.isArray(weights)) {
+		throw new Error("preserveMaskStats: mask must be a preserve mask object or a weights array");
+	}
+	let freeFrames = 0;
+	let preservedFrames = 0;
+	let rampFrames = 0;
+	for (let index = 0; index < weights.length; index += 1) {
+		const weight = weights[index];
+		if (typeof weight !== "number" || !Number.isFinite(weight)) {
+			throw new Error(`preserveMaskStats: weights[${index}] must be a finite number, got ${JSON.stringify(weight)}`);
+		}
+		if (weight === 0) freeFrames += 1;
+		else if (weight === 1) preservedFrames += 1;
+		else rampFrames += 1;
+	}
+	return { freeFrames, preservedFrames, rampFrames };
+}

--- a/tools/kimodo/runner.mjs
+++ b/tools/kimodo/runner.mjs
@@ -8,14 +8,27 @@
  * does for ARDY.
  *
  * WHAT THIS BACKEND DOES NOT DO. Kimodo is wired here for text-to-motion
- * sequencing, root 2D paths, pinned poses and motion edit. Base clips remain
- * ARDY-specific machinery in this repo (a base clip is autoregressive history,
- * which Kimodo has no input for) and refuse by name instead of silently
- * producing a take that ignored them.
+ * sequencing, root 2D paths, pinned poses, motion edit and scheduled
+ * inpainting. Base clips remain ARDY-specific machinery in this repo (a base
+ * clip is autoregressive history, which Kimodo has no input for) and refuse by
+ * name instead of silently producing a take that ignored them.
+ *
+ * HOW SCHEDULED INPAINTING TRAVELS. Between this runner and the code that
+ * actually builds the kimodo_gen command line (tools/kimodo/generate.mjs) sit
+ * the two wrapper scripts run-sequence-on-box.mjs and run-edit-on-box.mjs,
+ * whose argv is a stable contract shared with the ARDY wrappers. Preserve
+ * inputs therefore ride the ENVIRONMENT, which is the channel every other
+ * Kimodo tunable already uses (CCLAY_KIMODO_GEN_FPS, _DIFFUSION_STEPS,
+ * _TRANSITION_FRAMES ...):
+ *
+ *   CCLAY_KIMODO_PRESERVE     JSON {basePath, sigmaS, sigmaE, editRanges, maskPath}
+ *   CCLAY_KIMODO_NATIVE_OUT   where this run keeps Kimodo's own npz, so a LATER
+ *                             run can preserve from it
  */
 
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -37,6 +50,23 @@ function run(argv, timeoutMs = 60_000) {
 			resolve({ code, stdout, stderr });
 		});
 	});
+}
+
+/**
+ * Where a run whose bridge output is `outputPath` keeps Kimodo's OWN npz.
+ *
+ * `--base_motion` reads the format kimodo_gen writes (77-joint somaskel, no fps
+ * member); the file the bridge serves at /ardy/motions/<id> is the cskel27
+ * conversion of it and cannot be fed back in. One place decides this name:
+ * generate.mjs writes the file, baseMotionFor finds it again.
+ */
+export function nativeMotionPath(outputPath) {
+	return `${String(outputPath).replace(/\.npz$/i, "")}.kimodo.npz`;
+}
+
+/** The preserve mask this run ships, kept beside the take for inspection. */
+export function preserveMaskPath(outputPath) {
+	return join(dirname(outputPath), "preserve-mask.json");
 }
 
 function unsupported(feature) {
@@ -83,7 +113,39 @@ export function createKimodoRunner() {
 		return [];
 	}
 
-	function sequenceCommand({ segments, waypoints, poseFroms, seed, output }) {
+	// The environment every box wrapper inherits. Scheduled inpainting is
+	// carried here rather than on argv (see the header); both keys are DELETED
+	// when this run does not want them, because process.env is inherited from a
+	// long-lived sidecar and a leftover value would silently preserve the wrong
+	// take on the next request.
+	function boxEnv({ output, keepNative = false, preserve = null } = {}) {
+		const env = {
+			...process.env,
+			CCLAY_KIMODO_HOST: HOST,
+			CCLAY_KIMODO_REPO: REPO,
+			CCLAY_KIMODO_MODEL: MODEL,
+		};
+		delete env.CCLAY_KIMODO_NATIVE_OUT;
+		delete env.CCLAY_KIMODO_PRESERVE;
+		if (keepNative && output) env.CCLAY_KIMODO_NATIVE_OUT = nativeMotionPath(output);
+		if (preserve && output) {
+			// `preserve.basePath` is a take to reconstruct, NOT the ARDY `basePath`
+			// (autoregressive history) that singleCommand still refuses below.
+			env.CCLAY_KIMODO_PRESERVE = JSON.stringify({ ...preserve, maskPath: preserveMaskPath(output) });
+		}
+		return env;
+	}
+
+	// Which artifact of an earlier run can serve as this backend's preserve
+	// base, or null when that take has none — it was spliced together rather
+	// than generated whole, or it predates scheduled inpainting. The bridge
+	// degrades to a plain generation and says so on the status stream.
+	function baseMotionFor(motionPath) {
+		const native = nativeMotionPath(motionPath);
+		return existsSync(native) ? native : null;
+	}
+
+	function sequenceCommand({ segments, waypoints, poseFroms, seed, output, keepNative, preserve }) {
 		const args = [RUN_SEQUENCE];
 		for (const segment of segments) {
 			args.push("--segment", segment.prompt, String(segment.durationS));
@@ -108,12 +170,7 @@ export function createKimodoRunner() {
 		return {
 			command: process.execPath,
 			args,
-			env: {
-				...process.env,
-				CCLAY_KIMODO_HOST: HOST,
-				CCLAY_KIMODO_REPO: REPO,
-				CCLAY_KIMODO_MODEL: MODEL,
-			},
+			env: boxEnv({ output, keepNative, preserve }),
 			doneRe: /^run-kimodo-sequence: done - (.+) \((\d+) bytes\)$/,
 			label: "run-kimodo-sequence",
 		};
@@ -121,11 +178,13 @@ export function createKimodoRunner() {
 
 	// A single prompt is just a one-segment sequence, but only when the request
 	// carries none of the ARDY-only conditioning.
-	function singleCommand({ prompt, durationS, seed, output, basePath, poseFroms, waypoints }) {
+	function singleCommand({ prompt, durationS, seed, output, basePath, poseFroms, waypoints, keepNative, preserve }) {
 		if (basePath) throw new Error("the Kimodo backend does not implement base clips");
 		return sequenceCommand({
 			segments: [{ prompt, durationS }],
 			waypoints,
+			keepNative,
+			preserve,
 			// Pinned poses become Kimodo `fullbody` constraints downstream. The
 			// bridge hands them over as npz paths plus the clip frame to pin them
 			// at; src-frame is an ARDY concept (which frame of a multi-frame npz to
@@ -139,7 +198,7 @@ export function createKimodoRunner() {
 	// Regenerating a span is a whole-clip generation pinned to the source take on
 	// both sides of the edit, then spliced back — Kimodo has no history input, so
 	// the surrounding motion is expressed as constraints instead.
-	function editCommand({ source, manifest, prompt, contextBefore, contextAfter, seed, output }) {
+	function editCommand({ source, manifest, prompt, contextBefore, contextAfter, seed, output, preserve }) {
 		const args = [
 			RUN_EDIT,
 			"--source", source,
@@ -154,12 +213,11 @@ export function createKimodoRunner() {
 		return {
 			command: process.execPath,
 			args,
-			env: {
-				...process.env,
-				CCLAY_KIMODO_HOST: HOST,
-				CCLAY_KIMODO_REPO: REPO,
-				CCLAY_KIMODO_MODEL: MODEL,
-			},
+			// An edit SPLICES its regenerated span into the source take, so the
+			// npz Kimodo wrote is not the take that comes out and must never be
+			// kept as a base — keepNative stays off here. Preserving one is a
+			// different direction and fully supported.
+			env: boxEnv({ output, keepNative: false, preserve }),
 			doneRe: /^run-kimodo-edit: done - (.+) \((\d+) bytes\)$/,
 			label: "run-kimodo-edit",
 		};
@@ -170,6 +228,7 @@ export function createKimodoRunner() {
 		describe: () => `box ${HOST} (repo ${REPO}, model ${MODEL}, retimed to ${TARGET_FPS} fps)`,
 		probeHealth,
 		listBases,
+		baseMotionFor,
 		singleCommand,
 		sequenceCommand,
 		editCommand,

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -50,6 +50,7 @@ const NODE_FILES = [
 	"test/verify-kimodo-cskel27.mjs",
 	"test/verify-kimodo-edit.mjs",
 	"test/verify-kimodo-pose.mjs",
+	"test/verify-kimodo-preserve.mjs",
 	"test/verify-kimodo-runner.mjs",
 	"test/verify-kimodo-setup.mjs",
 	"test/verify-motion-trail.mjs",

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -69,6 +69,7 @@ const NODE_FILES = [
 	"test/verify-otio.mjs",
 	"test/verify-pose-extract.mjs",
 	"test/verify-pose-library.mjs",
+	"test/verify-preserve-bridge.mjs",
 	"test/verify-project.mjs",
 	"test/verify-pwa.mjs",
 	"test/verify-package-signature.mjs",


### PR DESCRIPTION
## 변경 내용
- IK OFF 일반 편집 뷰 우클릭 드래그 중 화면 윤곽선이 진해지거나 깨지는 문제 수정
- 카메라 이동 중 고비용 edge/ink 패스 지연 및 인터랙션 DPR 임시 조정
- 공용 캔버스 해상도 전환 시 Top-View/Shot preview가 비지 않도록 1회 복구 렌더
- 포인터 입력 invalidate를 프레임 단위로 묶어 중복 렌더 감소
- IK 노출 계산/차단물 스캔을 카메라 제스처 중 지연
- preserve/scheduled-inpainting 관련 기존 누적 커밋 포함

## 검증
- `npm test` — 97개 Node 검증 파일 전체 통과
- `npm run build` — 통과
- 실제 로컬 브라우저에서 IK OFF 우클릭 드래그/해제 확인 — 이동 중 윤곽선 안정화, preview 유지, 콘솔 오류 0건

## 확인 URL
- http://127.0.0.1:5180/app/