### PR TITLE
chore: harden runtime boundaries and refresh studio QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ https://github.com/user-attachments/assets/1d0113e5-6922-443d-affc-1bdabc666247
 - Node.js 22.13 or newer
 - npm, or bun
 - A Chromium-based browser
-* An SSH-accessible NVIDIA machine running Kimodo, for motion generation — run `npm run kimodo:setup` once; the first setup downloads the Kimodo checkpoint and text-encoder stack.
+- An SSH-accessible NVIDIA machine running Kimodo, for motion generation — run `npm run kimodo:setup` once; the first setup downloads the Kimodo checkpoint and text-encoder stack.
 
 ## Quick start
 
@@ -65,7 +65,7 @@ npx cozyclay
 bunx cozyclay
 ```
 
-That downloads the built studio and opens it at `http://127.0.0.1:5180`. Nothing to compile, no dependency tree to install. Useful flags: `--port 5200`, `--no-open`, `--no-motion`.
+That downloads the built studio and opens it at `http://127.0.0.1:5180/app/`. Nothing to compile, no dependency tree to install. Useful flags: `--port 5200`, `--no-open`, `--no-motion`.
 
 A global install gives you `cclay`, the same command with less typing. Once a day the launcher checks npm for a newer release and prints a one-line notice after the studio is up; it stays quiet when you're current or offline. `cclay update` installs the latest release, and `--no-update-check` skips the check entirely.
 
@@ -120,7 +120,7 @@ npm install
 npm run dev
 ```
 
-Open `http://127.0.0.1:5180`. `npm run dev` starts the studio together with its local Kimodo bridge once `CCLAY_KIMODO_HOST` points at a GPU box; without that variable it starts the studio alone and says so, and Block Generation stays unavailable until you set it. `npm run dev:ui` starts the browser UI alone in every case. The bridge listens on loopback only; Kimodo host variables are documented in [`tools/kimodo/setup-on-box.sh`](tools/kimodo/setup-on-box.sh).
+Open `http://127.0.0.1:5180/app/`. `npm run dev` starts the studio together with its local Kimodo bridge once `CCLAY_KIMODO_HOST` points at a GPU box; without that variable it starts the studio alone and says so, and Block Generation stays unavailable until you set it. `npm run dev:ui` starts the browser UI alone in every case. The bridge listens on loopback only; Kimodo host variables are documented in [`tools/kimodo/setup-on-box.sh`](tools/kimodo/setup-on-box.sh).
 
 ## Hosted demo
 
@@ -204,10 +204,10 @@ See [`workers/api/README.md`](workers/api/README.md) for the deployment, migrati
 | `cd mcp && npm run verify:live` | Live-control protocol against a fake editor (same `npm install` first) |
 | `npm run build` | Production build |
 
-Ad-hoc browser QA, while a dev server is available:
+Ad-hoc browser QA, while a dev server is available (the browser opens the studio at `/app/`):
 
 ```bash
-npm run qa:browser -- <qa-script>
+npm run qa:browser -- node <qa-script>
 ```
 
 ## Contributing

--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -50,7 +50,12 @@ const OFFICIAL_PACKAGE = (
 	&& !existsSync(join(PKG_ROOT, ".git"))
 	&& verifyPackageMarker(join(DIST, "cozyclay-package.json"), PKG_ROOT, packageMetadata)
 );
