### PR TITLE
fix(inspector): drag the number itself to scrub a transform value (#87)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11257,7 +11257,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						{selectedSceneObject && (
 							<>
 								<p className="inspector-hint">
-								{ko("Type a value and press Enter, or drag an axis letter to scrub.", "값을 입력하고 Enter를 누르거나 축 글자를 드래그해 조절하세요.")}
+								{ko("Type a value and press Enter, or drag a number sideways to scrub (Shift for fine).", "값을 입력하고 Enter를 누르거나 숫자를 좌우로 끌어 조절하세요(Shift는 미세 조정).")}
 								</p>
 								<label className="check snap-toggle">
 									<input type="checkbox" checked={snapEnabled} onChange={(event) => setSnapEnabled(event.target.checked)} />
@@ -11324,25 +11324,25 @@ function resizePromptClip(id, edge, rawFrame) {
 								<Vector3Row
 							label={ko("Position", "위치")}
 									fields={[
-										{ axis: "X", value: selectedSceneObject.x, step: 0.05, precision: 2, onChange: (x) => changeSceneObject(selectedSceneObject.id, { x }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
-										{ axis: "Y", value: selectedSceneObject.y ?? 0, step: 0.05, precision: 2, onChange: (y) => changeSceneObject(selectedSceneObject.id, { y }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
-										{ axis: "Z", value: selectedSceneObject.z, step: 0.05, precision: 2, onChange: (z) => changeSceneObject(selectedSceneObject.id, { z }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "X", value: selectedSceneObject.x, step: 0.05, precision: 2, scrubRange: 5, onChange: (x, token) => changeSceneObject(selectedSceneObject.id, { x }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "Y", value: selectedSceneObject.y ?? 0, step: 0.05, precision: 2, scrubRange: 5, onChange: (y, token) => changeSceneObject(selectedSceneObject.id, { y }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "Z", value: selectedSceneObject.z, step: 0.05, precision: 2, scrubRange: 5, onChange: (z, token) => changeSceneObject(selectedSceneObject.id, { z }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
 									]}
 								/>
 								<Vector3Row
 							label={ko("Rotation", "회전")}
 									fields={[
-										{ axis: "X", value: selectedSceneObject.rotX ?? 0, step: 1, precision: 1, onChange: (rotX) => changeSceneObject(selectedSceneObject.id, { rotX }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
-										{ axis: "Y", value: selectedSceneObject.rot, step: 1, precision: 1, onChange: (rot) => changeSceneObject(selectedSceneObject.id, { rot }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
-										{ axis: "Z", value: selectedSceneObject.rotZ ?? 0, step: 1, precision: 1, onChange: (rotZ) => changeSceneObject(selectedSceneObject.id, { rotZ }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "X", value: selectedSceneObject.rotX ?? 0, step: 1, precision: 1, scrubRange: 180, onChange: (rotX, token) => changeSceneObject(selectedSceneObject.id, { rotX }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "Y", value: selectedSceneObject.rot, step: 1, precision: 1, scrubRange: 180, onChange: (rot, token) => changeSceneObject(selectedSceneObject.id, { rot }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "Z", value: selectedSceneObject.rotZ ?? 0, step: 1, precision: 1, scrubRange: 180, onChange: (rotZ, token) => changeSceneObject(selectedSceneObject.id, { rotZ }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
 									]}
 								/>
 								<Vector3Row
 							label={ko("Scale", "크기")}
 									fields={[
-										{ axis: "X", value: selectedSceneObject.scaleX ?? 1, step: 0.05, precision: 2, onChange: (scaleX) => changeSceneObject(selectedSceneObject.id, { scaleX }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
-										{ axis: "Y", value: selectedSceneObject.scaleY ?? 1, step: 0.05, precision: 2, onChange: (scaleY) => changeSceneObject(selectedSceneObject.id, { scaleY }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
-										{ axis: "Z", value: selectedSceneObject.scaleZ ?? 1, step: 0.05, precision: 2, onChange: (scaleZ) => changeSceneObject(selectedSceneObject.id, { scaleZ }), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "X", value: selectedSceneObject.scaleX ?? 1, step: 0.05, precision: 2, scrubRange: 4, onChange: (scaleX, token) => changeSceneObject(selectedSceneObject.id, { scaleX }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "Y", value: selectedSceneObject.scaleY ?? 1, step: 0.05, precision: 2, scrubRange: 4, onChange: (scaleY, token) => changeSceneObject(selectedSceneObject.id, { scaleY }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
+										{ axis: "Z", value: selectedSceneObject.scaleZ ?? 1, step: 0.05, precision: 2, scrubRange: 4, onChange: (scaleZ, token) => changeSceneObject(selectedSceneObject.id, { scaleZ }, token), onScrubStart: beginSceneTransaction, onScrubEnd: endSceneTransaction },
 									]}
 								/>
 								{selectedSceneObject.renderer === CUTOUT_KIND && (

--- a/src/styles.css
+++ b/src/styles.css
@@ -6390,8 +6390,10 @@ input[type=range]::-moz-range-thumb {
 }
 /* ---- Object Transform: Unity-style numeric fields ---- */
 /* Three labelled rows (Position / Rotation / Scale) of three scrubbable
-   number fields. The axis letters are drag handles: ew-resize cursor and
-   touch-action off so pointer capture owns the whole gesture. */
+   number fields. The WHOLE field is the drag handle — badge and number alike
+   (issue #87: the badge alone was a 15 px hotspot users never found, and they
+   aim at the number). ew-resize advertises it, touch-action off so pointer
+   capture owns the whole gesture. */
 
 .vec3-row {
 	display: flex;
@@ -6413,6 +6415,7 @@ input[type=range]::-moz-range-thumb {
 	align-items: stretch;
 	flex: 1;
 	min-width: 0;
+	touch-action: none;
 }
 
 .number-field .axis {
@@ -6448,6 +6451,13 @@ input[type=range]::-moz-range-thumb {
 	font-weight: 480;
 	font-variant-numeric: tabular-nums;
 	text-align: right;
+	/* Draggable until it is being typed in: the caret only appears once the
+	   click has actually opened the field for editing. */
+	cursor: ew-resize;
+}
+
+.number-field.editing input {
+	cursor: text;
 }
 
 .number-field:hover input {
@@ -6465,6 +6475,7 @@ input[type=range]::-moz-range-thumb {
 	border-color: var(--accent);
 	background: var(--card2);
 	box-shadow: 0 0 0 2px var(--accent-ring);
+	cursor: text;
 }
 /* ---- Hierarchy row context menu & in-place rename ---- */
 /* The row menu (Rename/Duplicate/Delete/Frame) and the create catalogue

--- a/src/ui-scrub.js
+++ b/src/ui-scrub.js
@@ -1,0 +1,102 @@
+/**
+ * Number-field scrubbing — the pure half of the Inspector's drag-a-number.
+ *
+ * The field itself lives in ui.jsx, but the two decisions that make the
+ * gesture feel right are arithmetic, not React: "has the hand travelled far
+ * enough that this press is a drag and not a click?" and "how much value does
+ * a pixel buy?". They live here so a Node test can prove them without a DOM.
+ *
+ * Sensitivity is a RATE over a fixed travel, the same rule the timeline's
+ * curve editors follow (src/ardy/timeline.jsx DRAG_TRAVEL_PX): dragging the
+ * hand across `SCRUB_TRAVEL_PX` sweeps one meaningful span of the field. The
+ * old `pixels * step` mapping tied the feel to the field's precision, so a
+ * step 0.05 field needed 100 px to move 5 units while a step 1 field bolted.
+ */
+
+/**
+ * How far the hand travels to sweep a field's whole meaningful range, in
+ * pixels. Matches the timeline curve editors so the wrist learns one gesture.
+ */
+export const SCRUB_TRAVEL_PX = 220;
+
+/**
+ * How far the hand must travel before a press stops being a click. Blender and
+ * Unity both keep the number clickable for text entry, so the first few pixels
+ * belong to the click; only past this does the drag take the input away.
+ */
+export const SCRUB_THRESHOLD_PX = 4;
+
+/** Shift buys a quarter-speed pass for fine detail; Alt keeps its old 0.1x. */
+export const FINE_SCRUB_FACTOR = 0.25;
+export const EXTRA_FINE_SCRUB_FACTOR = 0.1;
+
+/**
+ * The meaningful span a full drag sweeps when the field does not name one.
+ * A step is "the smallest edit worth making", so a hundred of them is a
+ * sensible whole range: step 0.05 → 5 units, step 1 → 100 units.
+ */
+export const SCRUB_RANGE_STEPS = 100;
+
+/** The span one full `SCRUB_TRAVEL_PX` drag covers for a field. */
+export function scrubRangeFor({ scrubRange, step } = {}) {
+	if (typeof scrubRange === "number" && Number.isFinite(scrubRange) && scrubRange > 0) return scrubRange;
+	const size = typeof step === "number" && Number.isFinite(step) && step > 0 ? step : 1;
+	return size * SCRUB_RANGE_STEPS;
+}
+
+/**
+ * Does this much horizontal travel turn the press into a scrub? Vertical
+ * movement does not count: the gesture is explicitly left/right, and a hand
+ * sliding down a panel should not hijack the click.
+ */
+export function shouldStartScrub(dx) {
+	return Math.abs(dx) >= SCRUB_THRESHOLD_PX;
+}
+
+/**
+ * Value under the pointer for a rate-based horizontal drag.
+ *
+ * `dx` is measured from where the press landed, NOT from where the scrub
+ * armed: dropping the first threshold pixels would make the value jump
+ * backwards the moment the drag starts.
+ */
+export function scrubValue(base, dx, { step, scrubRange, shiftKey = false, altKey = false, precision = 2 } = {}) {
+	const range = scrubRangeFor({ scrubRange, step });
+	const gain = shiftKey ? FINE_SCRUB_FACTOR : altKey ? EXTRA_FINE_SCRUB_FACTOR : 1;
+	return snapScrubValue(base + (dx / SCRUB_TRAVEL_PX) * range * gain, { step, precision });
+}
+
+/**
+ * One press's worth of scrub state, shared by the field and its test.
+ *
+ * The gesture starts *disarmed*: a press on a number is a click until the hand
+ * proves otherwise, so `move` answers null while the travel is inside the
+ * threshold and the input keeps its focus. Once armed it stays armed — coming
+ * back near the press point is part of the drag, not a return to clicking —
+ * and every reported value is measured from the press point so arming does not
+ * teleport the value by the threshold's width.
+ */
+export function createScrubGesture({ x, value, step, precision, scrubRange }) {
+	const gesture = {
+		scrubbing: false,
+		move(clientX, { shiftKey = false, altKey = false } = {}) {
+			const dx = clientX - x;
+			if (!gesture.scrubbing && !shouldStartScrub(dx)) return null;
+			gesture.scrubbing = true;
+			return scrubValue(value, dx, { step, precision, scrubRange, shiftKey, altKey });
+		},
+	};
+	return gesture;
+}
+
+/**
+ * Land the dragged value on the field's own grid: `step` decides which values
+ * exist, `precision` kills the float dust that would otherwise print as
+ * 1.7000000000000002 in the input.
+ */
+export function snapScrubValue(value, { step, precision = 2 } = {}) {
+	const size = typeof step === "number" && Number.isFinite(step) && step > 0 ? step : 0;
+	const snapped = size > 0 ? Math.round(value / size) * size : value;
+	const digits = Number.isFinite(precision) ? Math.max(0, Math.min(15, Math.round(precision))) : 2;
+	return Number(snapped.toFixed(digits));
+}

--- a/src/ui.jsx
+++ b/src/ui.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { createScrubGesture } from "./ui-scrub.js";
 
 // Custom dropdown, structurally matched to the reference (`.dropdown`,
 // `dd-caret`, `dropdown-menu`, `dropdown-item`, `dd-check`) with the keyboard
@@ -278,7 +279,7 @@ export function Field({ label, children }) {
 		</div>
 	);
 }
-export function NumberField({ label, value, step, precision = 2, onChange, onScrubStart, onScrubEnd, title }) {
+export function NumberField({ label, value, step, precision = 2, scrubRange, onChange, onScrubStart, onScrubEnd, title }) {
 	const [focused, setFocused] = useState(false);
 	const [draft, setDraft] = useState(null);
 	// The draft must be readable synchronously: blur() fires the commit
@@ -293,9 +294,10 @@ export function NumberField({ label, value, step, precision = 2, onChange, onScr
 	// blur), so the freshest end callback is mirrored like `valueRef`.
 	const scrubEndRef = useRef(onScrubEnd);
 	scrubEndRef.current = onScrubEnd;
-	// `{ x, value, element, pointerId, token }` of the scrub start, null while
-	// not scrubbing. `element`/`pointerId` let the teardown release capture;
-	// `token` is the open store transaction, null when no scrub props exist.
+	// `{ gesture, scrubbing, token }` of the press, null while no button is
+	// down. `scrubbing` marks the press that has travelled far enough to be a
+	// drag; `token` is the open store transaction, null until then (a plain
+	// click must not open one) or when no scrub props exist.
 	const dragRef = useRef(null);
 
 	valueRef.current = value;
@@ -348,53 +350,74 @@ export function NumberField({ label, value, step, precision = 2, onChange, onScr
 		}
 	};
 
-	// Unity-style scrubbing: drag the axis label to change the value. Pointer
-	// capture keeps the drag alive when the cursor leaves the window; Shift
-	// moves 10x per pixel, Alt 0.1x.
-	const onAxisPointerDown = (e) => {
-		e.preventDefault();
-		const base = commitDraft();
-		const drag = {
-			x: e.clientX,
-			value: base ?? valueRef.current,
-			element: e.currentTarget,
-			pointerId: e.pointerId,
+	// Blender/Unity scrubbing: press anywhere on the field — badge OR number —
+	// and drag left/right to change the value. The press does not commit to
+	// anything yet: under the travel threshold it is still a click that focuses
+	// the input for typing (issue #87 — users aim at the number, and the badge
+	// alone was a 15 px hotspot nobody found). Sensitivity is a fixed-travel
+	// rate (src/ui-scrub.js), not pixels * step, so every field feels the same.
+	const onFieldPointerDown = (e) => {
+		if (e.button !== 0) return;
+		// A press inside an already-focused input is text editing (caret
+		// placement, drag-select), not a scrub — leave it alone.
+		if (focused && e.target === inputRef.current) return;
+		// A press on the badge while the number is being typed still commits what
+		// was typed, so the drag baselines from what the user just wrote.
+		const base = draftRef.current !== null ? commitDraft() : null;
+		dragRef.current = {
+			gesture: createScrubGesture({ x: e.clientX, value: base ?? valueRef.current, step, precision, scrubRange }),
+			scrubbing: false,
+			token: null,
 		};
-		// A scrub is one store transaction: begin before any apply so the
-		// whole drag lands as a single undo entry. The teardown is registered
-		// as the store's cancel so a settle leaves the scrub inert without
-		// this component closing the token itself.
-		dragRef.current = drag;
-		drag.token = onScrubStart?.({ owner: "field", cancel: () => teardownScrub(drag) });
-		e.currentTarget.setPointerCapture(e.pointerId);
 	};
 
-	const onAxisPointerMove = (e) => {
+	const onFieldPointerMove = (e) => {
 		const drag = dragRef.current;
 		if (!drag) return;
-		const multiplier = e.shiftKey ? 10 : e.altKey ? 0.1 : 1;
-		onChange(drag.value + (e.clientX - drag.x) * step * multiplier, drag.token);
+		const next = drag.gesture.move(e.clientX, { shiftKey: e.shiftKey, altKey: e.altKey });
+		if (next === null) return;
+		if (!drag.scrubbing) {
+			// First armed move: the press has become a drag. Take the focus back
+			// from the input (the press already focused it) so the drag is not
+			// typing into a selected number — with the draft dropped first, so the
+			// blur commits nothing outside the transaction.
+			e.preventDefault();
+			drag.scrubbing = true;
+			if (document.activeElement === inputRef.current) {
+				setDraftValue(null);
+				inputRef.current.blur();
+			}
+			// A scrub is one store transaction: begin before any apply so the whole
+			// drag lands as a single undo entry. The teardown is registered as the
+			// store's cancel so a settle leaves the scrub inert without this
+			// component closing the token itself.
+			drag.token = onScrubStart?.({ owner: "field", cancel: () => teardownScrub(drag) }) ?? null;
+		}
+		onChange(next, drag.token);
 	};
+	// The window listeners below are registered once, so they read the freshest
+	// move handler the same way `scrubEndRef` mirrors the end callback.
+	const scrubMoveRef = useRef(onFieldPointerMove);
+	scrubMoveRef.current = onFieldPointerMove;
 
-	// Drop the scrub ref and release the capture held on the axis label.
-	// Shared by every close path AND the store's cancel; never closes the
-	// transaction itself — the caller decides the commit value.
+	// Drop the scrub ref. Shared by every close path AND the store's cancel;
+	// never closes the transaction itself — the caller decides the commit value.
 	const teardownScrub = (drag) => {
 		if (!drag || dragRef.current !== drag) return;
 		dragRef.current = null;
-		if (drag.element.hasPointerCapture(drag.pointerId)) {
-			drag.element.releasePointerCapture(drag.pointerId);
-		}
 	};
 
+	// A press that never armed is a plain click: drop it without touching the
+	// store, so no empty transaction and no history entry for a focus.
 	const closeScrub = (commit) => {
 		const drag = dragRef.current;
 		if (!drag) return;
 		teardownScrub(drag);
+		if (!drag.scrubbing) return;
 		scrubEndRef.current?.(drag.token, { commit });
 	};
 
-	const endAxisDrag = () => closeScrub(true);
+	const endFieldDrag = () => closeScrub(true);
 
 	useEffect(() => {
 		// While a scrub is live, Escape cancels the whole drag. It must run in
@@ -404,16 +427,31 @@ export function NumberField({ label, value, step, precision = 2, onChange, onScr
 		// work, not intent to discard (plan §6.3).
 		const onEscape = (event) => {
 			if (event.key !== "Escape") return;
-			if (!dragRef.current) return;
+			if (!dragRef.current?.scrubbing) return;
 			event.stopPropagation();
 			closeScrub(false);
 		};
 		const onBlur = () => closeScrub(true);
+		// The drag lives on the window, not on the field: a 40 px wide number is
+		// left behind within a few pixels of travel, and pointer capture cannot
+		// be claimed mid-gesture reliably — the same window-listener shape the
+		// timeline's curve drags use.
+		const onMove = (event) => {
+			if (!dragRef.current) return;
+			scrubMoveRef.current(event);
+		};
+		const onUp = () => closeScrub(true);
 		window.addEventListener("keydown", onEscape, true);
 		window.addEventListener("blur", onBlur);
+		window.addEventListener("pointermove", onMove, true);
+		window.addEventListener("pointerup", onUp, true);
+		window.addEventListener("pointercancel", onUp, true);
 		return () => {
 			window.removeEventListener("keydown", onEscape, true);
 			window.removeEventListener("blur", onBlur);
+			window.removeEventListener("pointermove", onMove, true);
+			window.removeEventListener("pointerup", onUp, true);
+			window.removeEventListener("pointercancel", onUp, true);
 			closeScrub(true);
 		};
 	}, []);
@@ -421,16 +459,14 @@ export function NumberField({ label, value, step, precision = 2, onChange, onScr
 	const display = focused && draft !== null ? draft : formatValue(value);
 
 	return (
-		<span className="number-field" title={title}>
-			<span
-				className="axis"
-				onPointerDown={onAxisPointerDown}
-				onPointerMove={onAxisPointerMove}
-				onPointerUp={endAxisDrag}
-				onPointerCancel={endAxisDrag}
-			>
-				{label}
-			</span>
+		<span
+			className={`number-field${focused ? " editing" : ""}`}
+			title={title}
+			onPointerDown={onFieldPointerDown}
+			onPointerUp={endFieldDrag}
+			onPointerCancel={endFieldDrag}
+		>
+			<span className="axis">{label}</span>
 			<input
 				ref={inputRef}
 				type="text"
@@ -458,6 +494,7 @@ export function Vector3Row({ label, fields }) {
 					value={field.value}
 					step={field.step}
 					precision={field.precision}
+					scrubRange={field.scrubRange}
 					onChange={field.onChange}
 					onScrubStart={field.onScrubStart}
 					onScrubEnd={field.onScrubEnd}

--- a/test/verify-number-field-scrub-browser.mjs
+++ b/test/verify-number-field-scrub-browser.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Inspector number fields, scrubbed with a real mouse (issue #87).
+ *
+ * The maths and the click/drag threshold are unit-tested
+ * (test/verify-number-field-scrub.mjs); what only a browser can answer is
+ * whether a press on the NUMBER — where users actually aim — becomes a drag
+ * at all. That depends on pointer capture, the input's own focus-on-mousedown
+ * and React's synthetic pointer events, none of which exist under Node.
+ *
+ * Run: `npm run dev:ui` in one shell, then
+ * `QA_URL=http://127.0.0.1:5180/app/ node tools/qa-browser.mjs -- node test/verify-number-field-scrub-browser.mjs`.
+ */
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+	ws.onopen = resolve;
+	ws.onerror = reject;
+});
+
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	// Uncaught script errors only; network noise is environmental here (no
+	// ARDY bridge runs during this suite).
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params.exceptionDetails.exception?.description ?? message.params.exceptionDetails.text);
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) =>
+	new Promise((resolve, reject) => {
+		const id = nextId++;
+		pending.set(id, { resolve, reject });
+		ws.send(JSON.stringify({ id, method, params }));
+	});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+const evaluateSafely = async (expression) => {
+	try {
+		return await evaluate(expression);
+	} catch {
+		return undefined;
+	}
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (expression, { timeoutMs = 8000, intervalMs = 100 } = {}) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluateSafely(expression)) return true;
+		await sleep(intervalMs);
+	}
+	return false;
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+const mouse = (type, x, y, { modifiers = 0 } = {}) =>
+	send("Input.dispatchMouseEvent", {
+		type,
+		x: Math.round(x),
+		y: Math.round(y),
+		button: "left",
+		clickCount: 1,
+		buttons: type === "mouseReleased" ? 0 : 1,
+		modifiers,
+	});
+
+await send("Runtime.enable");
+
+// Scene persistence would boot a previous run's objects; start from empty
+// storage and pin the locale (the QA browser inherits the host's).
+for (let i = 0; i < 100 && !(await evaluateSafely("location.href.startsWith('http')")); i++) await sleep(200);
+await evaluate("localStorage.removeItem('cozyclay.scene.v1'); localStorage.removeItem('cozyclay.scene.v1.quarantine')");
+await evaluate("localStorage.setItem('cozyclay.locale', 'en')");
+await send("Page.reload");
+for (let i = 0; i < 100 && !(await evaluateSafely("!!document.querySelector('canvas')")); i++) await sleep(200);
+for (let i = 0; i < 50 && !(await evaluateSafely("!!window.__sceneHistory && document.querySelectorAll('.hierarchy-row').length > 0")); i++) await sleep(200);
+await sleep(1200);
+
+/* ------------------------------------------------------ a cube to scrub ---- */
+
+await evaluate("document.querySelector('.add-object-trigger').click()");
+await waitFor("document.querySelectorAll('.add-object-item').length > 0");
+await evaluate("[...document.querySelectorAll('.add-object-item')].find(b => b.textContent.startsWith('Cube')).click()");
+await waitFor("[...document.querySelectorAll('.inspector-pane .vec3-row')].some(r => r.querySelector('.vec3-label').textContent === 'Scale')");
+await sleep(400);
+
+/** The Inspector's Scale X field: its input rect, value and history depth. */
+const scaleField = () =>
+	evaluate(`(() => {
+		const row = [...document.querySelectorAll('.inspector-pane .vec3-row')].filter(r => !r.closest('.subject-box'))
+			.find(r => r.querySelector('.vec3-label').textContent === 'Scale');
+		if (!row) return null;
+		const field = row.querySelector('.number-field');
+		const input = field.querySelector('input');
+		const box = input.getBoundingClientRect();
+		return {
+			value: parseFloat(input.value),
+			x: box.left + box.width / 2,
+			y: box.top + box.height / 2,
+			cursor: getComputedStyle(input).cursor,
+			focused: document.activeElement === input,
+			past: window.__sceneHistory().past,
+		};
+	})()`);
+
+const start = await scaleField();
+expect("the Inspector shows a Scale row with a number field", start !== null, JSON.stringify(start));
+expect("the number itself advertises the scrub cursor", start.cursor === "ew-resize", JSON.stringify(start));
+
+/* ------------------------------------------------- dragging the NUMBER ----- */
+
+const DRAG_PX = 110;
+await mouse("mousePressed", start.x, start.y);
+for (let i = 1; i <= 12; i++) {
+	await mouse("mouseMoved", start.x + (DRAG_PX * i) / 12, start.y);
+	await sleep(16);
+}
+await mouse("mouseReleased", start.x + DRAG_PX, start.y);
+await sleep(300);
+
+const dragged = await scaleField();
+expect("dragging the number changes the value", Math.abs(dragged.value - start.value) > 0.2, JSON.stringify({ start: start.value, dragged: dragged.value }));
+expect("dragging right raises it", dragged.value > start.value, JSON.stringify(dragged));
+// Half of the 220 px sweep over Scale's 4-unit span: +2 from 1.
+expect("the rate is fixed-travel, not pixels * step", Math.abs(dragged.value - (start.value + (DRAG_PX / 220) * 4)) < 0.1, JSON.stringify(dragged));
+expect("the whole drag is exactly one undo entry", dragged.past === start.past + 1, JSON.stringify({ before: start.past, after: dragged.past }));
+expect("a drag does not leave the field in text-editing mode", dragged.focused === false, JSON.stringify(dragged));
+
+const undoable = await evaluate("window.__sceneHistory().past");
+await send("Input.dispatchKeyEvent", { type: "keyDown", key: "z", code: "KeyZ", windowsVirtualKeyCode: 90, modifiers: process.platform === "darwin" ? 4 : 2 });
+await send("Input.dispatchKeyEvent", { type: "keyUp", key: "z", code: "KeyZ", windowsVirtualKeyCode: 90, modifiers: process.platform === "darwin" ? 4 : 2 });
+await sleep(300);
+const undone = await scaleField();
+expect("one undo restores the pre-drag value", Math.abs(undone.value - start.value) < 1e-6, JSON.stringify({ start: start.value, undone: undone.value, past: undoable }));
+
+/* ------------------------------------------------- a click is still a click - */
+
+const beforeClick = await scaleField();
+await mouse("mousePressed", beforeClick.x, beforeClick.y);
+await mouse("mouseReleased", beforeClick.x, beforeClick.y);
+await sleep(250);
+const clicked = await scaleField();
+expect("a plain click focuses the number for typing", clicked.focused === true, JSON.stringify(clicked));
+expect("a plain click leaves the value alone", clicked.value === beforeClick.value, JSON.stringify({ before: beforeClick.value, after: clicked.value }));
+expect("a plain click writes no history entry", clicked.past === beforeClick.past, JSON.stringify({ before: beforeClick.past, after: clicked.past }));
+expect("a focused field shows a text caret", clicked.cursor === "text", JSON.stringify(clicked));
+
+/* --------------------------------------------------------------- artifacts - */
+
+const artifact = {
+	suite: "number-field-scrub",
+	issue: 87,
+	start: { value: start.value, cursor: start.cursor, past: start.past },
+	drag: { dx: DRAG_PX, value: dragged.value, past: dragged.past, focused: dragged.focused },
+	undo: { value: undone.value },
+	click: { value: clicked.value, focused: clicked.focused, cursor: clicked.cursor, past: clicked.past },
+	pageErrors,
+	failures,
+};
+if (process.env.QA_ARTIFACT) {
+	const { writeFileSync } = await import("node:fs");
+	writeFileSync(process.env.QA_ARTIFACT, `${JSON.stringify(artifact, null, "\t")}\n`);
+}
+if (process.env.QA_SCREENSHOT) {
+	const { writeFileSync } = await import("node:fs");
+	const shot = await send("Page.captureScreenshot", { format: "png" });
+	writeFileSync(process.env.QA_SCREENSHOT, Buffer.from(shot.data, "base64"));
+}
+
+expect("the page threw no uncaught errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILURE(S)`);
+ws.close();
+process.exit(failures === 0 ? 0 : 1);

--- a/test/verify-number-field-scrub.mjs
+++ b/test/verify-number-field-scrub.mjs
@@ -1,0 +1,169 @@
+// Inspector number fields: dragging the NUMBER scrubs it (issue #87).
+//
+// Two things are proved here. The arithmetic — a fixed-travel rate instead of
+// the old `pixels * step` mapping, plus the click/drag threshold — is pure, so
+// it is exercised directly. The wiring that makes the whole field the hotspot
+// (pointer handlers on the field, not just the axis badge) is asserted against
+// ui.jsx's source: the browser suite drives the real gesture, but this keeps a
+// regression that silently moves the handlers back onto the badge visible in
+// the Node tier.
+import { readFileSync } from "node:fs";
+import {
+	SCRUB_TRAVEL_PX,
+	SCRUB_THRESHOLD_PX,
+	FINE_SCRUB_FACTOR,
+	createScrubGesture,
+	scrubRangeFor,
+	scrubValue,
+	snapScrubValue,
+	shouldStartScrub,
+} from "../src/ui-scrub.js";
+
+let failures = 0;
+const ok = (name, pass, detail = "") => {
+	console.log(`${pass ? "PASS" : "FAIL"} ${name}${pass ? "" : ` — ${detail}`}`);
+	if (!pass) failures += 1;
+};
+const near = (a, b, tol = 1e-9) => Math.abs(a - b) <= tol;
+
+/* --- the click/drag threshold ---------------------------------------------- */
+
+ok("a press that never travels is a click", !shouldStartScrub(0) && !shouldStartScrub(3) && !shouldStartScrub(-3));
+ok("travel past the threshold is a scrub", shouldStartScrub(SCRUB_THRESHOLD_PX) && shouldStartScrub(-SCRUB_THRESHOLD_PX) && shouldStartScrub(40));
+
+/* --- the meaningful span --------------------------------------------------- */
+
+ok("a step-0.05 field sweeps 5 units per full travel", scrubRangeFor({ step: 0.05 }) === 5);
+ok("a step-1 field sweeps 100 units per full travel", scrubRangeFor({ step: 1 }) === 100);
+ok("an explicit scrubRange wins over the step default", scrubRangeFor({ step: 1, scrubRange: 180 }) === 180);
+ok("a nonsense range falls back to the step default", scrubRangeFor({ step: 0.05, scrubRange: 0 }) === 5 && scrubRangeFor({ step: 0.05, scrubRange: NaN }) === 5);
+ok("a missing step still has a span", scrubRangeFor({}) === 100);
+
+/* --- the rate: fixed travel, not pixels * step ----------------------------- */
+
+ok("a full travel moves one whole range", near(scrubValue(1, SCRUB_TRAVEL_PX, { step: 0.05, precision: 2 }), 6));
+ok("dragging left subtracts symmetrically", near(scrubValue(1, -SCRUB_TRAVEL_PX, { step: 0.05, precision: 2 }), -4));
+ok("the old pixels*step feel is gone", (() => {
+	// 60 px on a step-0.05 field used to buy 3.0 units of travel… no: 60*0.05 = 3
+	// only for step 1. The point is the rate no longer depends on step alone:
+	// 60 px is 60/220 of the span whatever the step is.
+	const small = scrubValue(0, 60, { step: 0.05, precision: 2 });
+	const big = scrubValue(0, 60, { step: 1, precision: 1 });
+	return near(small, snapScrubValue((60 / 220) * 5, { step: 0.05, precision: 2 })) &&
+		near(big, snapScrubValue((60 / 220) * 100, { step: 1, precision: 1 })) &&
+		Math.abs(small) > 1e-9;
+})());
+ok("60 px on Scale X is a felt change, not a twitch", (() => {
+	const moved = scrubValue(1, 60, { step: 0.05, precision: 2 });
+	return moved > 1.3 && moved < 2.5;
+})());
+ok("an explicit range drives the rate", near(scrubValue(0, SCRUB_TRAVEL_PX / 2, { step: 1, precision: 1, scrubRange: 180 }), 90));
+// Ratios are checked on an unsnapped field (step 0) so the step grid does not
+// round the quarter away; the snapping itself has its own checks below.
+ok("Shift is a quarter-speed pass", (() => {
+	const coarse = scrubValue(0, 110, { step: 0, precision: 6, scrubRange: 5 });
+	const fine = scrubValue(0, 110, { step: 0, precision: 6, scrubRange: 5, shiftKey: true });
+	return near(fine, coarse * FINE_SCRUB_FACTOR, 1e-6) && fine > 0;
+})());
+ok("Alt stays the finest pass", (() => {
+	const coarse = scrubValue(0, 110, { step: 0, precision: 6, scrubRange: 5 });
+	const fine = scrubValue(0, 110, { step: 0, precision: 6, scrubRange: 5, altKey: true });
+	return near(fine, coarse * 0.1, 1e-6);
+})());
+
+/* --- snapping: the field's own grid ---------------------------------------- */
+
+ok("values land on the step grid", snapScrubValue(1.7321, { step: 0.05, precision: 2 }) === 1.75);
+ok("precision kills float dust", snapScrubValue(0.1 + 0.2, { step: 0, precision: 2 }) === 0.3);
+ok("a degree field rounds to whole degrees", snapScrubValue(43.4, { step: 1, precision: 1 }) === 43);
+ok("scrubValue snaps its own result", scrubValue(1, 13, { step: 0.05, precision: 2 }) === snapScrubValue(1 + (13 / 220) * 5, { step: 0.05, precision: 2 }));
+
+/* --- the gesture state machine: click vs scrub ------------------------------ */
+
+const field = { step: 0.05, precision: 2 };
+
+ok("a press alone changes nothing", (() => {
+	const gesture = createScrubGesture({ x: 100, value: 1, ...field });
+	return gesture.scrubbing === false && gesture.move(102) === null && gesture.scrubbing === false;
+})());
+ok("travel arms the scrub and reports a value from the press point", (() => {
+	const gesture = createScrubGesture({ x: 100, value: 1, ...field });
+	gesture.move(102);
+	const armed = gesture.move(160);
+	return gesture.scrubbing === true && armed !== null && near(armed, scrubValue(1, 60, field));
+})());
+ok("an armed scrub keeps reporting, including back inside the threshold", (() => {
+	const gesture = createScrubGesture({ x: 100, value: 1, ...field });
+	gesture.move(160);
+	const back = gesture.move(101);
+	return back !== null && near(back, scrubValue(1, 1, field));
+})());
+ok("the value does not jump by the threshold when the scrub arms", (() => {
+	const gesture = createScrubGesture({ x: 100, value: 1, ...field });
+	const armed = gesture.move(100 + SCRUB_THRESHOLD_PX);
+	// Measuring from the press point (not from where it armed) means the first
+	// reported value is only the threshold's worth of travel away from base.
+	return near(armed, scrubValue(1, SCRUB_THRESHOLD_PX, field)) && Math.abs(armed - 1) < 0.2;
+})());
+ok("modifiers ride along per move", (() => {
+	const gesture = createScrubGesture({ x: 100, value: 1, step: 0, precision: 6, scrubRange: 5 });
+	const coarse = gesture.move(200);
+	const fine = gesture.move(200, { shiftKey: true });
+	return near(fine - 1, (coarse - 1) * FINE_SCRUB_FACTOR, 1e-6);
+})());
+ok("an explicit scrubRange reaches the gesture", (() => {
+	const gesture = createScrubGesture({ x: 0, value: 0, step: 1, precision: 1, scrubRange: 180 });
+	return near(gesture.move(SCRUB_TRAVEL_PX), 180);
+})());
+
+/* --- the wiring: the whole field is the hotspot ----------------------------- */
+
+const ui = readFileSync(new URL("../src/ui.jsx", import.meta.url), "utf8");
+const numberField = ui.slice(ui.indexOf("export function NumberField"), ui.indexOf("export function Vector3Row"));
+ok("NumberField exists to inspect", numberField.length > 0);
+ok("the field element owns the pointer gesture", (() => {
+	// Everything between the opening <span className="number-field"> tag and the
+	// first child: the press handler must live on the field wrapper itself, so
+	// badge and number are one hotspot.
+	const openTag = numberField.slice(numberField.search(/className=[{"]`?number-field/), numberField.indexOf('className="axis"'));
+	return /onPointerDown=/.test(openTag) && /onPointerUp=/.test(openTag);
+})());
+ok("the drag itself is tracked on the window", /window\.addEventListener\("pointermove"/.test(numberField) && /window\.addEventListener\("pointerup"/.test(numberField));
+ok("the pointer handlers no longer live only on the axis badge", (() => {
+	const axis = numberField.slice(numberField.indexOf('className="axis"'), numberField.indexOf("<input"));
+	return !/onPointerDown=/.test(axis);
+})());
+ok("the scrub still opens one store transaction", /onScrubStart\?\.\(/.test(numberField) && /scrubEndRef\.current\?\.\(/.test(numberField));
+ok("Escape still cancels a live scrub", /event\.key !== "Escape"/.test(numberField) && /closeScrub\(false\)/.test(numberField));
+ok("the rate math comes from the shared module", /from "\.\/ui-scrub\.js"/.test(ui) && !/e\.clientX - drag\.x\) \* step/.test(numberField));
+ok("Vector3Row passes a per-field scrub range", (() => {
+	const row = ui.slice(ui.indexOf("export function Vector3Row"));
+	return /scrubRange=\{field\.scrubRange\}/.test(row);
+})());
+
+/* --- the Inspector rows hand the transaction token back --------------------- */
+
+// A field callback that drops NumberField's second argument turns every move
+// of a scrub into an atomic edit, and the store settles the open transaction
+// on the first one — which is why the old drag froze after a single pixel's
+// worth of travel and left one stray undo entry behind.
+const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+const transformRows = app.slice(app.indexOf("selectedSceneObject.scaleX") - 4000, app.indexOf("selectedSceneObject.scaleZ") + 400);
+for (const axis of ["x", "y", "z", "rotX", "rot", "rotZ", "scaleX", "scaleY", "scaleZ"]) {
+	const pattern = new RegExp(`onChange: \\(${axis}, token\\) => changeSceneObject\\(selectedSceneObject\\.id, \\{ ${axis} \\}, token\\)`);
+	ok(`the ${axis} field applies inside the scrub's transaction`, pattern.test(transformRows));
+}
+ok("the transform rows name their own scrub spans", (() => {
+	const spans = [...transformRows.matchAll(/scrubRange: (\d+)/g)].map((match) => match[1]);
+	return spans.length === 9 && spans.slice(0, 3).every((span) => span === "5") &&
+		spans.slice(3, 6).every((span) => span === "180") && spans.slice(6).every((span) => span === "4");
+})());
+
+/* --- the affordance: the number reads as draggable -------------------------- */
+
+const css = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
+ok("the number itself shows the scrub cursor", /\.number-field input\s*\{[^}]*cursor:\s*ew-resize/.test(css));
+ok("a focused field goes back to a text caret", /\.number-field input:focus\s*\{[^}]*cursor:\s*text/.test(css));
+
+console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -124,6 +124,7 @@ const NODE_FILES = [
 	"mcp/verify-protocol-version.mjs",
 	"mcp/verify-tool-annotations.mjs",
 	"test/verify-object-path.mjs",
+	"test/verify-number-field-scrub.mjs",
 	"test/verify-speed-envelope.mjs",
 ];
 
@@ -132,6 +133,7 @@ const BROWSER_FILES = [
 	"test/verify-cutout-browser.mjs",
 	"test/verify-ik-browser.mjs",
 	"test/verify-motion-edit-browser.mjs",
+	"test/verify-number-field-scrub-browser.mjs",
 	"test/verify-object-colour-browser.mjs",
 	"test/verify-object-gizmo.mjs",
 	"test/verify-offscreen-export-browser.mjs",


### PR DESCRIPTION
Closes #87.

## Root cause (two defects)
1. `NumberField` only attached the scrub handlers to the axis badge; the number had none and showed a text caret.
2. Even the badge drag barely worked: the Inspector field callbacks dropped `NumberField`'s transaction token, so the first applied move went through `store.applyAtomic`, which settles the open transaction and cancels the drag after one pixel, leaving one stray undo entry.

## Fix
- The whole field is the hotspot. A press arms nothing; >= 4 px horizontal travel becomes a scrub (input blurred, transaction opened, `ew-resize` advertised), under the threshold it stays a plain click that focuses the number for typing.
- Sensitivity is a fixed-travel rate (`SCRUB_TRAVEL_PX = 220`, same rule as the timeline curve editors): Position 5 m, Rotation 180 deg, Scale 4, otherwise `step * 100`. Shift = 0.25x, Alt = 0.1x.
- Pure maths and the click-vs-drag state machine live in `src/ui-scrub.js`; Position/Rotation/Scale rows forward the token so a whole drag is exactly one undo entry.

## Tests
- New node suite `test/verify-number-field-scrub.mjs` (RED 6 failures on main, GREEN after).
- New real-browser suite `test/verify-number-field-scrub-browser.mjs` (CDP): press on the Scale X number, +110 px -> 1 -> 3, exactly one history entry, plain click focuses with no entry. 13/13 PASS locally; 6 FAIL on main.
- `test/verify-object-gizmo.mjs` identical before/after.
