### PR TITLE
fix(gizmo): selected object no longer blocks clicks on other objects (#81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,21 +84,38 @@ jobs:
           done
           exit "$failed"
 
-  # Real-browser rendering regressions via the CDP QA wrapper, in two tiers:
+  # Real-browser rendering regressions via the CDP QA wrapper — one matrix
+  # job per suite, because the suites dominate wall-clock (setup is ~20 s on
+  # the npm cache while verify-ik-browser and verify-object-gizmo together
+  # ran ~12 minutes in series). Splitting makes the whole workflow as fast as
+  # the single slowest suite and lands gating verdicts in a couple of
+  # minutes instead of after the observation tail.
   #
-  # - GATING: suites proven green on the runner fail the job when they fail.
-  #   camera-rail has been green on SwiftShader since the job landed.
-  #   qa-gizmo-click-through-browser guards the #81 regression (a selected
-  #   object's cage swallowing clicks on other objects); it asserts through
-  #   CPU-side raycast hooks and the DOM, not GPU pixels, so software GL is
-  #   not a risk factor for it.
-  # - OBSERVATION: suites the runner's software GL (SwiftShader) cannot pass
+  # Tiers:
+  # - gating: suites proven green on the runner fail their job when they
+  #   fail. camera-rail has been green on SwiftShader since the job landed;
+  #   qa-gizmo-click-through-browser guards the #81 regression and asserts
+  #   through CPU-side raycast hooks and the DOM, not GPU pixels.
+  # - observation: suites the runner's software GL (SwiftShader) cannot pass
   #   yet — ik-browser fails one occlusion check that passes on real GPUs —
   #   plus suites newly joining. Results go to the step summary and a
-  #   warning annotation. Promote a suite to GATING once it is green here.
+  #   warning annotation. Promote a suite to gating once it is green here.
   browser:
+    name: browser / ${{ matrix.suite }} (${{ matrix.tier }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: verify-camera-rail-browser
+            tier: gating
+          - suite: qa-gizmo-click-through-browser
+            tier: gating
+          - suite: verify-ik-browser
+            tier: observation
+          - suite: verify-object-gizmo
+            tier: observation
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -108,9 +125,9 @@ jobs:
       - run: npm ci
       # Vite only. `npm run dev` also starts the motion bridge, which since the
       # Kimodo backend landed exits 2 without CCLAY_KIMODO_HOST — a GPU box CI
-      # does not have, so the whole job died before a single suite ran. Both
-      # suites below drive the studio at /app/ and load their motion from
-      # static /demo/*.npz fixtures, so they need no motion backend.
+      # does not have, so the whole job died before a single suite ran. The
+      # suites drive the studio at /app/ and load their motion from static
+      # /demo/*.npz fixtures, so they need no motion backend.
       - name: Start dev server (vite)
         run: |
           npm run dev:ui -- --host 127.0.0.1 --port 5180 --strictPort &
@@ -120,66 +137,37 @@ jobs:
           done
           echo "dev server did not come up" >&2
           exit 1
-      - name: Browser suites (gating)
+      - name: Run ${{ matrix.suite }} (${{ matrix.tier }})
         run: |
+          t="${{ matrix.suite }}"
+          tier="${{ matrix.tier }}"
           {
-            echo "## Browser suites (gating)"
+            echo "## $t ($tier)"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
-          failed=0
-          for t in verify-camera-rail-browser qa-gizmo-click-through-browser; do
-            if node tools/qa-browser.mjs -- node "test/$t.mjs" > "/tmp/$t.log" 2>&1; then
-              echo "- :white_check_mark: $t ($(grep -c '^PASS' "/tmp/$t.log") checks)" >> "$GITHUB_STEP_SUMMARY"
-              echo "$t: PASS ($(grep -c '^PASS' "/tmp/$t.log") checks)"
-            else
-              failed=1
-              echo "::error title=browser suite failed::$t (see step summary)"
-              echo "::group::$t failure log (last 40 lines)"
-              echo "$t: FAIL ($(grep -c '^PASS' "/tmp/$t.log") checks passed, $(grep -c '^FAIL' "/tmp/$t.log") failed)"
-              tail -40 "/tmp/$t.log"
-              echo "::endgroup::"
-              {
-                echo "- :x: $t"
-                echo "  <details><summary>log tail</summary>"
-                echo ""
-                echo '  ```'
-                tail -40 "/tmp/$t.log" | sed 's/^/  /'
-                echo '  ```'
-                echo "  </details>"
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
-          done
-          exit "$failed"
-      - name: Browser suites (observation mode)
-        # Keep observing even when a gating suite already failed: the summary
-        # for a red run should still say how the other suites fared.
-        if: ${{ always() }}
-        run: |
+          if node tools/qa-browser.mjs -- node "test/$t.mjs" > "/tmp/$t.log" 2>&1; then
+            echo "- :white_check_mark: $t ($(grep -c '^PASS' "/tmp/$t.log") checks)" >> "$GITHUB_STEP_SUMMARY"
+            echo "$t: PASS ($(grep -c '^PASS' "/tmp/$t.log") checks)"
+            exit 0
+          fi
+          # Also to stdout: the step summary is not reachable from the API,
+          # so a summary-only failure cannot be read back when triaging a
+          # run after the fact.
+          echo "::group::$t failure log (last 40 lines)"
+          echo "$t: FAIL ($(grep -c '^PASS' "/tmp/$t.log") checks passed, $(grep -c '^FAIL' "/tmp/$t.log") failed)"
+          tail -40 "/tmp/$t.log"
+          echo "::endgroup::"
           {
-            echo "## Browser suites (observation mode)"
+            echo "- :x: $t"
+            echo "  <details><summary>log tail</summary>"
             echo ""
+            echo '  ```'
+            tail -40 "/tmp/$t.log" | sed 's/^/  /'
+            echo '  ```'
+            echo "  </details>"
           } >> "$GITHUB_STEP_SUMMARY"
-          for t in verify-ik-browser verify-object-gizmo; do
-            if node tools/qa-browser.mjs -- node "test/$t.mjs" > "/tmp/$t.log" 2>&1; then
-              echo "- :white_check_mark: $t ($(grep -c '^PASS' "/tmp/$t.log") checks)" >> "$GITHUB_STEP_SUMMARY"
-              echo "$t: PASS ($(grep -c '^PASS' "/tmp/$t.log") checks)"
-            else
-              echo "::warning title=browser suite failed::$t (see step summary)"
-              # Also to stdout: the step summary is not reachable from the API,
-              # so a summary-only failure cannot be read back when triaging a
-              # run after the fact.
-              echo "::group::$t failure log (last 40 lines)"
-              echo "$t: FAIL ($(grep -c '^PASS' "/tmp/$t.log") checks passed, $(grep -c '^FAIL' "/tmp/$t.log") failed)"
-              tail -40 "/tmp/$t.log"
-              echo "::endgroup::"
-              {
-                echo "- :x: $t"
-                echo "  <details><summary>log tail</summary>"
-                echo ""
-                echo '  ```'
-                tail -40 "/tmp/$t.log" | sed 's/^/  /'
-                echo '  ```'
-                echo "  </details>"
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
-          done
+          if [ "$tier" = "gating" ]; then
+            echo "::error title=browser suite failed::$t (see step summary)"
+            exit 1
+          fi
+          echo "::warning title=browser suite failed::$t (see step summary)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,48 @@ jobs:
           done
           echo "dev server did not come up" >&2
           exit 1
+      # MCP <-> real-editor element management, end to end: each suite spawns
+      # its own Vite, Chrome and MCP server on reserved ports (the shared 5180
+      # server above is not involved). These are the only checks that prove an
+      # element placed/updated/removed over MCP actually lands in the live
+      # editor — they existed but ran nowhere, which is exactly how a broken
+      # capture_frame shipped. Assertions are protocol/JSON-level, not GPU
+      # pixels, so SwiftShader is not a risk factor.
+      - name: MCP live suites (gating)
+        run: |
+          npm --prefix mcp ci
+          {
+            echo "## MCP live suites (gating)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          failed=0
+          for t in verify-live-batch verify-live-scene-parity verify-live-editor-model verify-live-capture; do
+            if node "mcp/$t.mjs" > "/tmp/$t.log" 2>&1; then
+              echo "- :white_check_mark: $t" >> "$GITHUB_STEP_SUMMARY"
+              echo "$t: PASS"
+            else
+              failed=1
+              echo "::error title=MCP live suite failed::$t (see step summary)"
+              echo "::group::$t failure log (last 40 lines)"
+              echo "$t: FAIL"
+              tail -40 "/tmp/$t.log"
+              echo "::endgroup::"
+              {
+                echo "- :x: $t"
+                echo "  <details><summary>log tail</summary>"
+                echo ""
+                echo '  ```'
+                tail -40 "/tmp/$t.log" | sed 's/^/  /'
+                echo '  ```'
+                echo "  </details>"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          exit "$failed"
       - name: Browser suites (gating)
+        # Runs even when the MCP step above is red: one failing tier must not
+        # hide how the other fared.
+        if: ${{ always() }}
         run: |
           {
             echo "## Browser suites (gating)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,18 @@ jobs:
       # under `npm test`; only browser-bound suites stay classified out.
       - run: npm test
 
-  # Real-browser rendering regressions via the CDP QA wrapper. Only the suites
-  # that are green against origin/main run here (ik, camera-rail); the other
-  # browser suites fail on main in a clean headless environment and can join
-  # once fixed.
+  # Real-browser rendering regressions via the CDP QA wrapper, in two tiers:
   #
-  # Observation mode: the runner's software GL (SwiftShader) currently fails
-  # occlusion checks that pass on real GPUs, so results go to the step summary
-  # instead of failing the check. Make this step exit non-zero once the suites
-  # are green on the runner.
+  # - GATING: suites proven green on the runner fail the job when they fail.
+  #   camera-rail has been green on SwiftShader since the job landed.
+  #   qa-gizmo-click-through-browser guards the #81 regression (a selected
+  #   object's cage swallowing clicks on other objects); it asserts through
+  #   CPU-side raycast hooks and the DOM, not GPU pixels, so software GL is
+  #   not a risk factor for it.
+  # - OBSERVATION: suites the runner's software GL (SwiftShader) cannot pass
+  #   yet — ik-browser fails one occlusion check that passes on real GPUs —
+  #   plus suites newly joining. Results go to the step summary and a
+  #   warning annotation. Promote a suite to GATING once it is green here.
   browser:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -67,13 +70,46 @@ jobs:
           done
           echo "dev server did not come up" >&2
           exit 1
+      - name: Browser suites (gating)
+        run: |
+          {
+            echo "## Browser suites (gating)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          failed=0
+          for t in verify-camera-rail-browser qa-gizmo-click-through-browser; do
+            if node tools/qa-browser.mjs -- node "test/$t.mjs" > "/tmp/$t.log" 2>&1; then
+              echo "- :white_check_mark: $t ($(grep -c '^PASS' "/tmp/$t.log") checks)" >> "$GITHUB_STEP_SUMMARY"
+              echo "$t: PASS ($(grep -c '^PASS' "/tmp/$t.log") checks)"
+            else
+              failed=1
+              echo "::error title=browser suite failed::$t (see step summary)"
+              echo "::group::$t failure log (last 40 lines)"
+              echo "$t: FAIL ($(grep -c '^PASS' "/tmp/$t.log") checks passed, $(grep -c '^FAIL' "/tmp/$t.log") failed)"
+              tail -40 "/tmp/$t.log"
+              echo "::endgroup::"
+              {
+                echo "- :x: $t"
+                echo "  <details><summary>log tail</summary>"
+                echo ""
+                echo '  ```'
+                tail -40 "/tmp/$t.log" | sed 's/^/  /'
+                echo '  ```'
+                echo "  </details>"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          exit "$failed"
       - name: Browser suites (observation mode)
+        # Keep observing even when a gating suite already failed: the summary
+        # for a red run should still say how the other suites fared.
+        if: ${{ always() }}
         run: |
           {
             echo "## Browser suites (observation mode)"
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
-          for t in verify-ik-browser verify-camera-rail-browser; do
+          for t in verify-ik-browser verify-object-gizmo; do
             if node tools/qa-browser.mjs -- node "test/$t.mjs" > "/tmp/$t.log" 2>&1; then
               echo "- :white_check_mark: $t ($(grep -c '^PASS' "/tmp/$t.log") checks)" >> "$GITHUB_STEP_SUMMARY"
               echo "$t: PASS ($(grep -c '^PASS' "/tmp/$t.log") checks)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,56 @@ jobs:
       # under `npm test`; only browser-bound suites stay classified out.
       - run: npm test
 
+  # MCP <-> real-editor element management, end to end: each suite spawns its
+  # own Vite, Chrome and MCP server on reserved ports. These are the only
+  # checks that prove an element placed/updated/removed over MCP actually
+  # lands in the live editor — they existed but ran nowhere, which is exactly
+  # how a broken capture_frame shipped. Assertions are protocol/JSON-level,
+  # not GPU pixels, so SwiftShader is not a risk factor. A job of its own,
+  # GATING, in parallel with `browser`: that job already runs ~14 minutes
+  # against a 20-minute timeout and must not absorb four more Chrome boots.
+  mcp-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm --prefix mcp ci
+      - name: MCP live suites (gating)
+        run: |
+          {
+            echo "## MCP live suites (gating)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          failed=0
+          for t in verify-live-batch verify-live-scene-parity verify-live-editor-model verify-live-capture; do
+            if node "mcp/$t.mjs" > "/tmp/$t.log" 2>&1; then
+              echo "- :white_check_mark: $t" >> "$GITHUB_STEP_SUMMARY"
+              echo "$t: PASS"
+            else
+              failed=1
+              echo "::error title=MCP live suite failed::$t (see step summary)"
+              echo "::group::$t failure log (last 40 lines)"
+              echo "$t: FAIL"
+              tail -40 "/tmp/$t.log"
+              echo "::endgroup::"
+              {
+                echo "- :x: $t"
+                echo "  <details><summary>log tail</summary>"
+                echo ""
+                echo '  ```'
+                tail -40 "/tmp/$t.log" | sed 's/^/  /'
+                echo '  ```'
+                echo "  </details>"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          exit "$failed"
+
   # Real-browser rendering regressions via the CDP QA wrapper, in two tiers:
   #
   # - GATING: suites proven green on the runner fail the job when they fail.
@@ -70,48 +120,7 @@ jobs:
           done
           echo "dev server did not come up" >&2
           exit 1
-      # MCP <-> real-editor element management, end to end: each suite spawns
-      # its own Vite, Chrome and MCP server on reserved ports (the shared 5180
-      # server above is not involved). These are the only checks that prove an
-      # element placed/updated/removed over MCP actually lands in the live
-      # editor — they existed but ran nowhere, which is exactly how a broken
-      # capture_frame shipped. Assertions are protocol/JSON-level, not GPU
-      # pixels, so SwiftShader is not a risk factor.
-      - name: MCP live suites (gating)
-        run: |
-          npm --prefix mcp ci
-          {
-            echo "## MCP live suites (gating)"
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-          failed=0
-          for t in verify-live-batch verify-live-scene-parity verify-live-editor-model verify-live-capture; do
-            if node "mcp/$t.mjs" > "/tmp/$t.log" 2>&1; then
-              echo "- :white_check_mark: $t" >> "$GITHUB_STEP_SUMMARY"
-              echo "$t: PASS"
-            else
-              failed=1
-              echo "::error title=MCP live suite failed::$t (see step summary)"
-              echo "::group::$t failure log (last 40 lines)"
-              echo "$t: FAIL"
-              tail -40 "/tmp/$t.log"
-              echo "::endgroup::"
-              {
-                echo "- :x: $t"
-                echo "  <details><summary>log tail</summary>"
-                echo ""
-                echo '  ```'
-                tail -40 "/tmp/$t.log" | sed 's/^/  /'
-                echo '  ```'
-                echo "  </details>"
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
-          done
-          exit "$failed"
       - name: Browser suites (gating)
-        # Runs even when the MCP step above is red: one failing tier must not
-        # hide how the other fared.
-        if: ${{ always() }}
         run: |
           {
             echo "## Browser suites (gating)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,12 @@ jobs:
   # own Vite, Chrome and MCP server on reserved ports. These are the only
   # checks that prove an element placed/updated/removed over MCP actually
   # lands in the live editor — they existed but ran nowhere, which is exactly
-  # how a broken capture_frame shipped. Assertions are protocol/JSON-level,
-  # not GPU pixels, so SwiftShader is not a risk factor. A job of its own,
-  # GATING, in parallel with `browser`: that job already runs ~14 minutes
-  # against a 20-minute timeout and must not absorb four more Chrome boots.
+  # how a broken capture_frame shipped. The element-management suites assert
+  # at the protocol/JSON level and GATE; verify-live-capture actually renders
+  # an offscreen frame, which overruns the 5 s live-command bound under the
+  # runner's software GL (SwiftShader), so it runs in observation until that
+  # bound and the runner get along. A job of its own, in parallel with
+  # `browser`, so the new tier adds no wall-clock to the critical path.
   mcp-live:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -60,7 +62,7 @@ jobs:
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
           failed=0
-          for t in verify-live-batch verify-live-scene-parity verify-live-editor-model verify-live-capture; do
+          for t in verify-live-batch verify-live-scene-parity verify-live-editor-model; do
             if node "mcp/$t.mjs" > "/tmp/$t.log" 2>&1; then
               echo "- :white_check_mark: $t" >> "$GITHUB_STEP_SUMMARY"
               echo "$t: PASS"
@@ -83,6 +85,35 @@ jobs:
             fi
           done
           exit "$failed"
+      - name: MCP live suites (observation)
+        # capture_frame renders a real offscreen frame; SwiftShader overruns
+        # the 5 s live-command bound. Keep it visible without gating.
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## MCP live suites (observation)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          t=verify-live-capture
+          if node "mcp/$t.mjs" > "/tmp/$t.log" 2>&1; then
+            echo "- :white_check_mark: $t" >> "$GITHUB_STEP_SUMMARY"
+            echo "$t: PASS"
+          else
+            echo "::warning title=MCP live suite failed::$t (see step summary)"
+            echo "::group::$t failure log (last 40 lines)"
+            echo "$t: FAIL"
+            tail -40 "/tmp/$t.log"
+            echo "::endgroup::"
+            {
+              echo "- :x: $t"
+              echo "  <details><summary>log tail</summary>"
+              echo ""
+              echo '  ```'
+              tail -40 "/tmp/$t.log" | sed 's/^/  /'
+              echo '  ```'
+              echo "  </details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # Real-browser rendering regressions via the CDP QA wrapper — one matrix
   # job per suite, because the suites dominate wall-clock (setup is ~20 s on

--- a/mcp/qa-chrome.mjs
+++ b/mcp/qa-chrome.mjs
@@ -1,0 +1,32 @@
+// Where the QA Chrome lives, resolved the same way tools/qa-browser.mjs does
+// it: an explicit CHROME_PATH wins, then the macOS app bundle, then the Linux
+// system binaries the CI runner images ship. The live-editor suites spawned
+// their own hardcoded macOS path before, which is why none of them could run
+// in CI at all.
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function resolveChromePath() {
+	const candidates = [
+		process.env.CHROME_PATH,
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/usr/bin/google-chrome",
+		"/usr/bin/chromium",
+	].filter(Boolean);
+	const found = candidates.find(existsSync);
+	if (!found) throw new Error("Google Chrome/Chromium not found; set CHROME_PATH");
+	return found;
+}
+
+/** Standard headless-QA argv: an isolated throwaway profile so parallel or
+ * dirty runner state can never bleed into a suite. Caller appends its URL. */
+export function chromeArgs(cdpPort) {
+	return [
+		"--headless=new",
+		"--no-first-run",
+		"--no-default-browser-check",
+		`--remote-debugging-port=${cdpPort}`,
+		`--user-data-dir=${mkdtempSync(join(tmpdir(), "cozyclay-live-qa-"))}`,
+	];
+}

--- a/mcp/verify-live-batch.mjs
+++ b/mcp/verify-live-batch.mjs
@@ -42,7 +42,11 @@ const waitForOutput = (child, pattern, label) =>
 		new Promise((resolve, reject) => {
 			let output = "";
 			const inspect = (chunk) => {
-				output += chunk.toString();
+				// picocolors turns colour ON when CI is set even without a TTY, and
+				// the port lands inside bold escapes ("...127.0.0.1:\x1b[1m5599...")
+				// — strip ANSI before matching or the ready banner never matches
+				// on a GitHub runner while passing everywhere locally.
+				output += chunk.toString().replace(/\u001b\[[0-9;]*m/g, "");
 				if (pattern.test(output)) finish(resolve);
 			};
 			const onExit = (code, signal) => finish(reject, new Error(`${label} exited (${code ?? signal ?? "unknown"}): ${output}`));

--- a/mcp/verify-live-batch.mjs
+++ b/mcp/verify-live-batch.mjs
@@ -9,6 +9,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { WebSocket } from "ws";
 
+import { chromeArgs, resolveChromePath } from "./qa-chrome.mjs";
+
 const root = fileURLToPath(new URL("..", import.meta.url)); const serverPath = fileURLToPath(new URL("./server.mjs", import.meta.url));
 
 const reservePort = () =>
@@ -70,12 +72,7 @@ const vite = spawn(process.execPath, ["node_modules/vite/bin/vite.js", "--host",
 	env: { ...process.env, COZYCLAY_LIVE_PORT: String(livePort) },
 	stdio: ["ignore", "pipe", "pipe"],
 });
-const browser = spawn("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", [
-	"--headless=new",
-	"--no-first-run",
-	"--no-default-browser-check",
-	`--remote-debugging-port=${cdpPort}`,
-], { stdio: ["ignore", "pipe", "pipe"] });
+const browser = spawn(resolveChromePath(), chromeArgs(cdpPort), { stdio: ["ignore", "pipe", "pipe"] });
 
 let socket;
 let client;
@@ -171,6 +168,33 @@ try {
 	assert.equal((await history()).past - singleDepth.past, 1);
 	await evaluate('window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyZ", ctrlKey: true, bubbles: true, cancelable: true }))');
 	assert.deepEqual(JSON.parse(await description()).objects, JSON.parse(beforeSingle).objects);
+
+	// Given an agent managing one element end to end — the reported "an MCP
+	// element sometimes goes missing" class of failure
+	// When place -> update -> remove run back to back as separate commands
+	// Then every step is visible in the editor's OWN description immediately:
+	// the placed object appears under its returned id, the update lands on
+	// that id, and the removal leaves no trace. No step may silently drop.
+	const placedResult = await call("place_object", { kind: "cube", x: 2, z: -2, name: "Lifecycle Crate" });
+	assert.equal(placedResult.isError, undefined, JSON.stringify(placedResult));
+	const placedId = placedResult.content[0].text.match(/Placed object as ([^.\s]+)\./)?.[1];
+	assert.ok(placedId, placedResult.content[0].text);
+	const afterPlace = JSON.parse(await description()).objects.find((object) => object.id === placedId);
+	assert.ok(afterPlace, `placed object ${placedId} missing from the editor description`);
+	assert.equal(afterPlace.name, "Lifecycle Crate");
+	const updated = await call("update_object", { id: placedId, x: 4, color: "#ff0000", name: "Lifecycle Crate B" });
+	assert.equal(updated.isError, undefined, JSON.stringify(updated));
+	const afterUpdate = JSON.parse(await description()).objects.find((object) => object.id === placedId);
+	assert.ok(afterUpdate, `updated object ${placedId} missing from the editor description`);
+	assert.equal(afterUpdate.x, 4);
+	assert.equal(afterUpdate.color, "#ff0000");
+	assert.equal(afterUpdate.name, "Lifecycle Crate B");
+	const removed = await call("remove_object", { id: placedId });
+	assert.equal(removed.isError, undefined, JSON.stringify(removed));
+	assert.ok(
+		!JSON.parse(await description()).objects.some((object) => object.id === placedId),
+		"removed object still present in the editor description",
+	);
 
 	// Given the real editor has an empty object history
 	// When an MCP agent applies multiple mutations as a batch

--- a/mcp/verify-live-capture.mjs
+++ b/mcp/verify-live-capture.mjs
@@ -35,7 +35,11 @@ const withTimeout = (promise, label, milliseconds = 30_000) => {
 const waitForOutput = (child, pattern, label) => withTimeout(new Promise((resolve, reject) => {
 	let output = "";
 	const inspect = (chunk) => {
-		output += chunk.toString();
+		// picocolors turns colour ON when CI is set even without a TTY, and
+		// the port lands inside bold escapes ("...127.0.0.1:\x1b[1m5599...")
+		// — strip ANSI before matching or the ready banner never matches
+		// on a GitHub runner while passing everywhere locally.
+		output += chunk.toString().replace(/\u001b\[[0-9;]*m/g, "");
 		if (pattern.test(output)) finish(resolve);
 	};
 	const onExit = (code, signal) => finish(reject, new Error(`${label} exited (${code ?? signal ?? "unknown"}): ${output}`));

--- a/mcp/verify-live-capture.mjs
+++ b/mcp/verify-live-capture.mjs
@@ -12,9 +12,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { WebSocket } from "ws";
 
+import { chromeArgs, resolveChromePath } from "./qa-chrome.mjs";
+
 const root = fileURLToPath(new URL("..", import.meta.url));
 const serverPath = fileURLToPath(new URL("./server.mjs", import.meta.url));
-const chromePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 const peerArtifactPath = join(tmpdir(), `cozyclay-capture-${randomUUID()}.png`);
 await writeFile(peerArtifactPath, "owned by another live MCP process", { mode: 0o600 });
 
@@ -115,7 +116,7 @@ const cdpPort = await reservePort();
 const vite = spawn(process.execPath, ["node_modules/vite/bin/vite.js", "--host", "127.0.0.1", "--port", String(vitePort), "--strictPort"], {
 	cwd: root, env: { ...process.env, COZYCLAY_LIVE_PORT: String(livePort) }, stdio: ["ignore", "pipe", "pipe"],
 });
-const browser = spawn(chromePath, ["--headless=new", "--no-first-run", "--no-default-browser-check", `--remote-debugging-port=${cdpPort}`], {
+const browser = spawn(resolveChromePath(), chromeArgs(cdpPort), {
 	stdio: ["ignore", "pipe", "pipe"],
 });
 let cdp;

--- a/mcp/verify-live-editor-model.mjs
+++ b/mcp/verify-live-editor-model.mjs
@@ -41,7 +41,11 @@ const waitForOutput = (child, pattern, label) =>
 		new Promise((resolve, reject) => {
 			let output = "";
 			const inspect = (chunk) => {
-				output += chunk.toString();
+				// picocolors turns colour ON when CI is set even without a TTY, and
+				// the port lands inside bold escapes ("...127.0.0.1:\x1b[1m5599...")
+				// — strip ANSI before matching or the ready banner never matches
+				// on a GitHub runner while passing everywhere locally.
+				output += chunk.toString().replace(/\u001b\[[0-9;]*m/g, "");
 				if (pattern.test(output)) finish(resolve);
 			};
 			const onExit = (code, signal) => finish(reject, new Error(`${label} exited (${code ?? signal ?? "unknown"}): ${output}`));

--- a/mcp/verify-live-editor-model.mjs
+++ b/mcp/verify-live-editor-model.mjs
@@ -7,6 +7,8 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
 
+import { chromeArgs, resolveChromePath } from "./qa-chrome.mjs";
+
 const root = fileURLToPath(new URL("..", import.meta.url));
 const serverPath = fileURLToPath(new URL("./server.mjs", import.meta.url));
 
@@ -71,12 +73,7 @@ const vite = spawn(process.execPath, ["node_modules/vite/bin/vite.js", "--host",
 	env: { ...process.env, COZYCLAY_LIVE_PORT: String(livePort) },
 	stdio: ["ignore", "pipe", "pipe"],
 });
-const browser = spawn("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", [
-	"--headless=new",
-	"--no-first-run",
-	"--no-default-browser-check",
-	`--remote-debugging-port=${cdpPort}`,
-], { stdio: ["ignore", "pipe", "pipe"] });
+const browser = spawn(resolveChromePath(), chromeArgs(cdpPort), { stdio: ["ignore", "pipe", "pipe"] });
 let socket;
 let client;
 try {

--- a/mcp/verify-live-routing.mjs
+++ b/mcp/verify-live-routing.mjs
@@ -150,6 +150,17 @@ try {
 	assert.notEqual(first.workspace, second.workspace, "each editor needs a distinct workspace handle");
 
 	const call = (name, args = {}) => client.callTool({ name, arguments: args });
+	/** Poll until the hub itself no longer lists this workspace — bounded, so
+	 * a hub that truly never notices a disconnect still fails loudly. */
+	const waitForWorkspaceGone = async (handle) => {
+		const deadline = Date.now() + 5_000;
+		for (;;) {
+			const status = await call("live_status");
+			if (!status.content[0].text.includes(handle)) return;
+			if (Date.now() > deadline) throw new Error(`live hub never dropped workspace ${handle}`);
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+	};
 	const beforeBoundOther = clone(second.state);
 
 	// Given two live editors and a command explicitly bound to the first handle
@@ -195,6 +206,10 @@ try {
 	const secondClosed = once(second.socket, "close");
 	second.socket.close();
 	await secondClosed;
+	// The client-side close resolves before the hub has processed the
+	// disconnect; until it does, formerHandle is still valid and the stale
+	// check below would race. Poll the hub's own view.
+	await waitForWorkspaceGone(formerHandle);
 	reconnected = await connectEditor("RECONNECTED");
 	assert.notEqual(reconnected.workspace, formerHandle, "reconnect must issue a fresh workspace handle");
 	const beforeStale = clone(reconnected.state);
@@ -206,6 +221,10 @@ try {
 	const firstClosed = once(first.socket, "close");
 	first.socket.close();
 	await firstClosed;
+	// Same hub race as above: the no-handle path below is only unambiguous
+	// once the hub has actually dropped the first workspace (first seen as a
+	// two-workspace ambiguity error on a slow CI runner).
+	await waitForWorkspaceGone(first.workspace);
 	// Given exactly one live editor
 	// When a mutation omits its handle
 	const unboundSingle = await call("set_camera", { x: 55 });

--- a/mcp/verify-live-scene-parity.mjs
+++ b/mcp/verify-live-scene-parity.mjs
@@ -183,6 +183,14 @@ try {
 	const closed = once(socket, "close");
 	socket.close();
 	await closed;
+	// The client-side close resolves before the hub has processed the
+	// disconnect; poll until the hub itself reports fallback mode so the
+	// headless assertions below test fallback, not close latency.
+	const fallbackDeadline = Date.now() + 5_000;
+	while (!(await call("live_status")).content[0].text.includes("No live editor")) {
+		if (Date.now() > fallbackDeadline) throw new Error("live hub never noticed the editor disconnect");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
 
 	// Given no connected editor
 	// When scenes are created, switched, saved, and reopened

--- a/mcp/verify-live.mjs
+++ b/mcp/verify-live.mjs
@@ -152,6 +152,15 @@ try {
 	const closed = once(socket, "close");
 	socket.close();
 	await closed;
+	// The client-side close resolves before the hub has necessarily processed
+	// the disconnect; on a slow runner the next command can still race down
+	// the live path. Wait until the hub itself reports the editor gone — the
+	// fallback assertions below then test fallback, not close latency.
+	const disconnectDeadline = Date.now() + 5_000;
+	while (!(await call("live_status")).includes("No live editor")) {
+		if (Date.now() > disconnectDeadline) throw new Error("live hub never noticed the editor disconnect");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
 	const fallback = await call("set_camera", { x: 9 });
 	assert(fallback.includes("Camera set") && !(fallback.includes("Live editor error")), "tools did not fall back to memory after disconnect");
 	assert((await call("describe_scene")).includes("x 9"), "memory fallback did not retain the camera update");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1698,9 +1698,13 @@ globalThis.playMode = centerTab === "play";
 		return () => window.removeEventListener("keydown", onKeyDown);
 	});
 
+	// Deps are identities, not the entry objects: charA/charB are rebuilt as
+	// fresh fallback objects on EVERY render when the cast is short (748-749),
+	// so depending on the objects fired this on each render and the actions
+	// menu closed the instant it opened.
 	useEffect(() => {
 		setInspectorActionsOpen(false);
-	}, [selectedSceneObjectId, selectedHierarchyId, keyLight, charA, charB, showB]);
+	}, [selectedSceneObjectId, selectedHierarchyId, charA.id, charB.id, showB]);
 	// A point index belongs to one object's route; carrying it to the next
 	// selection would point the gizmo at a stale dot.
 	useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -381,6 +381,7 @@ import {
 	attachWorldMatrix,
 	buildPromptSchedule,
 	cameraMoveLabelKo,
+	captureMcpFrame,
 	characterModelUrl,
 	defaultCharacterTint,
 	hierarchyIdForIkFocus,

--- a/src/app-stage.jsx
+++ b/src/app-stage.jsx
@@ -2355,7 +2355,7 @@ export function CaptureRig({ apiRef, camRef, width = CAPTURE_W, height = CAPTURE
 	return null;
 }
 
-async function captureMcpFrame({ capture, camera, characters, activeCharacterId, objects, rigs, readAuthoredState }) {
+export async function captureMcpFrame({ capture, camera, characters, activeCharacterId, objects, rigs, readAuthoredState }) {
 	if (!capture || !camera) throw new Error("No renderable shot camera is available for capture_frame.");
 	const authoredStateBefore = JSON.stringify(readAuthoredState());
 	const buffer = capture.render();

--- a/src/gizmo-claim.js
+++ b/src/gizmo-claim.js
@@ -1,0 +1,48 @@
+// Which GIZMO_LAYER surfaces own the press under them (#81).
+//
+// GIZMO_LAYER carries two very different kinds of things: grabbable handles
+// whose own listeners run AFTER ObjectGizmo's window-capture selection handler
+// (the twin gizmo's pick proxies, the key-light sun, path and crane dots), and
+// pure furniture that owns no press at all (the selection cage, the drawn
+// arrows and rings, rail lines, floating labels). ObjectGizmo must yield a
+// press aimed at the former — claiming it would deselect the character and
+// kill the drag their handler was about to start — but treating EVERY layer
+// hit as a claim let the SELECTED object's own cage veto a press aimed at a
+// different object's body, so Cube -> Sphere selection never happened.
+//
+// The split is explicit marking: a surface that handles its own press carries
+// one of these userData keys, everything else on the layer is furniture and
+// never blocks selection. This module has no three.js import on purpose — the
+// predicate is plain ancestor-walking, directly testable under Node.
+
+/** ObjectGizmo's own pick proxies (register* stamps this on every proxy). */
+export const HANDLE_PROXY_FLAG = "gizmoHandleProxy";
+
+/**
+ * userData keys whose owner handles the press itself. `shotCameraPick` is
+ * deliberately absent: the camera ghost is a selection TARGET for
+ * ObjectGizmo's pickObject, so its press must fall through to selection.
+ */
+const CLAIM_KEYS = [
+	HANDLE_PROXY_FLAG,
+	"keyLightPick", // the key-light sun's grab surfaces (app-stage KeyLightPuck)
+	"pathAxis", // travel path: axis-gizmo pick proxies (app-stage ObjectPathHandles)
+	"pathIndex", // travel path: waypoint dots — index 0 is a valid value
+	"craneAxis", // crane marks: axis-gizmo pick proxies (app-stage CraneHandles)
+	"craneIndex", // crane marks: height dots
+];
+
+/** Whether this hit object — or any ancestor — is a marked press-claimer. */
+export function isPressClaimer(object3d) {
+	for (let node = object3d; node; node = node.parent) {
+		const data = node.userData;
+		if (!data) continue;
+		for (const key of CLAIM_KEYS) if (data[key] !== undefined) return true;
+	}
+	return false;
+}
+
+/** Whether any raycast hit in the list lands on a press-claimer. */
+export function claimsPress(hits) {
+	return hits.some((hit) => isPressClaimer(hit.object));
+}

--- a/src/object-gizmo.jsx
+++ b/src/object-gizmo.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
 import { GIZMO_LAYER, SHOT_ASPECT, fitAspect } from "./dualview.jsx";
+import { HANDLE_PROXY_FLAG, claimsPress } from "./gizmo-claim.js";
 import {
 	CUTOUT_KIND,
 	objectSize,
@@ -661,26 +662,16 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 			// deselected the character and killed the drag it had just started.
 			if (!rayFrom(event)) return;
 			tools.raycaster.layers.set(GIZMO_LAYER);
-			// The default Line threshold is 1 WORLD METRE, and the layer also holds
-			// line furniture (the selection cage, axis lines). At that slop a large
-			// selected object's cage claims presses across most of the frame, so an
-			// empty-space press never reaches the deselect below. The twin's grabbable
-			// handles are solid surfaces; only a press truly ON a line should count.
-			const lineParams = tools.raycaster.params.Line;
-			const prevThreshold = lineParams.threshold;
-			lineParams.threshold = 0.02;
-			// The camera ghost rides GIZMO_LAYER too, but it is a selection target
-			// for pickObject below, not a twin's handles — it must not eat the
-			// press. The key-light sun is NOT exempted: its puck owns its own press
-			// (select + body drag) after this guard lets the event through.
-			const twinClaims = tools.raycaster.intersectObjects(scene.children, true).filter((entry) => {
-				for (let node = entry.object; node; node = node.parent) {
-					if (node.userData?.shotCameraPick) return false;
-				}
-				return true;
-			}).length;
-			lineParams.threshold = prevThreshold;
-			if (twinClaims) return;
+			// Only surfaces that OWN their press may veto selection (#81): the
+			// twin's marked pick proxies, the key-light sun, path and crane dots
+			// — see gizmo-claim.js. Everything else on the layer is furniture
+			// (the selection cage, drawn arrows and rings, rail lines, labels):
+			// counting ANY layer hit here let the SELECTED object's own cage veto
+			// a press aimed at a different object's body, so the press never
+			// reached pickObject and Cube -> Sphere selection silently failed.
+			// The camera ghost is deliberately NOT a claimer: it is a selection
+			// target for pickObject below, so its press must fall through.
+			if (claimsPress(tools.raycaster.intersectObjects(scene.children, true))) return;
 			// Selection. A left press on a body selects it and does nothing else;
 			// a press on empty space clears the selection. Both claim the press so
 			// the fly camera cannot also react — navigation lives on the right and
@@ -814,6 +805,9 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 	const register = (axis, dir) => (mesh) => {
 		if (!mesh) return;
 		mesh.layers.set(GIZMO_LAYER);
+		// The claim mark (gizmo-claim.js): the OTHER gizmo instance's selection
+		// handler yields presses on this proxy instead of deselecting mid-grab.
+		mesh.userData[HANDLE_PROXY_FLAG] = true;
 		handlesRef.current.set(axis ?? "centre", { mesh, axis, dir });
 	};
 	/** the group whose rotation.z picks which half of this axis ring is near */
@@ -824,12 +818,14 @@ export default function ObjectGizmo({ object, objects = [], mode = "move", snap 
 	const registerPlane = (plane) => (mesh) => {
 		if (!mesh) return;
 		mesh.layers.set(GIZMO_LAYER);
+		mesh.userData[HANDLE_PROXY_FLAG] = true;
 		handlesRef.current.set(`plane:${plane.id}`, { mesh, axis: null, plane });
 	};
 	/** a cutout card's corner: resizes the picture, so it owns no axis either */
 	const registerCorner = (corner) => (mesh) => {
 		if (!mesh) return;
 		mesh.layers.set(GIZMO_LAYER);
+		mesh.userData[HANDLE_PROXY_FLAG] = true;
 		handlesRef.current.set(`corner:${corner.id}`, { mesh, axis: null, corner });
 	};
 	/** invisible-but-raycastable pick volume */

--- a/test/qa-gizmo-click-through-browser.mjs
+++ b/test/qa-gizmo-click-through-browser.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Browser QA for #81: with a scene object selected, its cage and gizmo
+// furniture blanket GIZMO_LAYER around it — and the old selection guard
+// vetoed any press that crossed them, so a click aimed at a DIFFERENT
+// object's body never changed the selection. Stage the reported repro:
+// Cube first, then a Sphere parked 1.2 m beside it (selected, cage up),
+// then click the Cube's body straight through. Driven over CDP through the
+// QA browser wrapper. Standalone on purpose: the check must not wait on
+// the long verify-object-gizmo suite to reach its last section.
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params?.exceptionDetails?.exception?.description ?? "unknown page error");
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+await send("Runtime.enable");
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (expression, timeoutMs = 15000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		await sleep(120);
+	}
+	return false;
+};
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+const mouse = (type, x, y) => send("Input.dispatchMouseEvent", {
+	type,
+	x: Math.round(x),
+	y: Math.round(y),
+	button: "left",
+	clickCount: 1,
+	buttons: type === "mouseReleased" ? 0 : 1,
+});
+const addObject = async (label) => {
+	await evaluate("document.querySelector('.add-object-trigger').click()");
+	await waitFor("document.querySelectorAll('.add-object-item').length > 0");
+	await evaluate(`[...document.querySelectorAll('.add-object-item')].find(b => b.textContent.startsWith('${label}'))?.click()`);
+	await waitFor("window.__gizmoHandles().length > 0");
+};
+/** commit one Position field through the inspector, the way a user types it */
+const typePosition = async (index, value) => {
+	await evaluate(
+		"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Position');" +
+			` const input = r.querySelectorAll('input')[${index}]; input.focus();` +
+			` Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '${value}');` +
+			" input.dispatchEvent(new Event('input', { bubbles: true }));" +
+			" input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })); })()",
+	);
+	await sleep(250);
+};
+const selectedLabel = () => evaluate("document.querySelector('.hierarchy-row-wrap.selected .hierarchy-label')?.textContent ?? 'nothing selected'");
+
+expect("app becomes ready", await waitFor("!!document.querySelector('.add-object-trigger')", 30000));
+
+// The Cube, selected: read its position and its record id off its own body.
+await addObject("Cube");
+const cubePos = await evaluate(
+	"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Position');" +
+		" return [...r.querySelectorAll('input')].map(i => Number(i.value)); })()",
+);
+const cubeId = await evaluate(
+	"(() => { const g = window.__gizmoHandles(); const c = g.reduce((a, h) => ({ x: a.x + h.x / g.length, y: a.y + h.y / g.length }), { x: 0, y: 0 });" +
+		" for (let r = 4; r < 300; r += 4) { for (let a = 0; a < 360; a += 15) {" +
+		" const x = Math.round(c.x + r * Math.cos(a * Math.PI / 180)); const y = Math.round(c.y + r * Math.sin(a * Math.PI / 180));" +
+		" const picked = window.__objectPick(x, y); if (picked && !window.__gizmoPick(x, y)) return picked; } } return null; })()",
+);
+expect("the cube reports its record id", !!cubeId, String(cubeId));
+
+// The Sphere: created selected, cage up, parked 1.2 m beside the cube so
+// both bodies share the frame and the cage overlaps the cube on screen.
+await addObject("Sphere");
+expect("the sphere owns the selection", (await selectedLabel()) === "Sphere", await selectedLabel());
+await typePosition(0, cubePos[0] + 1.2);
+await typePosition(2, cubePos[2]);
+await evaluate("[...document.querySelectorAll('.inspector-pane .btn')].find(b => b.textContent.startsWith('Recenter'))?.click()");
+await sleep(1200); // the shot camera eases onto the sphere: scan when it lands
+
+// A pixel that is unambiguously the Cube's body while the Sphere owns the
+// cage — exactly the press the blanket veto used to swallow. The spiral
+// starts at the gizmo hub, so the first match is the cube pixel CLOSEST to
+// the selected sphere's furniture.
+const cubePixel = await evaluate(
+	"(() => { const g = window.__gizmoHandles(); if (!g.length) return null; const c = g.reduce((a, h) => ({ x: a.x + h.x / g.length, y: a.y + h.y / g.length }), { x: 0, y: 0 });" +
+		" for (let r = 8; r < 500; r += 4) { for (let a = 0; a < 360; a += 12) {" +
+		" const x = Math.round(c.x + r * Math.cos(a * Math.PI / 180)); const y = Math.round(c.y + r * Math.sin(a * Math.PI / 180));" +
+		` if (window.__objectPick(x, y) === ${JSON.stringify(cubeId)} && !window.__gizmoPick(x, y) && document.elementFromPoint(x, y)?.tagName === 'CANVAS') return { x, y }; } } return null; })()`,
+);
+expect("the cube offers a body pixel beside the selected sphere", !!cubePixel, JSON.stringify(cubePixel));
+if (cubePixel) {
+	await mouse("mousePressed", cubePixel.x, cubePixel.y);
+	await mouse("mouseReleased", cubePixel.x, cubePixel.y);
+	await waitFor("[...document.querySelectorAll('.hierarchy-row-wrap.selected .hierarchy-label')].some(n => n.textContent === 'Cube')", 5000);
+	expect(
+		"clicking another object past the selected cage moves the selection (#81)",
+		(await selectedLabel()) === "Cube",
+		await selectedLabel(),
+	);
+}
+
+expect("the page logged no errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+ws.close();
+if (failures > 0) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log("qa-gizmo-click-through-browser: all checks passed");
+process.exit(0);

--- a/test/verify-gizmo-claim.mjs
+++ b/test/verify-gizmo-claim.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Press-claim classification on GIZMO_LAYER (#81).
+ *
+ * The bug: ObjectGizmo's selection handler treated ANY GIZMO_LAYER raycast hit
+ * as "another gizmo's handle" and swallowed the press. The layer also carries
+ * pure furniture — the selected object's own cage, drawn arrows, rail lines —
+ * so with a Cube selected, a click aimed at a Sphere behind the cage never
+ * reached the object picker and the selection never changed.
+ *
+ * This rebuilds that exact geometry with real three.js raycasts and asserts
+ * the split gizmo-claim.js draws: furniture never claims a press, explicitly
+ * marked grab surfaces (handle proxies, key-light sun, path/crane dots) always
+ * do, and the camera ghost — a selection target — falls through.
+ */
+import { readFileSync } from "node:fs";
+import * as THREE from "three";
+import { HANDLE_PROXY_FLAG, claimsPress, isPressClaimer } from "../src/gizmo-claim.js";
+
+let failures = 0;
+function expect(name, condition, detail = "") {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+}
+
+// The editor-furniture layer. dualview.jsx owns the constant but is JSX; the
+// source assertion below keeps this literal honest.
+const GIZMO_LAYER = 5;
+const dualviewSource = readFileSync(new URL("../src/dualview.jsx", import.meta.url), "utf8");
+expect("GIZMO_LAYER literal matches dualview.jsx", dualviewSource.includes("export const GIZMO_LAYER = 5"));
+
+const onLayer = (node) => {
+	node.layers.set(GIZMO_LAYER);
+	return node;
+};
+const raycaster = new THREE.Raycaster();
+raycaster.layers.set(GIZMO_LAYER);
+const camera = new THREE.PerspectiveCamera(50, 16 / 9, 0.1, 100);
+camera.position.set(0, 1, 6);
+camera.updateMatrixWorld();
+
+/** GIZMO_LAYER hits for a ray from the camera through world `target`. */
+const layerHits = (scene, target) => {
+	scene.updateMatrixWorld(true);
+	raycaster.set(camera.position, target.clone().sub(camera.position).normalize());
+	return raycaster.intersectObjects(scene.children, true);
+};
+
+/* ------------------------- the reported scene ------------------------- */
+// A selected 1 m Cube at the origin: its cage (EdgesGeometry LineSegments) and
+// a drawn gizmo arrow ride GIZMO_LAYER unmarked, its pick proxy rides it
+// MARKED. A Sphere sits behind on layer 0, visible past the cage.
+const scene = new THREE.Scene();
+const cage = onLayer(
+	new THREE.LineSegments(
+		new THREE.EdgesGeometry(new THREE.BoxGeometry(1.04, 1.04, 1.04)),
+		new THREE.LineBasicMaterial(),
+	),
+);
+cage.position.set(0, 0.5, 0);
+const arrow = onLayer(new THREE.Mesh(new THREE.CylinderGeometry(0.016, 0.016, 0.62), new THREE.MeshBasicMaterial()));
+arrow.position.set(0, 1.1, 0);
+const proxy = onLayer(new THREE.Mesh(new THREE.CylinderGeometry(0.09, 0.09, 0.76), new THREE.MeshBasicMaterial()));
+proxy.position.copy(arrow.position);
+proxy.userData[HANDLE_PROXY_FLAG] = true;
+const sphere = new THREE.Mesh(new THREE.SphereGeometry(0.5, 16, 12), new THREE.MeshBasicMaterial());
+sphere.position.set(1.6, 0.5, -1);
+scene.add(cage, arrow, proxy, sphere);
+
+// The regression itself: a press aimed at the Sphere's body crosses the cage's
+// line raycast slop (the default Line threshold is 1 WORLD METRE), which used
+// to veto the press before the object picker ran.
+const towardSphere = layerHits(scene, sphere.position);
+expect(
+	"the cage line is actually under the sphere-bound ray (default 1 m Line slop)",
+	towardSphere.some((hit) => hit.object === cage),
+	JSON.stringify(towardSphere.map((hit) => hit.object.type)),
+);
+expect("a press aimed at another object's body is NOT claimed by furniture", !claimsPress(towardSphere));
+
+// A press ON the gizmo's marked pick proxy still yields — twin-handle
+// protection survives the fix.
+expect("a press on a marked handle proxy IS claimed", claimsPress(layerHits(scene, proxy.position)));
+
+// The drawn arrow alone (proxy removed) is furniture: it draws, it never owns
+// a press.
+scene.remove(proxy);
+const towardArrow = layerHits(scene, arrow.position);
+expect(
+	"the drawn arrow is hit but claims nothing",
+	towardArrow.some((hit) => hit.object === arrow) && !claimsPress(towardArrow),
+	JSON.stringify(towardArrow.map((hit) => hit.object.type)),
+);
+
+/* --------------------- the other press-owning marks -------------------- */
+// Markers ride meshes inside unmarked groups (KeyLightPuck's layout): the
+// ancestor walk must find them either way, and index 0 is a valid dot.
+const puck = new THREE.Group();
+const sun = new THREE.Mesh(new THREE.SphereGeometry(0.42, 8, 6), new THREE.MeshBasicMaterial());
+sun.userData.keyLightPick = true;
+puck.add(sun);
+expect("the key-light sun claims through its group", isPressClaimer(sun));
+const markedParent = new THREE.Group();
+markedParent.userData.pathAxis = "y";
+const plainChild = new THREE.Mesh();
+markedParent.add(plainChild);
+expect("a marked GROUP claims for its child mesh", isPressClaimer(plainChild));
+for (const [key, value] of [["pathAxis", "y"], ["pathIndex", 0], ["craneAxis", "x"], ["craneIndex", 0]]) {
+	const dot = new THREE.Mesh();
+	dot.userData[key] = value;
+	expect(`${key}=${JSON.stringify(value)} claims its press`, isPressClaimer(dot));
+}
+
+// The camera ghost is a selection target, not a claimer: its press must fall
+// through to pickObject.
+const ghost = new THREE.Mesh();
+ghost.userData.shotCameraPick = true;
+expect("the camera ghost never claims", !isPressClaimer(ghost));
+expect("an unmarked mesh never claims", !isPressClaimer(new THREE.Mesh()));
+
+/* ----------------------------- the wiring ------------------------------ */
+// The classification only guards clicks if ObjectGizmo actually consults it
+// and stamps its proxies. Source assertions keep the wiring from silently
+// regressing to the blanket layer veto.
+const gizmoSource = readFileSync(new URL("../src/object-gizmo.jsx", import.meta.url), "utf8");
+expect(
+	"every register* stamps the claim mark (axis, plane, corner proxies)",
+	(gizmoSource.match(/mesh\.userData\[HANDLE_PROXY_FLAG\] = true/g) ?? []).length >= 3,
+);
+expect("the selection handler vetoes through claimsPress, not raw layer hits", /claimsPress\(tools\.raycaster\.intersectObjects/.test(gizmoSource));
+
+if (failures) process.exit(1);
+console.log("OK verify-gizmo-claim");

--- a/test/verify-object-gizmo.mjs
+++ b/test/verify-object-gizmo.mjs
@@ -133,7 +133,7 @@ const reloadPage = async () => {
 /** the inspector's Transform rows, as { Position: [x,y,z], Rotation: [...], Scale: [...] } */
 const transform = () =>
 	evaluate(
-		"Object.fromEntries([...document.querySelectorAll('.inspector-pane .vec3-row')].map(r => [r.querySelector('.vec3-label').textContent, [...r.querySelectorAll('input')].map(i => parseFloat(i.value))]))",
+		"Object.fromEntries([...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).map(r => [r.querySelector('.vec3-label').textContent, [...r.querySelectorAll('input')].map(i => parseFloat(i.value))]))",
 	);
 const click = (selectorExpression) => evaluate(`${selectorExpression}.click()`);
 /** real visibility, not presence: the element must exist, paint a non-zero
@@ -209,7 +209,7 @@ expect("an X drag leaves the other axes alone", afterMove.Position[1] === before
 /* --------------------------------------------------- rotate gizmo ---- */
 
 await pressKey("e", "KeyE");
-expect("E selects the rotate tool", await evaluate("[...document.querySelectorAll('.gizmo-modes button')].find(b => b.classList.contains('active')).textContent.startsWith('Rotate')"));
+expect("E selects the rotate tool", await evaluate("[...document.querySelectorAll('.tool-switch button')].find(b => b.classList.contains('active')).textContent.startsWith('Rotate')"));
 await sleep(1200);
 const rings = await evaluate("window.__gizmoHandles()");
 expect("rotate mode shows one ring per axis plus the screen ring", ["x", "y", "z", "screen"].every((axis) => rings.some((handle) => handle.axis === axis)), JSON.stringify(rings));
@@ -224,7 +224,22 @@ const ringGrab = await evaluate(
 );
 expect("the Y ring is grabbable on screen", !!ringGrab);
 const beforeRotate = await transform();
-await drag(ringGrab, { x: ringGrab.x + 96, y: ringGrab.y + 60 });
+// Sweep a true arc around the gizmo centre, exactly like the screen-ring
+// roll below: a fixed straight chord from a grab spot near the hub can
+// subtend less than the 5-degree snap and read back as a no-op.
+const hubTurn = await evaluate(
+	"(() => { const hs = window.__gizmoHandles(); return { x: hs.reduce((a, h) => a + h.x / hs.length, 0), y: hs.reduce((a, h) => a + h.y / hs.length, 0) }; })()",
+);
+const turnRadius = Math.hypot(ringGrab.x - hubTurn.x, ringGrab.y - hubTurn.y);
+const turnStart = Math.atan2(ringGrab.y - hubTurn.y, ringGrab.x - hubTurn.x);
+await mouse("mousePressed", ringGrab.x, ringGrab.y);
+for (let i = 1; i <= 18; i++) {
+	const a = turnStart + (i / 18) * (Math.PI / 2);
+	await mouse("mouseMoved", Math.round(hubTurn.x + turnRadius * Math.cos(a)), Math.round(hubTurn.y + turnRadius * Math.sin(a)));
+	await sleep(16);
+}
+await mouse("mouseReleased", Math.round(hubTurn.x + turnRadius * Math.cos(turnStart + Math.PI / 2)), Math.round(hubTurn.y + turnRadius * Math.sin(turnStart + Math.PI / 2)));
+await sleep(150);
 const afterRotate = await transform();
 expect("dragging the Y ring turns the object", afterRotate.Rotation[1] !== beforeRotate.Rotation[1], JSON.stringify(afterRotate));
 expect("a Y ring drag leaves tilt and roll alone", afterRotate.Rotation[0] === beforeRotate.Rotation[0] && afterRotate.Rotation[2] === beforeRotate.Rotation[2]);
@@ -262,19 +277,52 @@ if (screenGrab) {
 }
 
 await pressKey("w", "KeyW");
-expect("W returns to the move tool", await evaluate("[...document.querySelectorAll('.gizmo-modes button')].find(b => b.classList.contains('active')).textContent.startsWith('Move')"));
+expect("W returns to the move tool", await evaluate("[...document.querySelectorAll('.tool-switch button')].find(b => b.classList.contains('active')).textContent.startsWith('Move')"));
 
 /* ---------------------------------------------------- scale gizmo ---- */
 
+// The ring tests above leave the cube turned, and a heavily turned local Y
+// can point almost AT the camera — there the knob's drag plane degenerates
+// and any drag reads back as a no-op. Scale is about the knob, not the
+// pose: zero the rotation first.
+for (const index of [0, 1, 2]) {
+	await evaluate(
+		"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Rotation');" +
+			` const input = r.querySelectorAll('input')[${index}]; input.focus();` +
+			" Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '0');" +
+			" input.dispatchEvent(new Event('input', { bubbles: true }));" +
+			" input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })); })()",
+	);
+}
+// R below must reach the tool hotkeys, not the still-focused number field
+await evaluate("document.activeElement?.blur()");
+await sleep(400);
+
 await pressKey("r", "KeyR");
-expect("R selects the scale tool", await evaluate("[...document.querySelectorAll('.gizmo-modes button')].find(b => b.classList.contains('active')).textContent.startsWith('Scale')"));
+expect("R selects the scale tool", await evaluate("[...document.querySelectorAll('.tool-switch button')].find(b => b.classList.contains('active')).textContent.startsWith('Scale')"));
 await sleep(1200);
 const knobs = await evaluate("window.__gizmoHandles()");
 expect("scale mode exposes three axis knobs", new Set(knobs.map((handle) => handle.axis)).size >= 3, JSON.stringify(knobs));
-const yKnob = knobs.find((handle) => handle.axis === "y");
+// An unambiguous grab ON the canvas: the projected knob position can sit
+// under the Top-View inset (a press there never reaches the canvas), and
+// the fat uniform-scale centre knob can outrank a press near the hub.
+const yKnob = await evaluate(
+	"(() => { const h = window.__gizmoHandles().find(e => e.axis === 'y'); if (!h) return null;" +
+		" const canvas = document.querySelector('canvas');" +
+		" const solid = (x, y) => document.elementFromPoint(x, y) === canvas && [[0,0],[3,0],[-3,0],[0,3],[0,-3]].every(([dx,dy]) => window.__gizmoPick(x+dx, y+dy) === 'y');" +
+		" for (let r = 0; r < 80; r += 2) { for (let a = 0; a < 360; a += 20) {" +
+		" const x = Math.round(h.x + r * Math.cos(a * Math.PI / 180)); const y = Math.round(h.y + r * Math.sin(a * Math.PI / 180));" +
+		" if (solid(x, y)) return { x, y }; } } return { x: Math.round(h.x), y: Math.round(h.y) }; })()",
+);
 const beforeScale = await transform();
-// pull the Y knob further from the pivot: straight up on screen
-await drag(yKnob, { x: yKnob.x, y: yKnob.y - 120 });
+// Pull the Y knob straight AWAY from the pivot on screen. "Up" is only
+// away while the object is unrotated; the rotate section above leaves it
+// turned, and an up-drag then crosses the knob's axis at a right angle,
+// so the scale delta snaps back to 1.0 and reads as a no-op.
+const hubScale = knobs.find((handle) => handle.axis === "centre")
+	?? { x: knobs.reduce((a, h) => a + h.x / knobs.length, 0), y: knobs.reduce((a, h) => a + h.y / knobs.length, 0) };
+const outLen = Math.hypot(yKnob.x - hubScale.x, yKnob.y - hubScale.y) || 1;
+await drag(yKnob, { x: yKnob.x + ((yKnob.x - hubScale.x) / outLen) * 120, y: yKnob.y + ((yKnob.y - hubScale.y) / outLen) * 120 });
 const afterScale = await transform();
 expect("dragging the Y knob scales height", afterScale.Scale[1] > beforeScale.Scale[1], JSON.stringify(afterScale));
 expect("a Y knob drag leaves the other axes alone", afterScale.Scale[0] === beforeScale.Scale[0] && afterScale.Scale[2] === beforeScale.Scale[2]);
@@ -284,14 +332,14 @@ await pressKey("w", "KeyW");
 // restore the unit scale: the following sections assume a 1 m cube — at 4x
 // the gizmo rides so high it projects under the bird's-eye inset pane
 await evaluate(
-	"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].find(r => r.querySelector('.vec3-label').textContent === 'Scale');" +
+	"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Scale');" +
 	" const input = r.querySelectorAll('input')[1]; input.focus();" +
 	" Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '1');" +
 	" input.dispatchEvent(new Event('input', { bubbles: true }));" +
 	" input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })); })()",
 );
 await waitFor(
-	"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].find(r => r.querySelector('.vec3-label').textContent === 'Scale'); return parseFloat(r.querySelectorAll('input')[1].value) === 1; })()",
+	"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Scale'); return parseFloat(r.querySelectorAll('input')[1].value) === 1; })()",
 );
 
 /* ------------------------------------------------------ selection ---- */
@@ -461,7 +509,9 @@ await click("[...document.querySelectorAll('.add-object-item')].find(b => b.text
 // the creation commit renders the gizmo and inspector together; poll for it
 await waitFor("window.__gizmoHandles().length > 0");
 expect("an object created from a swung camera is still unrotated", JSON.stringify((await transform()).Rotation) === "[0,0,0]", JSON.stringify(await transform()));
-await click("[...document.querySelectorAll('.inspector-pane .btn')].find(b => b.textContent.startsWith('Remove'))");
+await click("document.querySelector('.inspector-actions-trigger')");
+await waitFor("document.querySelectorAll('.inspector-actions-menu button').length > 0");
+await click("[...document.querySelectorAll('.inspector-actions-menu button')].find(b => b.textContent.startsWith('Delete'))");
 await sleep(300);
 await click("[...document.querySelectorAll('.hierarchy-row')].find(b => b.textContent.includes('Cube'))");
 await sleep(300);
@@ -485,7 +535,9 @@ await pressKey("Escape", "Escape");
 
 await click("[...document.querySelectorAll('.hierarchy-row')].find(b => b.textContent.includes('Cube'))");
 await sleep(250);
-await click("[...document.querySelectorAll('.inspector-pane .btn')].find(b => b.textContent.startsWith('Remove'))");
+await click("document.querySelector('.inspector-actions-trigger')");
+await waitFor("document.querySelectorAll('.inspector-actions-menu button').length > 0");
+await click("[...document.querySelectorAll('.inspector-actions-menu button')].find(b => b.textContent.startsWith('Delete'))");
 // the removal commit drops the row; poll for it
 await waitFor("![...document.querySelectorAll('.hierarchy-label')].some(n => n.textContent === 'Cube')");
 expect("removing the object clears it from the hierarchy", await evaluate("![...document.querySelectorAll('.hierarchy-label')].some(n => n.textContent === 'Cube')"));
@@ -731,8 +783,11 @@ expect(
 	historyAfterLoad.past === 0 && historyAfterLoad.settled === true,
 	JSON.stringify(historyAfterLoad),
 );
-// isolation: only now clear both keys and reload for anything that follows
-await clearSceneKeys();
+// Isolation: only now reset the store for anything that follows. The app
+// itself persists the whole stage under cozyclay.scenes.v4 — clearing just
+// the legacy pair leaves every object the cases above created to reload
+// into the drop-to-surface section. Sweep all cozyclay keys but the locale.
+await evaluate("Object.keys(localStorage).filter(k => k.startsWith('cozyclay.') && k !== 'cozyclay.locale').forEach(k => localStorage.removeItem(k))");
 await reloadPage();
 
 /* -------------------------------------------------- drop-to-surface ---- */
@@ -757,11 +812,16 @@ await waitFor("window.__gizmoHandles().length > 0");
 
 // Raise the chair clear of the cube (2.5 > 1) by typing into the Position Y
 // field; blur commits the draft as one atomic entry.
-const posRow = "(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].find(r => r.querySelector('.vec3-label').textContent === 'Position'); return r; })()";
+const posRow = "(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Position'); return r; })()";
 const pastBeforeY = await evaluate("window.__sceneHistory().past");
-await evaluate(`(() => { const r = ${posRow}; r.querySelectorAll('input')[1].focus(); })()`);
-await send("Input.insertText", { text: "2.5" });
-await evaluate("document.activeElement.blur()");
+// Drive the draft the way the field models it (focus -> input -> blur):
+// CDP's Input.insertText needs the browser window itself to be focused,
+// which the headless QA browser is not, so the text never lands there.
+await evaluate(
+	`(() => { const r = ${posRow}; const input = r.querySelectorAll('input')[1]; input.focus();` +
+		" Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '2.5');" +
+		" input.dispatchEvent(new Event('input', { bubbles: true })); input.blur(); })()",
+);
 await waitFor(`window.__sceneHistory().past === ${pastBeforeY + 1}`);
 expect("typing a Y value raises the object above the support", (await transform()).Position[1] === 2.5, JSON.stringify(await transform()));
 
@@ -826,17 +886,21 @@ const dragHeld = async (handle, { ticks = 5, dx = 160, dy = 0 } = {}) => {
  * search, so a press cannot land on the overlapping Y proxy). */
 const grabX = async () => {
 	await waitFor("(() => { const h = window.__gizmoHandles().find(e => e.axis === 'x'); return !!h && h.x > 0 && h.x < innerWidth && h.y > 0 && h.y < innerHeight && document.elementFromPoint(Math.round(h.x), Math.round(h.y)) === document.querySelector('canvas') && window.__gizmoPick(Math.round(h.x), Math.round(h.y)) === 'x'; })()");
+	// A full spiral, not just a horizontal walk: the arrow tip can project
+	// under overlays that span the pane's whole width (the bottom window
+	// tab bar), where every same-row candidate is equally covered.
 	return evaluate(
 		"(() => { const h = window.__gizmoHandles().find(e => e.axis === 'x'); if (!h) return null;" +
 			" const canvas = document.querySelector('canvas');" +
 			" const solid = (x, y) => document.elementFromPoint(x, y) === canvas && [[0,0],[2,0],[-2,0],[0,2],[0,-2]].every(([dx,dy]) => window.__gizmoPick(x+dx, y+dy) === 'x');" +
-			" for (let r = 0; r < 60; r += 2) { for (const s of [1, -1]) { const x = Math.round(h.x + r * s); const y = Math.round(h.y);" +
+			" for (let r = 0; r < 70; r += 2) { for (let a = 0; a < 360; a += 20) {" +
+			" const x = Math.round(h.x + r * Math.cos(a * Math.PI / 180)); const y = Math.round(h.y + r * Math.sin(a * Math.PI / 180));" +
 			" if (solid(x, y)) return { x, y }; } } return { x: Math.round(h.x), y: Math.round(h.y) }; })()",
 	);
 };
 
 /** the Position row's i-th input (0=X, 1=Y, 2=Z) — pollable after commits */
-const positionInput = (index) => `(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].find(r => r.querySelector('.vec3-label').textContent === 'Position'); return r ? parseFloat(r.querySelectorAll('input')[${index}].value) : NaN; })()`;
+const positionInput = (index) => `(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Position'); return r ? parseFloat(r.querySelectorAll('input')[${index}].value) : NaN; })()`;
 
 /** the Camera card's "camera to subject" readout, which live-tracks the
  * shot camera — the only DOM handle on the camera's position */
@@ -1034,12 +1098,11 @@ const chairForPlan = await transform(); // the Chair, now away from the Cube
 const pastBeforePlan = await evaluate("window.__sceneHistory().past");
 await click("[...document.querySelectorAll('.hierarchy-row')].find(b => b.textContent.includes('Cube'))");
 await waitFor("window.__gizmoHandles().length > 0");
-const insetCtrB = await evaluate("(() => { const p = document.querySelector('.vp-inset'); const r = p.getBoundingClientRect(); return { x: Math.round(r.left + r.width / 2), y: Math.round(r.top + r.height / 2) }; })()");
-await send("Input.dispatchMouseEvent", { type: "mousePressed", x: insetCtrB.x, y: insetCtrB.y, button: "left", buttons: 1, clickCount: 2 });
-await send("Input.dispatchMouseEvent", { type: "mouseReleased", x: insetCtrB.x, y: insetCtrB.y, button: "left", buttons: 0, clickCount: 2 });
-await waitFor("document.querySelector('.vp-main').classList.contains('plan')");
-await sleep(150); // the plan host's pointerdown listener binds after the commit
-const planRect = await evaluate("(() => { const b = document.querySelector('.vp-main').getBoundingClientRect(); return { left: b.left, top: b.top, width: b.width, height: b.height, scale: (b.height / 2) / 12.4 }; })()");
+// The plan board only lives in the Top-View inset now (planIsMain is
+// hard false — the double-click big-pane swap is gone for good), so the
+// puck is driven in the inset itself: PLAN_EXTENT (12.4 m) maps to half
+// its shorter side, same as the bird's-eye case above.
+const planRect = await evaluate("(() => { const b = document.querySelector('.vp-inset').getBoundingClientRect(); return { left: b.left, top: b.top, width: b.width, height: b.height, scale: Math.min(b.width, b.height) / 2 / 12.4 }; })()");
 const chairPuck = {
 	x: Math.round(planRect.left + planRect.width / 2 + chairForPlan.Position[0] * planRect.scale),
 	y: Math.round(planRect.top + planRect.height / 2 + chairForPlan.Position[2] * planRect.scale),
@@ -1098,16 +1161,30 @@ expect("the store stays settled after a camera drag", await evaluate("window.__s
 // travel commits as its own entry and the removal as a second — the two can
 // never fold into one. The producer dies with the drag: further pointer
 // movement resurrects nothing. (Last: it removes the Chair.)
-const insetCtr2B = await evaluate("(() => { const p = document.querySelector('.vp-inset'); const r = p.getBoundingClientRect(); return { x: Math.round(r.left + r.width / 2), y: Math.round(r.top + r.height / 2) }; })()");
-await send("Input.dispatchMouseEvent", { type: "mousePressed", x: insetCtr2B.x, y: insetCtr2B.y, button: "left", buttons: 1, clickCount: 2 });
-await send("Input.dispatchMouseEvent", { type: "mouseReleased", x: insetCtr2B.x, y: insetCtr2B.y, button: "left", buttons: 0, clickCount: 2 });
-await waitFor("!document.querySelector('.vp-main').classList.contains('plan')");
-await sleep(150);
 await click("[...document.querySelectorAll('.hierarchy-row')].find(b => b.textContent.includes('Chair'))");
 await waitFor("window.__gizmoHandles().length > 0");
-// the camera-puck flight above leaves the pose wherever the plan drag took it
+// The camera-puck flight above leaves the pose wherever the plan drag
+// took it, and from there the chair's gizmo projects into the bottom
+// letterbox band where no press is pickable. Park the chair near the
+// stage centre first, then recenter, then wait out the camera glide —
+// the projected handles must hold still before a grab point is read.
+for (const [index, value] of [[0, 0.5], [2, 0.5]]) {
+	await evaluate(
+		"(() => { const r = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box')).find(r => r.querySelector('.vec3-label').textContent === 'Position');" +
+			` const input = r.querySelectorAll('input')[${index}]; input.focus();` +
+			` Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '${value}');` +
+			" input.dispatchEvent(new Event('input', { bubbles: true }));" +
+			" input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })); })()",
+	);
+}
+await evaluate("document.activeElement?.blur()");
 await evaluate("[...document.querySelectorAll('.inspector-pane .btn')].find(b => b.textContent.startsWith('Recenter'))?.click()");
 await sleep(600);
+for (let i = 0; i < 20; i++) {
+	const a = JSON.stringify(await evaluate("window.__gizmoHandles()"));
+	await sleep(150);
+	if (a === JSON.stringify(await evaluate("window.__gizmoHandles()"))) break;
+}
 const pastBeforeDelete = await evaluate("window.__sceneHistory().past");
 const deleteBefore = await transform();
 const deleteGrab = await grabX();
@@ -1145,6 +1222,10 @@ expect(
 await mouse("mouseReleased", deleteEnd.x + 160, deleteEnd.y);
 expect("the store is settled after a Delete mid-drag", await evaluate("window.__sceneHistory().settled === true"));
 
+
+// The #81 click-through-the-cage repro lives in its own standalone suite,
+// test/qa-gizmo-click-through-browser.mjs, so the regression check does not
+// wait on every section above to stay green.
 
 expect("the page logged no errors", pageErrors.length === 0, pageErrors.join(" | "));
 

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -48,6 +48,7 @@ const NODE_FILES = [
 	"test/verify-error-boundary.mjs",
 	"test/verify-footage-bridge.mjs",
 	"test/verify-g006-css.mjs",
+	"test/verify-gizmo-claim.mjs",
 	"test/verify-grid-view.mjs",
 	"test/verify-hierarchy.mjs",
 	"test/verify-history.mjs",


### PR DESCRIPTION
Closes #81.

## Problem
With an object selected, its cage and gizmo furniture blanket GIZMO_LAYER around it, and the selection guard in ObjectGizmo vetoed any press whose ray crossed them — so a click aimed at a different object's body never reached the picker and the selection silently stayed put.

## Fix
- **src/gizmo-claim.js** (new): the split is explicit marking. Only surfaces that OWN their press may veto selection — the gizmo's handle proxies, the key-light sun, path and crane dots. Everything else on the layer (cage, drawn arrows/rings, rail lines, labels, grid floor) is furniture and falls through to the object picker. Covered by `test/verify-gizmo-claim.mjs` under `npm test`.
- **src/object-gizmo.jsx**: the guard now asks `claimsPress()` instead of counting arbitrary layer hits; `register*` stamps every proxy with the claim mark.

## CI: gating regression check
`test/qa-gizmo-click-through-browser.mjs` stages the reported repro in a real browser — Cube, then a Sphere parked 1.2 m beside it (selected, cage up), then a click on the Cube's body straight through — and asserts the selection moves. It reads the CPU raycast hooks and the DOM, no GPU pixels, so it runs in the **gating** tier on SwiftShader from day one. A recurrence of #81 fails the `browser` job.

## Also in this PR
- **fix(app)**: the inspector ⋮ actions menu (Duplicate/Delete) closed ~6 ms after opening — its close-on-context-change effect depended on `charA`/`charB` fallback objects that are rebuilt every render. Deps are the entry ids now.
- **test(gizmo)**: `verify-object-gizmo.mjs` crashed before its third check against today's UI; it now runs end to end (113 PASS). Two known-red areas remain by design, still in observation mode:
  - the persistence section asserts legacy `cozyclay.scene.v1` while the app persists `cozyclay.scenes.v4` envelopes — needs a section rewrite;
  - one history check: a mid-drag selection change commits the travel **without recording a history entry** (position persists, `past`/`future` unchanged) — looks like a real store bug worth its own issue.

## Verification
- `npm test`: 112 Node files PASS (includes the new claim-predicate suite).
- `qa-gizmo-click-through-browser`: 6/6 PASS locally against a cold dev server; A/B with the fix stashed reproduces the blocked-selection behaviour in overlap geometry.
- `verify-object-gizmo`: crash → 113 PASS / 11 known-drift FAIL (observation).