-let bridgePort = 5181;
+// A bridge is optional. Keep the endpoint unset until this launcher owns a
+// sidecar; otherwise /ardy requests could accidentally reach an unrelated
+// process that happens to be listening on the bridge's historical default
+// port (5181).
+let bridge = null;
+let bridgePort = null;
 
 const TYPES = {
 	".html": "text/html; charset=utf-8",
@@ -145,6 +150,12 @@ function serveFile(res, path) {
 // Forward /ardy to the sidecar. Same contract as the Vite dev proxy, so the
 // browser code needs no build-time knowledge of how it was launched.
 function proxyToBridge(req, res) {
+	if (!bridge || bridgePort === null || bridge.exitCode !== null || bridge.signalCode !== null) {
+		req.resume();
+		res.writeHead(503, { "content-type": "application/json; charset=utf-8" });
+		res.end(JSON.stringify({ error: "motion sidecar is not running" }));
+		return;
+	}
 	const upstream = httpRequest(
 		{ host: "127.0.0.1", port: bridgePort, path: req.url, method: req.method, headers: req.headers },
 		(upstreamRes) => {
@@ -297,7 +308,6 @@ if (!existsSync(join(DIST, "app", "index.html"))) {
 // unconditionally would greet a first-time `npx cozyclay` with an error it
 // cannot act on. An unset CCLAY_KIMODO_HOST is the normal case, not a fault.
 const kimodoHost = process.env.CCLAY_KIMODO_HOST?.trim();
-let bridge = null;
 let server = null;
 const startedAt = Date.now();
 let shuttingDown = false;

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
             "name": "How does motion generation work?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "You sequence multi-phase motion as Prompt Blocks on the timeline and send them to NVIDIA ARDY through a local bridge, then play the result back with sparse IK correction. ARDY is a separate third-party project maintained by NVIDIA; it is not bundled with CozyClay. Staging, root paths, cameras and playback all work without it, and the build ships a pre-generated clip so the timeline has real motion on it from the first run."
+              "text": "You sequence multi-phase motion as Prompt Blocks on the timeline and send them to Kimodo through a local bridge, then play the result back with sparse IK correction. Kimodo is optional: staging, root paths, cameras and playback all work without the bridge, and the build ships a pre-generated clip so the timeline has real motion on it from the first run."
             }
           },
           {
@@ -314,7 +314,7 @@
             <h3>Generate motion</h3>
             <p>
               Pose characters, sequence multi-phase motion as Prompt Blocks on a resizable
-              timeline, send them to NVIDIA ARDY, then play the result back with sparse IK
+              timeline, send them to Kimodo, then play the result back with sparse IK
               correction where the generated motion needs fixing.
             </p>
           </div>
@@ -335,7 +335,7 @@ cd CozyClay
 npm install
 npm run dev</code></pre>
         <p class="note">
-          <code>npm run dev</code> starts the studio together with its local ARDY bridge;
+          <code>npm run dev</code> starts the studio together with its local Kimodo bridge;
           <code>npm run dev:ui</code> starts the browser UI alone, without motion generation.
         </p>
       </section>
@@ -417,12 +417,10 @@ npm run dev</code></pre>
           <summary>How does motion generation work?</summary>
           <p>
             You sequence multi-phase motion as Prompt Blocks on the timeline and send them to
-            <a href="https://github.com/nv-tlabs/ardy">NVIDIA ARDY</a> through a local bridge,
-            then play the result back with sparse IK correction. ARDY is a separate third-party
-            project owned and maintained by NVIDIA; it is not bundled here, and CozyClay is not
-            affiliated with or endorsed by NVIDIA. Staging, root paths, cameras and playback all
-            work without it, and the build ships a pre-generated clip so the timeline has real
-            motion on it from the first run.
+            Kimodo through a local bridge, then play the result back with sparse IK correction.
+            The bridge is optional: staging, root paths, cameras and playback all work without
+            it, and the build ships a pre-generated clip so the timeline has real motion on it
+            from the first run.
           </p>
         </details>
         <details>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { Line, OrthographicCamera, PerspectiveCamera, Text, useFBX } from "@react-three/drei";
 import * as THREE from "three";
-import { SkeletonUtils } from "three/examples/jsm/Addons.js";
+import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils.js";
 import { buildArdyPose } from "./ardy/export.js";
 import { checkBridge, generate as ardyGenerate } from "./ardy/client.js";
 import { characterScaleFor, loadMotionFromUrl } from "./ardy/npz.js";

--- a/src/pose-thumbs.js
+++ b/src/pose-thumbs.js
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader.js";
-import { SkeletonUtils } from "three/examples/jsm/Addons.js";
+import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils.js";
 import { applyPose, primeBindPose, POSE_BONES } from "./poses.js";
 
 /**

--- a/test/process/verify-bridge-launch.mjs
+++ b/test/process/verify-bridge-launch.mjs
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { execFile, fork } from "node:child_process";
 import { once } from "node:events";
+import { createServer as createHttpServer } from "node:http";
 import { createConnection, createServer } from "node:net";
 import { promisify } from "node:util";
 import { spawnOwned, terminateOwned } from "../../tools/process-supervisor.mjs";
@@ -164,6 +165,64 @@ function launch(kind, port, env = {}) {
 	return { child, output: createOutputWatcher(child) };
 }
 
+function launchPackageNoMotion(port) {
+	const env = { ...process.env, CCLAY_MOTION_BACKEND: "kimodo" };
+	delete env.CCLAY_KIMODO_HOST;
+	delete env.COZYCLAY_BRIDGE_PORT;
+	delete env.COZYCLAY_BRIDGE_URL;
+	const child = spawnOwned(
+		process.execPath,
+		["bin/cozyclay.mjs", "--host", "127.0.0.1", "--port", String(port), "--no-open", "--no-star", "--no-motion"],
+		{ cwd: REPO, env, stdio: ["ignore", "pipe", "pipe"] },
+	);
+	return { child, output: createOutputWatcher(child) };
+}
+
+async function expectNoMotionDoesNotProxyForeignBridge() {
+	const foreign = createHttpServer((_req, res) => {
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(JSON.stringify({ foreign: true }));
+	});
+	let foreignListening = false;
+	try {
+		try {
+			await listen(foreign, 5181);
+			foreignListening = true;
+		} catch (error) {
+			if (error?.code !== "EADDRINUSE") throw error;
+		}
+		const reservation = createServer();
+		const port = await listen(reservation);
+		await close(reservation);
+		const { child, output } = launchPackageNoMotion(port);
+		try {
+			await output.waitFor(/CozyClay is running at http:\/\/127\.0\.0\.1:(\d+)\/app\//, "package no-motion server readiness");
+			const response = await fetch(`http://127.0.0.1:${port}/ardy/health`);
+			const body = await response.text();
+			assert.equal(response.status, 503, "no-motion /ardy routes return unavailable instead of proxying");
+			assert.match(body, /motion sidecar is not running/, "no-motion response identifies the unavailable sidecar");
+		} finally {
+			await terminateOwned(child);
+		}
+	} finally {
+		if (foreignListening) await close(foreign);
+	}
+}
+
+async function expectViteProxyRequiresExplicitBridge() {
+	const script = "import config from './vite.config.js'; console.log(JSON.stringify(config.server?.proxy?.['/ardy']?.target ?? null));";
+	const withoutBridge = { ...process.env };
+	delete withoutBridge.COZYCLAY_BRIDGE_PORT;
+	delete withoutBridge.COZYCLAY_BRIDGE_URL;
+	const none = await execFileAsync(process.execPath, ["--input-type=module", "-e", script], { cwd: REPO, env: withoutBridge });
+	assert.equal(JSON.parse(none.stdout.trim()), null, "Vite UI-only mode does not proxy to a default bridge port");
+	const explicit = await execFileAsync(process.execPath, ["--input-type=module", "-e", script], {
+		cwd: REPO,
+		env: { ...withoutBridge, COZYCLAY_BRIDGE_PORT: "61234" },
+	});
+	assert.equal(JSON.parse(explicit.stdout.trim()), "http://127.0.0.1:61234", "Vite preserves an explicit dev-full bridge endpoint");
+}
+
 async function expectLaunchFailure(kind, env, expected) {
 	const reservation = createServer();
 	const port = await listen(reservation);
@@ -316,6 +375,8 @@ async function expectDevStartsWithoutKimodoHost() {
 await expectBridgeIpcReadiness();
 await expectForeignListenerDoesNotReportBridgeReady();
 await expectDevStartsWithoutKimodoHost();
+await expectNoMotionDoesNotProxyForeignBridge();
+await expectViteProxyRequiresExplicitBridge();
 {
 	const invalidMainPort = spawnOwned(process.execPath, ["bin/cozyclay.mjs", "--port", "65535", "--no-open", "--no-star"], {
 		cwd: REPO,

--- a/test/verify-cutout-browser.mjs
+++ b/test/verify-cutout-browser.mjs
@@ -9,8 +9,9 @@
  * size the right way up. This drives Chrome over CDP with a real file on a
  * real <input type="file">.
  *
- * Run: `npm run dev:ui` in one shell, then `npm run test:cutout`, which
- * launches the headless QA browser against QA_URL (default 127.0.0.1:5180).
+ * Run: `npm run dev:ui` in one shell, then
+ * `QA_URL=http://127.0.0.1:5180/app/ npm run qa:browser -- node test/verify-cutout-browser.mjs`.
+ * The QA browser defaults to the studio route (`/app/`), not the landing page.
  */
 
 import { deflateSync } from "node:zlib";

--- a/tools/ardy/visual-qa.mjs
+++ b/tools/ardy/visual-qa.mjs
@@ -5,11 +5,12 @@
  * frames for pose review.
  *
  * Usage: node tools/ardy/visual-qa.mjs <outDir> [url]
+ * The default URL is the studio route (`/app/`), not the marketing landing page.
  */
 import { writeFileSync, mkdirSync } from "node:fs";
 
 const OUT = process.argv[2] || "/tmp/visual-qa";
-const URL = process.argv[3] || "http://127.0.0.1:5180/";
+const URL = process.argv[3] || "http://127.0.0.1:5180/app/";
 mkdirSync(OUT, { recursive: true });
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -75,12 +76,24 @@ await tab.send("Runtime.enable");
 await tab.send("Page.navigate", { url: URL });
 await sleep(6000);
 
+// Prompt Blocks replaced the old single "Generate motion" field. Select the
+// first character, open the Prompt Blocks foldout, then add a block before
+// looking for its prompt input and batch Generate action.
+await evaluate(tab, `(() => {
+	const character = [...document.querySelectorAll('.hierarchy-row')].find((row) => /Character 1|Subject 1|인물 1/.test(row.textContent));
+	character?.click();
+	const foldout = [...document.querySelectorAll('.foldout-head')].find((button) => /Prompt Blocks|프롬프트 블록/.test(button.textContent));
+	foldout?.click();
+	const add = document.querySelector('.tl-track.prompts .tl-track-add') || document.querySelector('.tl-track-add[title*="prompt"]');
+	add?.click();
+	return true;
+})()`);
+await sleep(400);
 const state0 = await evaluate(tab, `(() => {
 	const seed = document.querySelector('input[placeholder="empty = random"]');
-	const gen = [...document.querySelectorAll("button")].find(b => /generate motion/i.test(b.textContent));
-	const promptEl = [...document.querySelectorAll("textarea, input")].find(e =>
-		(e.closest("div,label")?.textContent || "").includes("Motion prompt"));
-	return { seedValue: seed?.value ?? null, hasGenerate: !!gen, hasPrompt: !!promptEl };
+	const promptEl = document.querySelector('input[placeholder*="motion block"], input[placeholder*="모션 블록"]');
+	const gen = document.querySelector('button.prompt-block-generate');
+	return { seedValue: seed?.value ?? null, hasGenerate: !!gen, generateDisabled: !!gen?.disabled, hasPrompt: !!promptEl };
 })()`);
 console.log("initial:", JSON.stringify(state0));
 
@@ -88,15 +101,13 @@ if (!state0.hasGenerate || !state0.hasPrompt) {
 	await shot(tab, "00-no-ui");
 	throw new Error("studio UI not ready");
 }
-if (state0.seedValue !== "2") {
-	console.log("WARN: seed default is not 2:", state0.seedValue);
-}
+if (state0.seedValue === null) throw new Error("Prompt Blocks panel did not open");
 
 // Set the prompt and generate: focus the field, then type via the Input
 // domain so React's controlled input sees real key events.
 await evaluate(tab, `(() => {
-	const el = [...document.querySelectorAll("textarea, input")].find(e =>
-		(e.closest("div,label")?.textContent || "").includes("Motion prompt"));
+	const el = document.querySelector('input[placeholder*="motion block"], input[placeholder*="모션 블록"]');
+	if (!el) return false;
 	el.focus();
 	el.select?.();
 	return true;
@@ -107,11 +118,13 @@ for (const key of ["a", " ", "p", "e", "r", "s", "o", "n", " ", "w", "a", "l", "
 }
 await sleep(300);
 await shot(tab, "01-before-generate");
-await evaluate(tab, `(() => {
-	const gen = [...document.querySelectorAll("button")].find(b => /generate motion/i.test(b.textContent));
+const clicked = await evaluate(tab, `(() => {
+const gen = document.querySelector('button.prompt-block-generate');
+	if (!gen || gen.disabled) return false;
 	gen.click();
 	return true;
 })()`);
+if (!clicked) throw new Error("Kimodo bridge is unavailable or generation is disabled");
 console.log("generate clicked, waiting for the clip...");
 
 // Wait for "Motion loaded" or the PLAYBACK badge (generation ~12 s).
@@ -128,27 +141,22 @@ if (!loaded) {
 }
 await sleep(1500);
 
-// Scrub to specific frames via the timeline frame buttons and capture.
+// Scrub to specific frames by clicking the timeline's accessible ruler. The
+// old tick-text selector clicked labels, not the scrub surface, after the
+// timeline was redesigned.
 const frames = [0, 20, 40, 60, 79];
 for (const f of frames) {
-	const okFrame = await evaluate(tab, `(() => {
-		const btns = [...document.querySelectorAll("button, span, div")].filter(e =>
-			e.textContent.trim() === "${f}" && e.closest('[class*="tl"], [class*="frame"], [class*="track"]'));
-		if (btns.length) { btns[0].click(); return "tick"; }
-		return "no-tick";
+	const point = await evaluate(tab, `(() => {
+		const lane = document.querySelector('[role="slider"][aria-label*="Scrub timeline"], [role="slider"][aria-label*="타임라인"]');
+		if (!lane) return null;
+		const rect = lane.getBoundingClientRect();
+		const max = Math.max(1, Number(lane.getAttribute('aria-valuemax')) || 1);
+		return { x: rect.left + rect.width * Math.min(1, ${f} / max), y: rect.top + rect.height / 2 };
 	})()`);
-	if (okFrame === "no-tick") {
-		// fall back: type the frame into a frame input if one exists
-		await evaluate(tab, `(() => {
-			const inp = [...document.querySelectorAll("input")].find(e => /frame/i.test(e.closest("div,label")?.textContent || "") || e.type === "number");
-			if (!inp) return false;
-			const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-			setter.call(inp, "${f}");
-			inp.dispatchEvent(new Event("input", { bubbles: true }));
-			inp.dispatchEvent(new Event("change", { bubbles: true }));
-			return true;
-		})()`);
-	}
+	if (!point) throw new Error("timeline scrub ruler not found");
+	await tab.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y, button: "none" });
+	await tab.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
+	await tab.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
 	await sleep(700);
 	await shot(tab, `10-frame-${String(f).padStart(2, "0")}`);
 }

--- a/tools/ardy/vq-car.mjs
+++ b/tools/ardy/vq-car.mjs
@@ -37,7 +37,7 @@ const tab = await newTab();
 await tab.send("Page.enable"); await tab.send("Runtime.enable");
 await tab.send("Network.enable");
 await tab.send("Network.setCacheDisabled", { cacheDisabled: true });
-await tab.send("Page.navigate", { url: "http://127.0.0.1:5180/?v=" + Date.now() });
+await tab.send("Page.navigate", { url: "http://127.0.0.1:5180/app/?v=" + Date.now() });
 await sleep(7000);
 await shot(tab, "car-default-view");
 // wide preset for a broader read of the set

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,9 +4,15 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { PROMPT_MAX_CHARS } from "./tools/ardy/prompt-limits.mjs";
 
-const motionBridgeUrl = process.env.COZYCLAY_BRIDGE_PORT
-	? `http://127.0.0.1:${process.env.COZYCLAY_BRIDGE_PORT}`
-	: process.env.COZYCLAY_BRIDGE_URL || "http://127.0.0.1:5181";
+// Vite can run as a UI-only server. Do not silently proxy /ardy to the
+// bridge's historical default port: a different local process may own it.
+// dev-full supplies COZYCLAY_BRIDGE_PORT after starting its own sidecar;
+// COZYCLAY_BRIDGE_URL remains an explicit escape hatch for a user-managed
+// bridge.
+const explicitBridgePort = process.env.COZYCLAY_BRIDGE_PORT?.trim();
+const motionBridgeUrl = explicitBridgePort
+	? `http://127.0.0.1:${explicitBridgePort}`
+	: process.env.COZYCLAY_BRIDGE_URL?.trim() || null;
 const livePort = process.env.COZYCLAY_LIVE_PORT ?? "5184";
 
 export default defineConfig({
@@ -48,10 +54,17 @@ export default defineConfig({
 			apply: "serve",
 			configureServer(server) {
 				server.middlewares.use((req, res, next) => {
+					const path = (req.url || "").split("?")[0];
+					if (!motionBridgeUrl && /^\/ardy\/(health|bases|generate|footage|extract|motions)(\/|$)/.test(path)) {
+						res.statusCode = 503;
+						res.setHeader("content-type", "application/json; charset=utf-8");
+						res.end(JSON.stringify({ error: "motion sidecar is not configured" }));
+						return;
+					}
 					// The lying clip is a browser-regression fixture. Serve it only from
 					// the dev server so it can exercise the real UI without shipping a
 					// second motion archive in production output.
-					if ((req.url || "").split("?")[0] === "/demo/qa-lying.npz") {
+					if (path === "/demo/qa-lying.npz") {
 						res.statusCode = 200;
 						res.setHeader("content-type", "application/octet-stream");
 						res.setHeader("cache-control", "no-store");
@@ -80,22 +93,25 @@ export default defineConfig({
 	server: {
 		port: 5180,
 		// Dev-only: the motion sidecar (tools/ardy/bridge.mjs) is an optional
-		// companion on loopback. COZYCLAY_BRIDGE_PORT selects it for dev-full;
-		// direct Vite use falls back to 5181. The production build stays fully static
-		// (`base: "./"`, no build-time coupling), so this proxy must never be
-		// promoted into a server-side requirement.
-		proxy: {
-			// Only the routes the bridge actually owns. /ardy/ is ALSO a public
-			// asset directory (cskel27-rest.json), and a blanket proxy would
-			// hand those static files to the bridge, which 404s them.
-			"/ardy": {
-				target: motionBridgeUrl,
-				bypass(req) {
-					const path = (req.url || "").split("?")[0];
-					if (/^\/ardy\/(health|bases|generate|footage|extract|motions)(\/|$)/.test(path)) return undefined;
-					return req.url; // not a bridge route: serve the static asset
+		// companion on loopback. The proxy is enabled only when dev-full (or a
+		// user-managed bridge) explicitly provides its endpoint. The production
+		// build stays fully static, so this proxy must never become a requirement.
+		...(motionBridgeUrl
+			? {
+				proxy: {
+					// Only the routes the bridge actually owns. /ardy/ is ALSO a public
+					// asset directory (cskel27-rest.json), and a blanket proxy would
+					// hand those static files to the bridge, which 404s them.
+					"/ardy": {
+						target: motionBridgeUrl,
+						bypass(req) {
+							const path = (req.url || "").split("?")[0];
+							if (/^\/ardy\/(health|bases|generate|footage|extract|motions)(\/|$)/.test(path)) return undefined;
+							return req.url; // not a bridge route: serve the static asset
+						},
+					},
 				},
-			},
-		},
+			}
+			: {}),
 	},
 });


### PR DESCRIPTION
## What changed
- Fail closed when no motion bridge is owned/configured; prevents cross-session proxying through port 5181.
- Added bridge-launch regressions for no-motion and explicit Vite bridge configuration.
- Replaced Three.js Addons barrel imports with direct SkeletonUtils imports; build no longer emits Draco/Basis assets.
- Updated README, landing copy, visual QA scripts, and cutout QA instructions to use `/app/` and current Kimodo/Prompt Blocks UI.

## Verification
- `npm test` — 106 Node verification files passed
- `node test/process/verify-bridge-launch.mjs` — passed
- `npm run build` — passed; 737 modules, 9 asset files, no Draco/Basis assets
- `QA_URL=http://127.0.0.1:5180/app/ npm run qa:browser -- node tools/ardy/vq-car.mjs` — passed
- `git diff --check` and QA script syntax checks — passed

Known unrelated issue: cutout browser QA still has four existing texture assertions failing; this PR only updates its instructions.