### PR TITLE
fix(dev): don't start the motion bridge when CCLAY_KIMODO_HOST is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ npm install
 npm run dev
 ```
 
-Open `http://127.0.0.1:5180`. `npm run dev` starts the studio together with its local Kimodo bridge; `npm run dev:ui` starts the browser UI alone, without Block Generation. The bridge listens on loopback only; Kimodo host variables are documented in [`tools/kimodo/setup-on-box.sh`](tools/kimodo/setup-on-box.sh).
+Open `http://127.0.0.1:5180`. `npm run dev` starts the studio together with its local Kimodo bridge once `CCLAY_KIMODO_HOST` points at a GPU box; without that variable it starts the studio alone and says so, and Block Generation stays unavailable until you set it. `npm run dev:ui` starts the browser UI alone in every case. The bridge listens on loopback only; Kimodo host variables are documented in [`tools/kimodo/setup-on-box.sh`](tools/kimodo/setup-on-box.sh).
 
 ## Hosted demo
 

--- a/test/process/verify-bridge-launch.mjs
+++ b/test/process/verify-bridge-launch.mjs
@@ -266,6 +266,20 @@ async function expectLifecycle(kind) {
 	}
 }
 
+// Poll until the studio answers on `port`, or the child dies first.
+async function waitForStudio(port, child) {
+	for (;;) {
+		if (child.exitCode !== null) throw new Error(`dev exited with code ${child.exitCode} before serving the studio`);
+		try {
+			const res = await fetch(`http://127.0.0.1:${port}/app/`);
+			await res.arrayBuffer();
+			return res;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+		}
+	}
+}
+
 // A fresh clone has no CCLAY_KIMODO_HOST, and that must not be a startup
 // failure: `npm run dev` then serves the studio without motion generation, the
 // way `npx cozyclay` and `npm run dev:ui` already do. The sidecar refuses to
@@ -288,9 +302,9 @@ async function expectDevStartsWithoutKimodoHost() {
 			/CCLAY_KIMODO_HOST is not set .* without motion generation/,
 			"dev names the missing Kimodo host without failing",
 		);
-		await output.waitFor(/Local:\s+http:\/\/127\.0\.0\.1:\d+/, "dev Vite readiness without a bridge");
-		const res = await withTimeout(fetch(`http://127.0.0.1:${port}/app/`), "dev studio response without a bridge");
-		await res.arrayBuffer();
+		// Vite's banner is coloured on a CI runner and plain in a local pipe, so
+		// readiness is the studio answering, not a line of output.
+		const res = await withTimeout(waitForStudio(port, child), "dev studio response without a bridge");
 		assert.equal(res.status, 200, "dev serves the studio without a bridge");
 		assert.equal(child.exitCode, null, "dev stays up without a Kimodo host");
 		assert.doesNotMatch(output.all(), /motion dev bridge listening/, "dev starts no bridge without a Kimodo host");

--- a/test/process/verify-bridge-launch.mjs
+++ b/test/process/verify-bridge-launch.mjs
@@ -266,8 +266,42 @@ async function expectLifecycle(kind) {
 	}
 }
 
