### PR TITLE
feat(inspector): pick any object colour, not just the six presets (#88)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,13 +147,17 @@ import {
 	createSceneObject,
 	duplicateCutoutOptions,
 	dropToSurfacePatch,
+	normalizeObjectColor,
 	objectSize,
 	placementInFront,
+	readStoredObjectColors,
+	rememberObjectColor,
 	removeSceneObject,
 	setSceneObjectAttach,
 	setSceneObjectParent,
 	sceneObjectIdFromHierarchy,
 	updateSceneObject,
+	writeStoredObjectColors,
 } from "./scene-objects.js";
 import { createSceneHistoryStore } from "./scene-history.js";
 import {
@@ -1094,6 +1098,24 @@ globalThis.playMode = centerTab === "play";
 	// ARDY workflow in pipeline order. Selecting anything in the scene routes
 	// to the inspector tab; the root SHOT row routes to the shot tab.
 	const [inspectorActionsOpen, setInspectorActionsOpen] = useState(false);
+	// Hand-mixed object tints, newest first. An editor preference like the
+	// guides above — it belongs to this browser, never to the scene, so it is
+	// kept out of the scene document and written straight back to storage.
+	const [recentObjectColors, setRecentObjectColors] = useState(() => readStoredObjectColors(globalThis.localStorage));
+	// What is being typed into the hex field right now, or null when nobody is
+	// typing. Held apart from the record so a half-written "#ff3" survives on
+	// screen without ever repainting the prop, and so the field snaps back to
+	// the object's real colour the moment the edit ends.
+	const [objectColorDraft, setObjectColorDraft] = useState(null);
+	function rememberSceneObjectColor(hex) {
+		setRecentObjectColors((previous) => {
+			const next = rememberObjectColor(previous, hex);
+			// rememberObjectColor returns the same array when nothing changed, so a
+			// re-pick of the same tint neither writes storage nor re-renders.
+			if (next !== previous) writeStoredObjectColors(globalThis.localStorage, next);
+			return next;
+		});
+	}
 	const [objectDeleteUndo, setObjectDeleteUndo] = useState(null);
 	// An undo offer is an offer, not a banner: without a window it sits on the
 	// screen for the rest of the session. Long enough to notice and reach, then
@@ -11608,6 +11630,65 @@ function resizePromptClip(id, edge, rawFrame) {
 												}}
 											/>
 										))}
+										{/* Recently mixed tints, fenced off from the presets by a
+										    rule: they are this browser's memory, not the palette,
+										    and MCP's update_object can put any hex on a prop — an
+										    author has to be able to reach the same colour back. */}
+										{recentObjectColors.length > 0 && <span className="object-colors-split" aria-hidden="true" />}
+										{recentObjectColors.map((color) => (
+											<button
+												type="button"
+												key={color}
+												className={"object-color" + (selectedSceneObject.color === color ? " active" : "")}
+												style={{ background: color }}
+												aria-label={isKo ? `최근 색상 ${color}` : `Recent colour ${color}`}
+												aria-pressed={selectedSceneObject.color === color}
+												onClick={(event) => {
+													changeSceneObject(selectedSceneObject.id, { color });
+													rememberSceneObjectColor(color);
+													event.currentTarget.closest("details")?.removeAttribute("open");
+												}}
+											/>
+										))}
+										{/* The free colour: the native picker for choosing one, the
+										    hex field for typing or reading back an exact value. Neither
+										    closes the popover the way a preset does — a picker drag and
+										    a half-typed hex both fire change after change, and a row
+										    that vanished mid-edit would be unusable. */}
+										<input
+											type="color"
+											className="object-color object-color-free"
+											value={normalizeObjectColor(selectedSceneObject.color) ?? "#ffffff"}
+											title={ko("Custom colour", "직접 고른 색상")}
+											aria-label={ko("Custom colour", "직접 고른 색상")}
+											onChange={(event) => {
+												const color = normalizeObjectColor(event.target.value);
+												if (!color) return;
+												changeSceneObject(selectedSceneObject.id, { color });
+												rememberSceneObjectColor(color);
+											}}
+										/>
+										<input
+											type="text"
+											className="object-color-hex"
+											// Idle, the field IS the object's colour — including one an
+											// agent set through MCP's update_object, which the palette
+											// alone could never show. Mid-edit the draft takes over.
+											value={objectColorDraft ?? selectedSceneObject.color}
+											spellCheck={false}
+											maxLength={7}
+											placeholder="#rrggbb"
+											title={ko("Colour hex", "색상 hex")}
+											aria-label={ko("Colour hex", "색상 hex")}
+											onChange={(event) => {
+												setObjectColorDraft(event.target.value);
+												const color = normalizeObjectColor(event.target.value);
+												if (!color) return; // a typo is a keystroke, not a repaint
+												changeSceneObject(selectedSceneObject.id, { color });
+												rememberSceneObjectColor(color);
+											}}
+											onBlur={() => setObjectColorDraft(null)}
+										/>
 										</div>
 									</details>
 								)}

