### PR TITLE
fix(extract): One-Euro on the arm chains quiets SAM wrist tremble (#84)

### DIFF
--- a/test/verify-bvh-cskel27.mjs
+++ b/test/verify-bvh-cskel27.mjs
@@ -65,11 +65,35 @@ function takeMetrics(motion) {
 	const ankle = accelRms([idx.LeftFoot, idx.RightFoot]);
 	const toe = accelRms([idx.LeftToeBase, idx.RightToeBase]);
 	const hips = accelRms([idx.Hips]);
+	// Hand speed and the guard-band wrist accel (#84). GUARD frames are the
+	// ones whose hand moves under 1.2 m/s across both steps of the second
+	// difference — the band the "our take jitters" complaint lives in, and the
+	// band a speed-adaptive filter is allowed to touch. Peak hand speed is the
+	// punch: the filter must leave it standing.
+	const handSpeed = (f, j) => Math.hypot(...[0, 1, 2].map((axis) => at(f, j, axis) - at(f - 1, j, axis))) * 100 * motion.fps;
+	const handSpeeds = [];
+	let guardSum = 0;
+	let guardCount = 0;
+	for (const j of [idx.LeftHand, idx.RightHand]) {
+		for (let f = 1; f < motion.frames; f += 1) handSpeeds.push(handSpeed(f, j));
+		for (let f = 1; f < motion.frames - 1; f += 1) {
+			if (handSpeed(f, j) > 120 || handSpeed(f + 1, j) > 120) continue;
+			for (let axis = 0; axis < 3; axis += 1) {
+				const acc = at(f + 1, j, axis) - 2 * at(f, j, axis) + at(f - 1, j, axis);
+				guardSum += acc * acc;
+				guardCount += 1;
+			}
+		}
+	}
+	const wrist = accelRms([idx.LeftHand, idx.RightHand]);
 	return {
 		lowest,
-		wrist: accelRms([idx.LeftHand, idx.RightHand]),
+		wrist,
+		guardWrist: Math.sqrt(guardSum / Math.max(1, guardCount)) * 100, // cm per frame²
+		handSpeedMax: Math.max(...handSpeeds), // cm/s — the punch peak
 		ankle, toe, hips, kneeJerk, worstKneeStep,
 		// per-second forms — comparable across frame rates
+		wristPerS2: wrist * motion.fps ** 2,
 		anklePerS2: ankle * motion.fps ** 2,
 		hipsPerS2: hips * motion.fps ** 2,
 		kneeJerkPerS2: kneeJerk * motion.fps ** 2,
@@ -259,6 +283,19 @@ const offlineMetrics = takeMetrics(offline);
 	pass("the offline-pipeline take stays smooth (wrist accel < 3.5 cm) and grounded");
 }
 
+// The arm One-Euro (#84), pinned from both sides. Unfiltered, this fixture
+// measures wrist accel 2.76 cm and guard-band wrist accel 1.36; the filter
+// takes them to 2.56 / 1.24 while peak hand speed keeps 799 of its 802 cm/s.
+// The rejected leg-style slerp on the arms scores 724 cm/s of peak with the
+// guard band UNTOUCHED at 1.36 — so the peak bound catches swapping in any
+// blunt smoother, and the two accel bounds catch removing the filter.
+{
+	assert.ok(offlineMetrics.wrist < 2.7, `wrist accel ${offlineMetrics.wrist} — arm filter missing?`);
+	assert.ok(offlineMetrics.guardWrist < 1.32, `guard-band wrist accel ${offlineMetrics.guardWrist} — arm filter missing?`);
+	assert.ok(offlineMetrics.handSpeedMax > 760, `peak hand speed ${offlineMetrics.handSpeedMax} cm/s — the punch got smoothed`);
+	pass("the arm One-Euro quiets the guard-band wrists without collapsing punch speed");
+}
+
 // The legs get the same zero-lag slerp as the torso (harder), and the 4f
 // penetration guard's correction is dilated-then-blurred rather than applied
 // raw. Together they took ankle accel RMS 2.33 → 1.72 cm, knee angle jerk
@@ -321,6 +358,10 @@ const offlineMetrics = takeMetrics(offline);
 		`60 fps ankle jitter ${fast.anklePerS2.toFixed(0)} cm/s² vs 30 fps ${offlineMetrics.anklePerS2.toFixed(0)}`);
 	assert.ok(fast.kneeJerkPerS2 < offlineMetrics.kneeJerkPerS2 * 1.35,
 		`60 fps knee jerk ${fast.kneeJerkPerS2.toFixed(0)} °/s² vs 30 fps ${offlineMetrics.kneeJerkPerS2.toFixed(0)}`);
+	// The arm One-Euro's constants are Hz, not frame counts: measured 1.20x
+	// here, held to the same bar as the legs.
+	assert.ok(fast.wristPerS2 < offlineMetrics.wristPerS2 * 1.35,
+		`60 fps wrist jitter ${fast.wristPerS2.toFixed(0)} cm/s² vs 30 fps ${offlineMetrics.wristPerS2.toFixed(0)}`);
 	// The hip bound is looser because the hips ride the ground line, which is
 	// read from the input sole track and cannot be smoother than it: measured
 	// 1.34x here against 1.72x before the conversion.

--- a/tools/ardy/bvh-cskel27.mjs
+++ b/tools/ardy/bvh-cskel27.mjs
@@ -45,9 +45,10 @@ const CM_TO_M = 0.01;
 //    per-frame threshold the same physical spin reads half as fast at 60 fps
 //    and the repair silently stops firing) and bridged with one shortest-path
 //    slerp, corrected on EVERY joint so local articulation survives.
-//  - TORSO: mild zero-lag three-frame slerp on the trunk only; hands and
-//    arms stay untouched so punch timing and impact speed survive.
+//  - TORSO: mild zero-lag three-frame slerp on the trunk only.
 //  - LEGS: the same slerp, harder, on both leg chains — see LEG_BLEND.
+//  - ARMS: a One-Euro filter instead (#84) — speed-adaptive, so guard-band
+//    tremor is cut while punch speed survives; see the ARM_* block.
 const SPIN_DEG_PER_S = 25 * 30; // = 25°/frame at 30 fps
 const TORSO_BLEND = 0.2;
 const TORSO_JOINTS = ["Hips", "Spine", "Spine1", "Spine2", "Neck", "Head"].map((n) => `mixamorig:${n}`);
@@ -61,13 +62,42 @@ const TORSO_JOINTS = ["Hips", "Spine", "Spine1", "Spine2", "Neck", "Head"].map((
 // 1.78 on shadow17); take it back out of the finished stack and the ankle
 // returns to 2.35. It costs almost nothing in motion: the 95th percentile
 // ankle speed falls 318 → 303 cm/s, so the footwork is smoothed, not killed.
-// Arms are still deliberately NOT smoothed: a punch is a two-frame
+// Arms deliberately do NOT get this slerp: a punch is a two-frame
 // acceleration into an impact, and blending it with its neighbours is exactly
-// what softens the landing the animation exists to show. A foot has no such
-// event — it plants and it swings — so the same filter costs it nothing.
+// what softens the landing the animation exists to show — measured, this
+// slerp on the arm chains cuts peak hand speed 802 -> 724 cm/s while leaving
+// the guard-band wrist tremor it was meant to fix untouched (1.36 -> 1.36).
+// A foot has no such event — it plants and it swings — so the same filter
+// costs it nothing. The arms get the speed-adaptive filter below instead.
 const LEG_BLEND = 0.4;
 const LEG_JOINTS = ["LeftUpLeg", "LeftLeg", "LeftFoot", "LeftToeBase", "RightUpLeg", "RightLeg", "RightFoot", "RightToeBase"]
 	.map((n) => `mixamorig:${n}`);
+// ARMS (#84): a One-Euro filter on the arm chains only — an adaptive low-pass
+// whose cutoff RISES with angular speed. The neighbour slerp above is the
+// wrong tool here: it attenuates by frequency regardless of amplitude, and a
+// punch is a two-frame acceleration into contact that shares its band with
+// the tremor. One-Euro separates them by SPEED instead: near rest the chain
+// is filtered at ARM_MIN_CUTOFF_HZ (SAM's per-frame shoulder/elbow noise is
+// what reads as wrist tremble in a guard), while a strike drives the cutoff
+// up by ARM_BETA per °/s until the filter passes it essentially untouched.
+// Constants are durations/rates (Hz, °/s), so 30 and 60 fps clips filter the
+// same amount of TIME — dt enters only through the alpha formula (measured:
+// wrist accel per second² lands within 1.20x across a rate doubling, inside
+// the legs' 1.35x bar).
+// Measured on the fixtures (boxing / shadow17): wrist accel RMS 2.76 -> 2.56
+// / 2.69 -> 2.49 cm, the guard-band wrist accel (hands under 1.2 m/s, the
+// tremble the complaint is about) 1.36 -> 1.24 / 1.28 -> 1.19, while PEAK
+// hand speed keeps 799 of 802 cm/s — against the rejected leg-style slerp's
+// 724 with the guard band untouched. Swept: a lower ARM_MIN_CUTOFF_HZ buys
+// nothing (a boxer's arms are never still enough for the floor term to bind)
+// and a higher ARM_BETA_PER_DEG_S under-filters the guard band; the speed
+// cutoff at 5 Hz is what lets the filter snap OPEN on punch onset instead of
+// shaving its first frame (1 Hz there cost 25 cm/s of peak).
+const ARM_JOINTS = ["LeftShoulder", "LeftArm", "LeftForeArm", "LeftHand", "RightShoulder", "RightArm", "RightForeArm", "RightHand"]
+	.map((n) => `mixamorig:${n}`);
+const ARM_MIN_CUTOFF_HZ = 1.5; // rest-tremor low-pass on the arm chain
+const ARM_BETA_PER_DEG_S = 0.02; // cutoff gain: +1 Hz per 20 °/s of joint speed
+const ARM_SPEED_CUTOFF_HZ = 5.0; // smoothing on the speed estimate the cutoff reads
 // Neighbour span of that slerp: ±1 frame at 30 fps. Widening the span instead
 // of repeating the pass would be wrong — a stride-2 three-tap filter has unity
 // gain at Nyquist, so at 60 fps it would leave the every-other-frame noise
@@ -377,6 +407,7 @@ export function bvhToCskel27Motion(bvh) {
 	const bvhIndices = (names) => names.map((name) => bvhIndex.get(name)).filter((i) => i !== undefined);
 	stabilizeChain(worldsByFrame, bvhIndices(TORSO_JOINTS), TORSO_BLEND, torsoPasses);
 	stabilizeChain(worldsByFrame, bvhIndices(LEG_JOINTS), LEG_BLEND, torsoPasses);
+	oneEuroChain(worldsByFrame, bvhIndices(ARM_JOINTS), fps);
 
 	// The BVH's own sole heights, via FK over ITS skeleton. SAM's offline
 	// foot-contact pass already leveled the ground relationship in that
@@ -915,6 +946,33 @@ function stabilizeChain(worldsByFrame, chainIndices, blend, passes) {
 				const mid = slerpQuat(original[f - 1], original[f + 1], 0.5);
 				worldsByFrame[f][j] = quatToMat(slerpQuat(original[f], mid, blend));
 			}
+		}
+	}
+}
+
+/** One-Euro on world rotations (#84): sequential per joint, the filtered
+ *  quaternion slides toward each frame's raw one by an alpha derived from a
+ *  cutoff that RISES with the (smoothed) angular speed — slow tremor is cut,
+ *  a fast strike passes. See the ARM_* constants for why the arms get this
+ *  instead of the neighbour slerp above. Causal (a first frame of lag at
+ *  rest, none at speed) where the slerp is zero-lag — acceptable on arms,
+ *  wrong on legs, whose planted-foot metrics read absolute position. */
+function oneEuroChain(worldsByFrame, chainIndices, fps) {
+	const frames = worldsByFrame.length;
+	if (frames < 2 || chainIndices.length === 0) return;
+	const dt = 1 / fps;
+	const alphaFor = (cutoffHz) => 1 / (1 + 1 / (2 * Math.PI * cutoffHz * dt));
+	const speedAlpha = alphaFor(ARM_SPEED_CUTOFF_HZ);
+	for (const j of chainIndices) {
+		let filtered = matToQuat(worldsByFrame[0][j]);
+		let speedFiltered = 0;
+		for (let f = 1; f < frames; f += 1) {
+			const raw = matToQuat(worldsByFrame[f][j]);
+			const dot = Math.min(1, Math.abs(raw[0] * filtered[0] + raw[1] * filtered[1] + raw[2] * filtered[2] + raw[3] * filtered[3]));
+			const speedDegPerS = ((2 * Math.acos(dot) * 180) / Math.PI) / dt;
+			speedFiltered += speedAlpha * (speedDegPerS - speedFiltered);
+			filtered = slerpQuat(filtered, raw, alphaFor(ARM_MIN_CUTOFF_HZ + ARM_BETA_PER_DEG_S * speedFiltered));
+			worldsByFrame[f][j] = quatToMat(filtered);
 		}
 	}
 }


### PR DESCRIPTION
Closes #84.

## What
An arm/wrist-only filter on the GPU extract path (`bvh-cskel27.mjs`, after Mixamo BVH, alongside the existing torso/leg passes): a **One-Euro** filter on the arm chains (`Left/RightShoulder, Arm, ForeArm, Hand` — not torso, not legs, not root). Speed-adaptive: near rest the chain is low-passed at `ARM_MIN_CUTOFF_HZ`; a strike drives the cutoff up by `ARM_BETA_PER_DEG_S` per °/s until it passes essentially untouched.

## Why One-Euro and not the leg slerp
Measured on the same fixtures, the leg-style slerp applied to the arms is exactly the failure the issue predicted: peak hand speed collapses **802 → 724 cm/s** while the guard-band tremor it was meant to fix stays at **1.36** (untouched). The One-Euro instead:

| metric (boxing / shadow17) | before | after |
|---|---|---|
| wrist accel RMS (cm) | 2.76 / 2.69 | **2.56 / 2.49** |
| guard-band wrist accel (hands < 1.2 m/s) | 1.36 / 1.28 | **1.24 / 1.19** |
| peak hand speed (cm/s) | 802 / 796 | **799 / 796** |
| ankle / toe / hips accel | — | **byte-identical** |

## Duration-based, per the file's contract
Constants are Hz and °/s — dt enters only through the alpha formula. Measured across a rate doubling: wrist accel per-s² ratio **1.20×**, inside the 1.35× bar the legs are held to (asserted).

## Acceptance (all in `test/verify-bvh-cskel27.mjs`)
- `wrist < 2.7` and `guardWrist < 1.32` — catch removing the filter (unfiltered: 2.76 / 1.36).
- `handSpeedMax > 760 cm/s` — catches swapping in any blunt smoother (slerp scores 724).
- 60 fps wrist-per-s² parity `< 1.35×`.
- Existing leg/grounding bounds unchanged and passing — the arm pass is disjoint from the leg FK.

Out of scope, per the issue: no foot-IK changes, no model swap, browser MediaPipe path untouched.