+// A fresh clone has no CCLAY_KIMODO_HOST, and that must not be a startup
+// failure: `npm run dev` then serves the studio without motion generation, the
+// way `npx cozyclay` and `npm run dev:ui` already do. The sidecar refuses to
+// run without a box to talk to, so launching it anyway killed the studio over
+// a variable a first-time contributor has no reason to have set.
+async function expectDevStartsWithoutKimodoHost() {
+	const reservation = createServer();
+	const port = await listen(reservation);
+	await close(reservation);
+	const env = { ...process.env };
+	delete env.CCLAY_KIMODO_HOST;
+	const child = spawnOwned(process.execPath, ["tools/dev-full.mjs", "--host", "127.0.0.1", "--port", String(port)], {
+		cwd: REPO,
+		env,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const output = createOutputWatcher(child);
+	try {
+		await output.waitFor(
+			/CCLAY_KIMODO_HOST is not set .* without motion generation/,
+			"dev names the missing Kimodo host without failing",
+		);
+		await output.waitFor(/Local:\s+http:\/\/127\.0\.0\.1:\d+/, "dev Vite readiness without a bridge");
+		const res = await withTimeout(fetch(`http://127.0.0.1:${port}/app/`), "dev studio response without a bridge");
+		await res.arrayBuffer();
+		assert.equal(res.status, 200, "dev serves the studio without a bridge");
+		assert.equal(child.exitCode, null, "dev stays up without a Kimodo host");
+		assert.doesNotMatch(output.all(), /motion dev bridge listening/, "dev starts no bridge without a Kimodo host");
+	} finally {
+		await terminateOwned(child);
+	}
+}
+
 await expectBridgeIpcReadiness();
 await expectForeignListenerDoesNotReportBridgeReady();
+await expectDevStartsWithoutKimodoHost();
 {
 	const invalidMainPort = spawnOwned(process.execPath, ["bin/cozyclay.mjs", "--port", "65535", "--no-open", "--no-star"], {
 		cwd: REPO,

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -29,30 +29,47 @@ const children = [];
 const removeSignalCleanup = installSignalCleanup(() => children);
 const trackChild = (child) => children.push(child);
 const untrackChild = (child) => children.splice(children.indexOf(child), 1);
+// The bridge's only backend is Kimodo, and that runner refuses to start
+// without a box to talk to. Starting it unconditionally turned a fresh
+// clone's first `npm run dev` into a hard exit over a variable a new
+// contributor has no reason to have set yet. An unset CCLAY_KIMODO_HOST is
+// the normal case, not a fault — `npx cozyclay` has always treated it that
+// way, and the studio itself already renders the sidecar as absent rather
+// than crashing, which is exactly what `npm run dev:ui` is.
+const kimodoHost = process.env.CCLAY_KIMODO_HOST?.trim();
 let bridge;
 let bridgePort;
-try {
-	({ child: bridge, port: bridgePort } = await startBridge({
-		command: process.execPath,
-		args: ["tools/ardy/bridge.mjs"],
-		cwd: REPO,
-		env: process.env,
-		mainPort: mainPortFrom(viteArgs),
-		onSpawn: trackChild,
-		onFailure: untrackChild,
-	}));
-} catch (err) {
-	console.error(`[dev] Studio did not start: ${err.message}`);
-	removeSignalCleanup();
-	await Promise.allSettled(children.map((child) => terminateOwned(child)));
-	process.exit(1);
+if (kimodoHost) {
+	try {
+		({ child: bridge, port: bridgePort } = await startBridge({
+			command: process.execPath,
+			args: ["tools/ardy/bridge.mjs"],
+			cwd: REPO,
+			env: process.env,
+			mainPort: mainPortFrom(viteArgs),
+			onSpawn: trackChild,
+			onFailure: untrackChild,
+		}));
+	} catch (err) {
+		console.error(`[dev] Studio did not start: ${err.message}`);
+		removeSignalCleanup();
+		await Promise.allSettled(children.map((child) => terminateOwned(child)));
+		process.exit(1);
+	}
+} else {
+	console.error(
+		"[dev] CCLAY_KIMODO_HOST is not set — starting the studio without motion generation (set CCLAY_KIMODO_HOST=user@gpu-box to enable Block Generation).",
+	);
 }
 
 const vite = spawnOwned(process.execPath, ["node_modules/vite/bin/vite.js", ...viteArgs], {
 	cwd: REPO,
 		env: {
 			...process.env,
-			COZYCLAY_BRIDGE_PORT: String(bridgePort),
+			// Left as it came in when no bridge runs: Vite's /ardy proxy then
+			// falls back the same way `dev:ui` does, and the probe fails
+			// gracefully instead of pointing at a port nothing owns.
+			...(bridgePort === undefined ? {} : { COZYCLAY_BRIDGE_PORT: String(bridgePort) }),
 			COZYCLAY_LIVE_PORT: livePort,
 		},
 });


### PR DESCRIPTION
Closes #70.

`tools/dev-full.mjs` started the motion bridge unconditionally as part of
bringing the studio up. The bridge's only backend is Kimodo, and
`createKimodoRunner()` (`tools/kimodo/runner.mjs:96`) throws the moment
`CCLAY_KIMODO_HOST` is unset — which it is on any fresh clone. That throw
propagates through `bridge.mjs`'s `die()` (exit 2), through
`startBridge()`'s rejection, into `dev-full.mjs`'s catch block, and `npm run
dev` exits 1 before Vite ever starts. No motion generation was requested;
nothing was misconfigured beyond a variable a new contributor has no reason
to have set yet.

`bin/cozyclay.mjs` already treats an unset host as the normal case, not a
fault (its own comment says so, `bin/cozyclay.mjs:296-298`), and gates the
bridge behind `opts.motion && kimodoHost && existsSync(BRIDGE)`
(`bin/cozyclay.mjs:319`). `dev-full.mjs` never got the equivalent guard.

**What changed**

- `tools/dev-full.mjs` now checks `CCLAY_KIMODO_HOST` before calling
  `startBridge()`. When it's unset, the bridge is skipped entirely, one
  guidance line is printed naming the variable and an example value, and Vite
  starts regardless. When it's set, behavior is unchanged — the bridge starts
  and a failure still surfaces as `[dev] Studio did not start: ...` and exits
  1, same as before.
- The `COZYCLAY_BRIDGE_PORT` env var passed to the Vite child is now only set
  when a bridge actually started; when it isn't, Vite's `/ardy` proxy falls
  back to its own default the same way `npm run dev:ui` already does, so
  routes the studio doesn't call go nowhere instead of pointing at a port
  nothing owns.
- A regression case in `test/process` covering `dev-full.mjs` with the host
  unset.

**Verification**

- `env -u CCLAY_KIMODO_HOST node tools/dev-full.mjs --host 127.0.0.1 --port 5197`:
  stays up, prints the guidance line, Vite comes up; `GET /app/` → 200,
  `GET /ardy/health` → 502 (the proxy's normal answer when nothing listens —
  `checkBridge()` in `src/ardy/client.js` already renders that as "no sidecar").
- `CCLAY_KIMODO_HOST=fake@box node tools/dev-full.mjs --host 127.0.0.1 --port 5198`:
  the bridge starts on 5199 exactly as before (`[bridge] motion dev bridge listening…`).
- `npm run build && node test/process/verify-bridge-launch.mjs && node test/process/verify-lifecycle.mjs`:
  all pass. The new case is not vacuous: with `tools/dev-full.mjs` temporarily
  restored to `main`'s version it fails with `dev names the missing Kimodo host
  without failing did not happen within 15000 ms` on top of the original crash output.
- Known and unchanged: with no bridge running Vite logs one `http proxy error:
  /ardy/health … ECONNREFUSED` block per 3 s health poll while a studio tab is
  open. `npm run dev:ui` has always behaved the same way; quieting that proxy is
  a separate change if wanted.

This does not change `tools/ardy/bridge.mjs`'s own exit-2 contract when it's
launched directly, and does not touch ARDY or the hosted demo / `npx
cozyclay` path (which already handles this correctly).