--- a/src/scene-objects.js
+++ b/src/scene-objects.js
@@ -75,9 +75,95 @@ export const OBJECT_LIBRARY = [
 	{ kind: "small-plane", label: "Plane (aircraft)", group: "Set pieces", footprint: { width: 3.4, depth: 3.6 }, height: 1.4, color: "#7896a4" },
 ];
 
-/** Blockout greys first, then the clay accents, for re-tinting from the
- * inspector. */
-export const OBJECT_COLORS = ["#e2e5e6", GREY_BOX, "#9aa1a5", "#767d81", "#d9b18c", "#8fae9b"];
+/** Blockout greys first, then the clay accents, then the blocking chromatics,
+ * for re-tinting from the inspector. The greys lead because a blockout starts
+ * grey; the saturated four exist so a shot can say "the red ball, the blue
+ * box" at a glance — the inspector had no way to say that at all (#88). They
+ * are muted off pure RGB so they still read as clay under the set's lighting.
+ * Any other colour is authored through the inspector's free colour input. */
+export const OBJECT_COLORS = [
+	"#e2e5e6",
+	GREY_BOX,
+	"#9aa1a5",
+	"#767d81",
+	"#d9b18c",
+	"#8fae9b",
+	"#d94a4a",
+	"#4a7bd9",
+	"#e2c04a",
+	"#4fa86a",
+];
+
+/** How many hand-mixed colours the inspector remembers. Six is one palette
+ * row: enough to keep a scene's custom tints reachable, short enough that the
+ * popover never turns into a second, unruly palette. */
+export const RECENT_OBJECT_COLORS_MAX = 6;
+/** Session memory of hand-mixed tints; versioned like every other key here. */
+export const RECENT_OBJECT_COLORS_KEY = "cozyclay.objectColors.recent";
+
+const HEX_SHORT = /^#?([0-9a-f]{3})$/i;
+const HEX_LONG = /^#?([0-9a-f]{6})$/i;
+
+/**
+ * What a colour input typed by a human means, or null if it means nothing.
+ *
+ * The hex field accepts what people actually type — `#f36`, `ff3366`, upper
+ * case, stray spaces — and folds it to the one form the record stores, so a
+ * colour typed by hand and the same colour picked from the native swatch are
+ * byte-identical (and therefore compare equal against the palette). Anything
+ * else returns null rather than throwing or guessing: a half-typed `#12` is a
+ * keystroke on the way somewhere, not an instruction to repaint the prop.
+ */
+export function normalizeObjectColor(value) {
+	if (typeof value !== "string") return null;
+	const text = value.trim();
+	const short = HEX_SHORT.exec(text);
+	if (short) return `#${short[1].toLowerCase().replace(/./g, (digit) => digit + digit)}`;
+	const long = HEX_LONG.exec(text);
+	return long ? `#${long[1].toLowerCase()}` : null;
+}
+
+/**
+ * The recent-colours list after mixing `hex`: newest first, no duplicates,
+ * capped, presets excluded.
+ *
+ * Pure so the list can be proved without a browser, and so a corrupt stored
+ * list is repaired on the way through instead of painting a swatch with junk.
+ * Presets are skipped because they are already one row up — remembering them
+ * would push the author's own colours off the end with colours they never
+ * mixed. Returns the SAME array when nothing changes, so a re-pick of an
+ * unchanged colour cannot trigger a storage write or a re-render.
+ */
+export function rememberObjectColor(list, hex) {
+	const clean = Array.isArray(list)
+		? list.map(normalizeObjectColor).filter((color, index, all) => color && all.indexOf(color) === index && !OBJECT_COLORS.includes(color))
+		: [];
+	const color = normalizeObjectColor(hex);
+	const next = color && !OBJECT_COLORS.includes(color) ? [color, ...clean.filter((entry) => entry !== color)] : clean;
+	const capped = next.slice(0, RECENT_OBJECT_COLORS_MAX);
+	const unchanged = Array.isArray(list) && capped.length === list.length && capped.every((entry, index) => entry === list[index]);
+	return unchanged ? list : capped;
+}
+
+/** Recent colours as last left by this browser; storage can be unavailable
+ * (private mode), and a corrupt body must not take the inspector down with
+ * it — either way the palette simply starts without a memory. */
+export function readStoredObjectColors(storage) {
+	try {
+		const parsed = JSON.parse(storage?.getItem(RECENT_OBJECT_COLORS_KEY) ?? "[]");
+		return rememberObjectColor(Array.isArray(parsed) ? parsed : [], null);
+	} catch {
+		return [];
+	}
+}
+
+export function writeStoredObjectColors(storage, list) {
+	try {
+		storage?.setItem(RECENT_OBJECT_COLORS_KEY, JSON.stringify(list));
+	} catch {
+		// Storage can be unavailable (private mode); the colours simply stop persisting.
+	}
+}
 
 /**
  * A cutout is a standee: an imported image standing on a card. Its size is NOT

--- a/src/styles.css
+++ b/src/styles.css
@@ -1774,12 +1774,61 @@ select {
 	top: 26px;
 	z-index: 20;
 	display: flex;
+	/* Ten presets, the author's recent tints and the two free-colour inputs no
+	   longer fit one line of a narrow inspector (#88): wrap into rows of six
+	   swatches so the popover stays inside the panel instead of running off it. */
+	flex-wrap: wrap;
+	align-items: center;
+	width: max-content;
+	max-width: 176px;
 	gap: 4px;
 	padding: 5px;
 	border: 1px solid rgba(126, 154, 255, .28);
 	border-radius: 8px;
 	background: #161c2b;
 	box-shadow: 0 8px 18px rgba(0, 0, 0, .45);
+}
+
+/* The author's own colours are a different kind of thing from the palette, so
+   a full-width rule separates them rather than a gap nobody would read. */
+.object-colors-split {
+	flex: 1 0 100%;
+	height: 1px;
+	margin: 1px 0;
+	background: rgba(126, 154, 255, .28);
+}
+
+/* The native picker, dressed as one more swatch: same box as .object-color so
+   the row reads as one palette (the character picker's .sb-color does the
+   same trick for the subject box). */
+.object-color-free {
+	padding: 1px;
+	background: #ffffff05;
+	appearance: none;
+	-webkit-appearance: none;
+}
+
+.object-color-free::-webkit-color-swatch-wrapper { padding: 0; }
+.object-color-free::-webkit-color-swatch { border: 0; border-radius: 4px; }
+
+/* The exact value, typed or read back — an agent's update_object hex has to be
+   both visible and re-typable here. Monospace: it is a machine value. */
+.object-color-hex {
+	flex: 1 0 100%;
+	width: 100%;
+	padding: 2px 5px;
+	border: 1px solid var(--line2);
+	border-radius: 6px;
+	background: rgba(0, 0, 0, .28);
+	color: var(--fg);
+	font-family: var(--mono);
+	font-size: 10px;
+	text-transform: lowercase;
+}
+
+.object-color-hex:focus-visible {
+	outline: 1px solid var(--accent);
+	outline-offset: 0;
 }
 
 .scene-switcher-heading {

--- a/test/verify-object-colour-browser.mjs
+++ b/test/verify-object-colour-browser.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * Object colour, end to end in a real browser (issue #88).
+ *
+ * The palette, the hex parser and the recent-colour memory are pure and proved
+ * in verify-scene-objects.mjs. What only exists in a running page is the part
+ * the issue is actually about: that a colour typed into the inspector reaches
+ * the prop in the 3D scene, that the popover survives being typed into (a
+ * preset click deliberately closes it — an edit in progress must not), that a
+ * typo repaints nothing, and that a hand-mixed tint is still on the palette
+ * after a reload.
+ *
+ * Run: `npm run dev:ui` in one shell, then
+ * `QA_URL=http://127.0.0.1:5180/app/ npm run qa:browser -- node test/verify-object-colour-browser.mjs`.
+ * QA_SCREENSHOT / QA_SUMMARY write the review artifacts.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+	ws.onopen = resolve;
+	ws.onerror = reject;
+});
+
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params.exceptionDetails.exception?.description ?? message.params.exceptionDetails.text);
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) =>
+	new Promise((resolve, reject) => {
+		const id = nextId++;
+		pending.set(id, { resolve, reject });
+		ws.send(JSON.stringify({ id, method, params }));
+	});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+/** evaluate that treats a mid-navigation context loss as "not ready", not a crash */
+const evaluateSafely = async (expression) => {
+	try {
+		return await evaluate(expression);
+	} catch {
+		return undefined;
+	}
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+/** poll the page until expression is truthy or the timeout expires */
+const waitFor = async (expression, { timeoutMs = 10000, intervalMs = 100 } = {}) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluateSafely(expression)) return true;
+		await sleep(intervalMs);
+	}
+	return false;
+};
+
+let failures = 0;
+const results = [];
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	results.push({ name, pass: !!condition, detail: condition ? "" : String(detail) });
+	if (!condition) failures += 1;
+};
+
+/** Type into a React-controlled input the way a keyboard would: the native
+ * value setter, then the input event React actually listens to. */
+const typeInto = (selector, text) =>
+	evaluate(`(() => {
+		const input = document.querySelector(${JSON.stringify(selector)});
+		if (!input) return false;
+		input.focus();
+		Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, ${JSON.stringify(text)});
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		return true;
+	})()`);
+
+/** The colour the prop is actually rendered with, read off the live three.js
+ * material — not the record, not the swatch: the pixel-facing truth. */
+const renderedColour = () =>
+	evaluate(`(() => {
+		let node = window.__cozyclay?.shotCam;
+		while (node && !node.isScene) node = node.parent;
+		if (!node) return null;
+		let hex = null;
+		node.traverse((object) => {
+			if (hex || !object.userData?.sceneObjectId) return;
+			object.traverse((child) => {
+				if (hex || !child.isMesh || !child.material?.color) return;
+				hex = '#' + child.material.color.getHexString();
+			});
+		});
+		return hex;
+	})()`);
+
+/** The colour the scene document was saved with (debounced ~400ms). */
+const storedColour = () =>
+	evaluate(`(() => {
+		const body = JSON.parse(localStorage.getItem('cozyclay.scenes.v4') || 'null');
+		const scene = body?.scenes?.find((entry) => entry.id === body.activeSceneId) ?? body?.scenes?.[0];
+		return scene?.objects?.[0]?.color ?? null;
+	})()`);
+
+const detailsOpen = () => evaluate("!!document.querySelector('.object-colors-pop')?.open");
+const recentStored = () =>
+	evaluate("JSON.parse(localStorage.getItem('cozyclay.objectColors.recent') || '[]')");
+
+const reloadPage = async () => {
+	await send("Page.reload");
+	await waitFor("!!document.querySelector('canvas')", { timeoutMs: 30000 });
+	await waitFor("!!window.__sceneHistory && document.querySelectorAll('.hierarchy-row').length > 0", { timeoutMs: 30000 });
+	await sleep(1200);
+};
+
+await send("Runtime.enable");
+
+try {
+	// Start from empty storage: a scene or a recent list left by an earlier run
+	// would boot on the first reload and poison every assertion below.
+	await waitFor("location.href.startsWith('http')", { timeoutMs: 30000 });
+	await evaluate(`(() => {
+		localStorage.clear();
+		localStorage.setItem('cozyclay.locale', 'en');
+	})()`);
+	await reloadPage();
+	expect("the studio renders a canvas", await evaluate("!!document.querySelector('canvas')"));
+
+	/* --------------------------------------------------- a cube to paint ---- */
+
+	await evaluate("document.querySelector('.add-object-trigger').click()");
+	expect("the add-object catalogue opens", await waitFor("document.querySelectorAll('.add-object-item').length > 0"));
+	await evaluate("[...document.querySelectorAll('.add-object-item')].find(b => b.textContent.startsWith('Cube')).click()");
+	expect("the cube opens in the inspector", await waitFor("!!document.querySelector('.object-colors-pop')"));
+
+	/* ------------------------------------------------------ the palette ---- */
+
+	await evaluate("document.querySelector('.object-colors-pop > summary').click()");
+	expect("the colour popover opens", await waitFor("!!document.querySelector('.object-colors-pop')?.open"));
+	const swatches = await evaluate(
+		"[...document.querySelectorAll('.object-colors .object-color:not(.object-color-free)')].map(b => b.style.background)",
+	);
+	expect(
+		"the palette offers red, blue, yellow and green",
+		["rgb(217, 74, 74)", "rgb(74, 123, 217)", "rgb(226, 192, 74)", "rgb(79, 168, 106)"].every((rgb) => swatches.includes(rgb)),
+		JSON.stringify(swatches),
+	);
+	expect("the popover carries a native colour picker", await evaluate("!!document.querySelector('.object-colors input[type=color]')"));
+	const hexFieldValue = () => evaluate("document.querySelector('.object-color-hex')?.value ?? null");
+	expect("the hex field shows the object's current colour", (await hexFieldValue()) === "#c2c6c8", await hexFieldValue());
+
+	/* ------------------------------------------------ an arbitrary colour --- */
+
+	await typeInto(".object-color-hex", "#ff3366");
+	expect(
+		"a typed hex repaints the prop in the 3D scene",
+		await waitFor(`(() => {
+			let node = window.__cozyclay?.shotCam;
+			while (node && !node.isScene) node = node.parent;
+			if (!node) return false;
+			let hit = false;
+			node.traverse((object) => {
+				if (hit || !object.userData?.sceneObjectId) return;
+				object.traverse((child) => { if (child.isMesh && child.material?.color?.getHexString() === 'ff3366') hit = true; });
+			});
+			return hit;
+		})()`),
+		await renderedColour(),
+	);
+	expect("the popover stays open while the hex field is used", await detailsOpen());
+	expect("the typed colour reaches the saved scene", await waitFor("JSON.parse(localStorage.getItem('cozyclay.scenes.v4') || 'null')?.scenes?.[0]?.objects?.[0]?.color === '#ff3366'"), await storedColour());
+	expect("the hex field reads back the value an agent could also have set", (await hexFieldValue()) === "#ff3366", await hexFieldValue());
+
+	/* --------------------------------------------------------- typos --------- */
+
+	await typeInto(".object-color-hex", "zzz");
+	await sleep(300);
+	expect("a malformed hex repaints nothing", (await renderedColour()) === "#ff3366", await renderedColour());
+	expect("a malformed hex leaves the saved scene alone", (await storedColour()) === "#ff3366", await storedColour());
+	expect("the popover survives a typo too", await detailsOpen());
+	expect("no uncaught page error from the typo", pageErrors.length === 0, pageErrors.join(" | "));
+	// Blur puts the field back to what the prop actually is, so a typo never
+	// lingers as a value the author might believe.
+	await evaluate("document.querySelector('.object-color-hex')?.blur()");
+	await sleep(200);
+	expect("leaving the field restores the object's real colour", (await hexFieldValue()) === "#ff3366", await hexFieldValue());
+
+	const screenshotPath = process.env.QA_SCREENSHOT;
+	if (screenshotPath) {
+		mkdirSync(dirname(screenshotPath), { recursive: true });
+		const capture = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: false });
+		writeFileSync(screenshotPath, Buffer.from(capture.data, "base64"));
+	}
+
+	/* --------------------------------------------------- recent colours ---- */
+
+	expect("the mixed colour is remembered", (await recentStored()).includes("#ff3366"), JSON.stringify(await recentStored()));
+	await reloadPage();
+	expect("the recent list survives a reload", (await recentStored()).includes("#ff3366"), JSON.stringify(await recentStored()));
+	// A reload lands on no selection and a folded Props group: unfold it and
+	// pick the cube, which is what an author does coming back to a scene.
+	await evaluate(`(() => {
+		const props = [...document.querySelectorAll('.hierarchy-row-wrap')].find((row) => row.textContent.includes('Props'));
+		if (props?.getAttribute('aria-expanded') === 'false') props.querySelector('.hierarchy-toggle')?.click();
+	})()`);
+	await waitFor("[...document.querySelectorAll('.hierarchy-label')].some(n => n.textContent === 'Cube')");
+	await evaluate("[...document.querySelectorAll('.hierarchy-label')].find(n => n.textContent === 'Cube')?.closest('.hierarchy-row')?.click()");
+	expect("the cube can be selected again after the reload", await waitFor("!!document.querySelector('.object-colors-pop')"));
+	await evaluate("document.querySelector('.object-colors-pop > summary')?.click()");
+	expect("the popover reopens after the reload", await waitFor("!!document.querySelector('.object-colors-pop')?.open"));
+	expect(
+		"the remembered tint is offered as a swatch after the presets",
+		await waitFor("[...document.querySelectorAll('.object-colors .object-color')].some(b => b.style.background === 'rgb(255, 51, 102)')"),
+		await evaluate("[...document.querySelectorAll('.object-colors .object-color')].map(b => b.style.background).join(',')"),
+	);
+	expect("the recent swatches are separated from the palette", await evaluate("!!document.querySelector('.object-colors .object-colors-split')"));
+
+	expect("no uncaught page errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+	const summaryPath = process.env.QA_SUMMARY;
+	if (summaryPath) {
+		mkdirSync(dirname(summaryPath), { recursive: true });
+		writeFileSync(
+			summaryPath,
+			`${JSON.stringify(
+				{
+					issue: 88,
+					url: process.env.QA_URL ?? null,
+					when: new Date().toISOString(),
+					objectColor: await renderedColour(),
+					storedColor: await storedColour(),
+					recent: await recentStored(),
+					palette: swatches,
+					screenshot: screenshotPath ?? null,
+					failures,
+					checks: results,
+				},
+				null,
+				"\t",
+			)}\n`,
+		);
+	}
+} finally {
+	ws.close();
+}
+
+if (failures) process.exit(1);
+console.log("all object colour browser checks PASS");

--- a/test/verify-scene-objects.mjs
+++ b/test/verify-scene-objects.mjs
@@ -9,7 +9,10 @@ import {
 	normalizeSceneObject,
 	serializeScene,
 	DEFAULT_SCENE_OBJECTS,
+	OBJECT_COLORS,
 	OBJECT_LIBRARY,
+	normalizeObjectColor,
+	rememberObjectColor,
 	createSceneObject,
 	createCutoutObject,
 	duplicateCutoutOptions,
@@ -890,6 +893,80 @@ expect(
 		const { attach, ...old } = aProp;
 		return normalizeSceneObject(old).attach === null;
 	})(),
+);
+
+/* ------------------------------------------------- object colours ---- */
+// Issue #88: the palette was six neutrals, so a blockout could not even say
+// "the red ball". The chromatics are part of the contract now.
+expect(
+	"the palette keeps its six neutrals first",
+	OBJECT_COLORS.slice(0, 6).join() === ["#e2e5e6", "#c2c6c8", "#9aa1a5", "#767d81", "#d9b18c", "#8fae9b"].join(),
+	JSON.stringify(OBJECT_COLORS),
+);
+expect(
+	"the palette offers red, blue, yellow and green for blocking",
+	["#d94a4a", "#4a7bd9", "#e2c04a", "#4fa86a"].every((color) => OBJECT_COLORS.includes(color)),
+	JSON.stringify(OBJECT_COLORS),
+);
+expect(
+	"every palette entry is a normalized lowercase #rrggbb",
+	OBJECT_COLORS.every((color) => normalizeObjectColor(color) === color),
+	JSON.stringify(OBJECT_COLORS),
+);
+
+// The hex field takes what a human types — shorthand, no hash, upper case —
+// and everything else is a typo, not a colour: it must not reach the record.
+expect(
+	"a hex field accepts #rgb, #rrggbb and bare digits, folded to lowercase #rrggbb",
+	normalizeObjectColor("#F36") === "#ff3366" &&
+		normalizeObjectColor("#FF3366") === "#ff3366" &&
+		normalizeObjectColor("ff3366") === "#ff3366" &&
+		normalizeObjectColor("  f36 ") === "#ff3366",
+	JSON.stringify([normalizeObjectColor("#F36"), normalizeObjectColor("#FF3366"), normalizeObjectColor("ff3366"), normalizeObjectColor("  f36 ")]),
+);
+expect(
+	"malformed hex reads as no colour at all",
+	["zzz", "#12345", "#gggggg", "", "#", "red", null, undefined, 255, {}].every((bad) => normalizeObjectColor(bad) === null),
+	JSON.stringify(["zzz", "#12345", "#gggggg", "", "red"].map(normalizeObjectColor)),
+);
+
+// Recent colours are a memory of what the author mixed, not a second palette:
+// presets stay out of it, the newest is first, and the list never grows.
+expect(
+	"a remembered colour moves to the front and never duplicates",
+	(() => {
+		const once = rememberObjectColor([], "#ff3366");
+		const twice = rememberObjectColor(rememberObjectColor(once, "#123456"), "#FF3366");
+		return once.join() === "#ff3366" && twice.join() === ["#ff3366", "#123456"].join();
+	})(),
+	JSON.stringify(rememberObjectColor(rememberObjectColor(rememberObjectColor([], "#ff3366"), "#123456"), "#FF3366")),
+);
+expect(
+	"the recent list caps at six, dropping the oldest",
+	(() => {
+		const hexes = ["#111111", "#222222", "#333333", "#444444", "#555555", "#666666", "#777777"];
+		const list = hexes.reduce((acc, hex) => rememberObjectColor(acc, hex), []);
+		return list.length === 6 && list[0] === "#777777" && !list.includes("#111111");
+	})(),
+	JSON.stringify(["#111111", "#222222", "#333333", "#444444", "#555555", "#666666", "#777777"].reduce((acc, hex) => rememberObjectColor(acc, hex), [])),
+);
+expect(
+	"a preset is already on the palette, so it is never remembered twice",
+	rememberObjectColor(["#ff3366"], OBJECT_COLORS[0]).join() === "#ff3366" &&
+		rememberObjectColor(["#ff3366"], "#D94A4A").join() === "#ff3366",
+	JSON.stringify(rememberObjectColor(["#ff3366"], OBJECT_COLORS[0])),
+);
+expect(
+	"malformed input leaves the recent list untouched, by identity",
+	(() => {
+		const list = ["#ff3366"];
+		return rememberObjectColor(list, "zzz") === list && rememberObjectColor(list, null) === list;
+	})(),
+);
+expect(
+	"a stored recent list is sanitised, so junk in storage cannot paint a swatch",
+	rememberObjectColor(["nope", "#ABCDEF", 7, "#ff3366"], "#010203").join() === ["#010203", "#abcdef", "#ff3366"].join(),
+	JSON.stringify(rememberObjectColor(["nope", "#ABCDEF", 7, "#ff3366"], "#010203")),
 );
 
 // The grouping and attachment sections run after the first gate above, so they

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -131,6 +131,7 @@ const BROWSER_FILES = [
 	"test/verify-cutout-browser.mjs",
 	"test/verify-ik-browser.mjs",
 	"test/verify-motion-edit-browser.mjs",
+	"test/verify-object-colour-browser.mjs",
 	"test/verify-object-gizmo.mjs",
 	"test/verify-offscreen-export-browser.mjs",
 	"test/verify-project-menu-browser.mjs",


### PR DESCRIPTION
Closes #88.

## What
- `OBJECT_COLORS` gains four saturated blocking presets (red, blue, yellow, green) after the six neutrals.
- The Inspector colour popover grows a native `<input type="color">` swatch and a hex text field, both routed through the same `changeSceneObject` path as the presets. Malformed hex (`zzz`, `#12`, empty) is ignored without touching the record.
- Hand-mixed tints are remembered per browser (`cozyclay.objectColors.recent`, newest first, deduped, capped at 6, presets skipped) and offered after the palette. Any hex set through MCP `update_object` now reads back in the hex field and can be re-picked.

## Tests
- `test/verify-scene-objects.mjs`: +12 assertions (palette, `normalizeObjectColor`, `rememberObjectColor` dedupe/cap/preset-skip/sanitise). Captured RED before the palette change.
- New real-browser suite `test/verify-object-colour-browser.mjs` (CDP, in `BROWSER_FILES`): types `#ff3366`, asserts the live three.js material, the saved scene doc, `details[open]`, malformed input inertness, and the recent list surviving a reload. 23/23 PASS locally on Apple M4 Pro (ANGLE Metal).
- `npm test` green locally.
