### PR TITLE
fix(ik): cache camera exposure decisions and reject hidden picks (#68)

### DIFF
--- a/.omo/qa/68-perf-baseline-1.json
+++ b/.omo/qa/68-perf-baseline-1.json
@@ -1,0 +1,89 @@
+{
+  "capturedAt": "2026-09-03T12:20:19.612Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "devicePixelRatio": 1,
+    "canvasWidth": 907,
+    "canvasHeight": 569,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 7.899999976158142
+  },
+  "run": {
+    "frameCount": 121,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.700000000000273,
+    "fps": 57.16796515116439,
+    "minFrameMs": 16.56999999999971,
+    "maxFrameMs": 66.69999999999982
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2953562
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 226829
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 65819
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 56356
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2522
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2516
+    },
+    {
+      "function": "(anonymous)",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+      "microseconds": 2513
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2512
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2512
+    },
+    {
+      "function": "batchedUpdates$1",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+      "microseconds": 2507
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2505
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 1282
+    }
+  ]
+}

--- a/.omo/qa/68-perf-baseline-2.json
+++ b/.omo/qa/68-perf-baseline-2.json
@@ -1,0 +1,89 @@
+{
+  "capturedAt": "2026-09-03T12:20:27.178Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "devicePixelRatio": 1,
+    "canvasWidth": 907,
+    "canvasHeight": 569,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 8.199999928474426
+  },
+  "run": {
+    "frameCount": 122,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 57.640427673074825,
+    "minFrameMs": 16.5,
+    "maxFrameMs": 66.69999999999982
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2989793
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 246531
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 57145
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 55288
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 4635
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2510
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2400
+    },
+    {
+      "function": "intersect",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+      "microseconds": 1484
+    },
+    {
+      "function": "exports.useState",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react.js?v=0569d781",
+      "microseconds": 1260
+    },
+    {
+      "function": "prepareFreshStack",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+      "microseconds": 1258
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 1258
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 1258
+    }
+  ]
+}

--- a/.omo/qa/68-perf-baseline-3.json
+++ b/.omo/qa/68-perf-baseline-3.json
@@ -1,0 +1,89 @@
+{
+  "capturedAt": "2026-09-03T12:20:34.762Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "devicePixelRatio": 1,
+    "canvasWidth": 907,
+    "canvasHeight": 569,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 7.799999952316284
+  },
+  "run": {
+    "frameCount": 119,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.799999999999727,
+    "fps": 56.669257261284315,
+    "minFrameMs": 0,
+    "maxFrameMs": 83.30000000000018
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 3059306
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 259782
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 83204
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 62195
+    },
+    {
+      "function": "(anonymous)",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+      "microseconds": 5125
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 3761
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2569
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2540
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2514
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2512
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2512
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2508
+    }
+  ]
+}

--- a/.omo/qa/68-perf-baseline.json
+++ b/.omo/qa/68-perf-baseline.json
@@ -1,0 +1,290 @@
+{
+  "phase": "baseline",
+  "runs": [
+    {
+      "capturedAt": "2026-09-03T12:20:19.612Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "devicePixelRatio": 1,
+        "canvasWidth": 907,
+        "canvasHeight": 569,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 7.899999976158142
+      },
+      "run": {
+        "frameCount": 121,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.700000000000273,
+        "fps": 57.16796515116439,
+        "minFrameMs": 16.56999999999971,
+        "maxFrameMs": 66.69999999999982
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2953562
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 226829
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 65819
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 56356
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2522
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2516
+        },
+        {
+          "function": "(anonymous)",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+          "microseconds": 2513
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2512
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2512
+        },
+        {
+          "function": "batchedUpdates$1",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+          "microseconds": 2507
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2505
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 1282
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:20:27.178Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "devicePixelRatio": 1,
+        "canvasWidth": 907,
+        "canvasHeight": 569,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.199999928474426
+      },
+      "run": {
+        "frameCount": 122,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 57.640427673074825,
+        "minFrameMs": 16.5,
+        "maxFrameMs": 66.69999999999982
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2989793
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 246531
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 57145
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 55288
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 4635
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2510
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2400
+        },
+        {
+          "function": "intersect",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+          "microseconds": 1484
+        },
+        {
+          "function": "exports.useState",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react.js?v=0569d781",
+          "microseconds": 1260
+        },
+        {
+          "function": "prepareFreshStack",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+          "microseconds": 1258
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 1258
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 1258
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:20:34.762Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "devicePixelRatio": 1,
+        "canvasWidth": 907,
+        "canvasHeight": 569,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 7.799999952316284
+      },
+      "run": {
+        "frameCount": 119,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.799999999999727,
+        "fps": 56.669257261284315,
+        "minFrameMs": 0,
+        "maxFrameMs": 83.30000000000018
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 3059306
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 259782
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 83204
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 62195
+        },
+        {
+          "function": "(anonymous)",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+          "microseconds": 5125
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 3761
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2569
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2540
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2514
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2512
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2512
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2508
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "medianFrameMs": [
+      16.699999999999818,
+      16.699999999999818,
+      16.699999999999818
+    ],
+    "p95FrameMs": [
+      16.700000000000273,
+      16.800000000000182,
+      16.799999999999727
+    ],
+    "fps": [
+      57.16796515116439,
+      57.640427673074825,
+      56.669257261284315
+    ],
+    "medianOfMedians": 16.699999999999818
+  }
+}

--- a/.omo/qa/68-perf-dpr2-baseline-1.json
+++ b/.omo/qa/68-perf-dpr2-baseline-1.json
@@ -1,0 +1,92 @@
+{
+  "capturedAt": "2026-09-03T12:44:19.549Z",
+  "baseUrl": "http://127.0.0.1:5384/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "requestedDevicePixelRatio": 2,
+    "effectiveDevicePixelRatio": 2,
+    "viewportWidth": 1920,
+    "viewportHeight": 1200,
+    "canvasWidth": 1223,
+    "canvasHeight": 853,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 7.799999952316284
+  },
+  "run": {
+    "frameCount": 120,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 56.69469904563925,
+    "minFrameMs": 16.599999999999454,
+    "maxFrameMs": 83.29999999999973
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2985199
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 225959
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 56090
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 54645
+    },
+    {
+      "function": "WebGLRenderer.setSize",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=17547878",
+      "microseconds": 4993
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 3766
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 3765
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2519
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2518
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2517
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2513
+    },
+    {
+      "function": "ReactElement",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2506
+    }
+  ]
+}

--- a/.omo/qa/68-perf-dpr2-baseline-2.json
+++ b/.omo/qa/68-perf-dpr2-baseline-2.json
@@ -1,0 +1,92 @@
+{
+  "capturedAt": "2026-09-03T12:44:27.082Z",
+  "baseUrl": "http://127.0.0.1:5384/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "requestedDevicePixelRatio": 2,
+    "effectiveDevicePixelRatio": 2,
+    "viewportWidth": 1920,
+    "viewportHeight": 1200,
+    "canvasWidth": 1223,
+    "canvasHeight": 853,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 8.5
+  },
+  "run": {
+    "frameCount": 121,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.700000000000273,
+    "fps": 57.17055820199067,
+    "minFrameMs": 16.57400000000007,
+    "maxFrameMs": 66.70000000000027
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2964496
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 242200
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 57757
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 56627
+    },
+    {
+      "function": "WebGLRenderer.setSize",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=17547878",
+      "microseconds": 5032
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2520
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2520
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2516
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2510
+    },
+    {
+      "function": "WebSocket",
+      "url": "",
+      "microseconds": 1387
+    },
+    {
+      "function": "requestAnimationFrame",
+      "url": "",
+      "microseconds": 1298
+    },
+    {
+      "function": "(garbage collector)",
+      "url": "",
+      "microseconds": 1269
+    }
+  ]
+}

--- a/.omo/qa/68-perf-dpr2-baseline-3.json
+++ b/.omo/qa/68-perf-dpr2-baseline-3.json
@@ -1,0 +1,92 @@
+{
+  "capturedAt": "2026-09-03T12:44:34.644Z",
+  "baseUrl": "http://127.0.0.1:5384/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "requestedDevicePixelRatio": 2,
+    "effectiveDevicePixelRatio": 2,
+    "viewportWidth": 1920,
+    "viewportHeight": 1200,
+    "canvasWidth": 1225,
+    "canvasHeight": 854,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 8.100000023841858
+  },
+  "run": {
+    "frameCount": 119,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 56.6710384324886,
+    "minFrameMs": 16.5,
+    "maxFrameMs": 83.39999999999964
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2951139
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 214627
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 61184
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 52732
+    },
+    {
+      "function": "WebGLRenderer.setSize",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=17547878",
+      "microseconds": 4815
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 3766
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2515
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2513
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2511
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2511
+    },
+    {
+      "function": "(anonymous)",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react-dom_client.js?v=6d65e396",
+      "microseconds": 2509
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+      "microseconds": 2509
+    }
+  ]
+}

--- a/.omo/qa/68-perf-dpr2-baseline.json
+++ b/.omo/qa/68-perf-dpr2-baseline.json
@@ -1,0 +1,321 @@
+{
+  "phase": "baseline",
+  "requestedDpr": 2,
+  "window": "1920,1200",
+  "runs": [
+    {
+      "capturedAt": "2026-09-03T12:44:19.549Z",
+      "baseUrl": "http://127.0.0.1:5384/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "requestedDevicePixelRatio": 2,
+        "effectiveDevicePixelRatio": 2,
+        "viewportWidth": 1920,
+        "viewportHeight": 1200,
+        "canvasWidth": 1223,
+        "canvasHeight": 853,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 7.799999952316284
+      },
+      "run": {
+        "frameCount": 120,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 56.69469904563925,
+        "minFrameMs": 16.599999999999454,
+        "maxFrameMs": 83.29999999999973
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2985199
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 225959
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 56090
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 54645
+        },
+        {
+          "function": "WebGLRenderer.setSize",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=17547878",
+          "microseconds": 4993
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 3766
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 3765
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2519
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2518
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2517
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2513
+        },
+        {
+          "function": "ReactElement",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2506
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:44:27.082Z",
+      "baseUrl": "http://127.0.0.1:5384/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "requestedDevicePixelRatio": 2,
+        "effectiveDevicePixelRatio": 2,
+        "viewportWidth": 1920,
+        "viewportHeight": 1200,
+        "canvasWidth": 1223,
+        "canvasHeight": 853,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.5
+      },
+      "run": {
+        "frameCount": 121,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.700000000000273,
+        "fps": 57.17055820199067,
+        "minFrameMs": 16.57400000000007,
+        "maxFrameMs": 66.70000000000027
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2964496
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 242200
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 57757
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 56627
+        },
+        {
+          "function": "WebGLRenderer.setSize",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=17547878",
+          "microseconds": 5032
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2520
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2520
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2516
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2510
+        },
+        {
+          "function": "WebSocket",
+          "url": "",
+          "microseconds": 1387
+        },
+        {
+          "function": "requestAnimationFrame",
+          "url": "",
+          "microseconds": 1298
+        },
+        {
+          "function": "(garbage collector)",
+          "url": "",
+          "microseconds": 1269
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:44:34.644Z",
+      "baseUrl": "http://127.0.0.1:5384/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "requestedDevicePixelRatio": 2,
+        "effectiveDevicePixelRatio": 2,
+        "viewportWidth": 1920,
+        "viewportHeight": 1200,
+        "canvasWidth": 1225,
+        "canvasHeight": 854,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.100000023841858
+      },
+      "run": {
+        "frameCount": 119,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 56.6710384324886,
+        "minFrameMs": 16.5,
+        "maxFrameMs": 83.39999999999964
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2951139
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 214627
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 61184
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 52732
+        },
+        {
+          "function": "WebGLRenderer.setSize",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=17547878",
+          "microseconds": 4815
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 3766
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2515
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2513
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2511
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2511
+        },
+        {
+          "function": "(anonymous)",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react-dom_client.js?v=6d65e396",
+          "microseconds": 2509
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5384/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=d2a17755",
+          "microseconds": 2509
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "medianFrameMs": [
+      16.699999999999818,
+      16.699999999999818,
+      16.699999999999818
+    ],
+    "p95FrameMs": [
+      16.800000000000182,
+      16.700000000000273,
+      16.800000000000182
+    ],
+    "fps": [
+      56.69469904563925,
+      57.17055820199067,
+      56.6710384324886
+    ],
+    "medianOfMedians": 16.699999999999818,
+    "ikVisibility": [
+      {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 7.799999952316284
+      },
+      {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.5
+      },
+      {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.100000023841858
+      }
+    ]
+  }
+}

--- a/.omo/qa/68-perf-dpr2-fixed-1.json
+++ b/.omo/qa/68-perf-dpr2-fixed-1.json
@@ -1,0 +1,92 @@
+{
+  "capturedAt": "2026-09-03T12:44:55.050Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "requestedDevicePixelRatio": 2,
+    "effectiveDevicePixelRatio": 2,
+    "viewportWidth": 1920,
+    "viewportHeight": 1200,
+    "canvasWidth": 1223,
+    "canvasHeight": 853,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 8.5
+  },
+  "run": {
+    "frameCount": 120,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 56.69737774627923,
+    "minFrameMs": 16.5,
+    "maxFrameMs": 66.59999999999991
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2976193
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 211198
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 57560
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 51530
+    },
+    {
+      "function": "WebGLRenderer.setSize",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+      "microseconds": 4742
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 3860
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 3770
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2514
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2513
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2509
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 1343
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 1267
+    }
+  ]
+}

--- a/.omo/qa/68-perf-dpr2-fixed-2.json
+++ b/.omo/qa/68-perf-dpr2-fixed-2.json
@@ -1,0 +1,92 @@
+{
+  "capturedAt": "2026-09-03T12:45:02.663Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "requestedDevicePixelRatio": 2,
+    "effectiveDevicePixelRatio": 2,
+    "viewportWidth": 1920,
+    "viewportHeight": 1200,
+    "canvasWidth": 1223,
+    "canvasHeight": 853,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 8.200000047683716
+  },
+  "run": {
+    "frameCount": 119,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.799999999999727,
+    "fps": 56.22293385442701,
+    "minFrameMs": 16.57400000000007,
+    "maxFrameMs": 83.30000000000018
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2996500
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 227415
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 58874
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 53810
+    },
+    {
+      "function": "WebGLRenderer.setSize",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+      "microseconds": 5051
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 3770
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 3620
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2512
+    },
+    {
+      "function": "setFromRotationMatrix",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+      "microseconds": 1913
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 1338
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 1286
+    },
+    {
+      "function": "recursivelyTraversePassiveMountEffects",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=31439b1a",
+      "microseconds": 1279
+    }
+  ]
+}

--- a/.omo/qa/68-perf-dpr2-fixed-3.json
+++ b/.omo/qa/68-perf-dpr2-fixed-3.json
@@ -1,0 +1,92 @@
+{
+  "capturedAt": "2026-09-03T12:45:10.363Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "requestedDevicePixelRatio": 2,
+    "effectiveDevicePixelRatio": 2,
+    "viewportWidth": 1920,
+    "viewportHeight": 1200,
+    "canvasWidth": 1223,
+    "canvasHeight": 853,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 8.200000047683716
+  },
+  "run": {
+    "frameCount": 119,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 56.224155787213775,
+    "minFrameMs": 16.599999999999454,
+    "maxFrameMs": 83.29999999999973
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2999054
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 225357
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 57636
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 49921
+    },
+    {
+      "function": "WebGLRenderer.setSize",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+      "microseconds": 5018
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 3762
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2519
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2515
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2514
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+      "microseconds": 2514
+    },
+    {
+      "function": "App",
+      "url": "http://127.0.0.1:5284/src/App.jsx",
+      "microseconds": 2508
+    },
+    {
+      "function": "(anonymous)",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=31439b1a",
+      "microseconds": 1333
+    }
+  ]
+}

--- a/.omo/qa/68-perf-dpr2-fixed.json
+++ b/.omo/qa/68-perf-dpr2-fixed.json
@@ -1,0 +1,323 @@
+{
+  "phase": "fixed",
+  "requestedDpr": 2,
+  "window": "1920,1200",
+  "runs": [
+    {
+      "capturedAt": "2026-09-03T12:44:55.050Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "requestedDevicePixelRatio": 2,
+        "effectiveDevicePixelRatio": 2,
+        "viewportWidth": 1920,
+        "viewportHeight": 1200,
+        "canvasWidth": 1223,
+        "canvasHeight": 853,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.5
+      },
+      "run": {
+        "frameCount": 120,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 56.69737774627923,
+        "minFrameMs": 16.5,
+        "maxFrameMs": 66.59999999999991
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2976193
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 211198
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 57560
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 51530
+        },
+        {
+          "function": "WebGLRenderer.setSize",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+          "microseconds": 4742
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 3860
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 3770
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2514
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2513
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2509
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 1343
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 1267
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:45:02.663Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "requestedDevicePixelRatio": 2,
+        "effectiveDevicePixelRatio": 2,
+        "viewportWidth": 1920,
+        "viewportHeight": 1200,
+        "canvasWidth": 1223,
+        "canvasHeight": 853,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.200000047683716
+      },
+      "run": {
+        "frameCount": 119,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.799999999999727,
+        "fps": 56.22293385442701,
+        "minFrameMs": 16.57400000000007,
+        "maxFrameMs": 83.30000000000018
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2996500
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 227415
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 58874
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 53810
+        },
+        {
+          "function": "WebGLRenderer.setSize",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+          "microseconds": 5051
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 3770
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 3620
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2512
+        },
+        {
+          "function": "setFromRotationMatrix",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+          "microseconds": 1913
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 1338
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 1286
+        },
+        {
+          "function": "recursivelyTraversePassiveMountEffects",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=31439b1a",
+          "microseconds": 1279
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:45:10.363Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "requestedDevicePixelRatio": 2,
+        "effectiveDevicePixelRatio": 2,
+        "viewportWidth": 1920,
+        "viewportHeight": 1200,
+        "canvasWidth": 1223,
+        "canvasHeight": 853,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.200000047683716
+      },
+      "run": {
+        "frameCount": 119,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 56.224155787213775,
+        "minFrameMs": 16.599999999999454,
+        "maxFrameMs": 83.29999999999973
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2999054
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 225357
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 57636
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 49921
+        },
+        {
+          "function": "WebGLRenderer.setSize",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/three.module-2I7R9NbB.js?v=31439b1a",
+          "microseconds": 5018
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 3762
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2519
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2515
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2514
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=31439b1a",
+          "microseconds": 2514
+        },
+        {
+          "function": "App",
+          "url": "http://127.0.0.1:5284/src/App.jsx",
+          "microseconds": 2508
+        },
+        {
+          "function": "(anonymous)",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=31439b1a",
+          "microseconds": 1333
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "medianFrameMs": [
+      16.699999999999818,
+      16.699999999999818,
+      16.699999999999818
+    ],
+    "p95FrameMs": [
+      16.800000000000182,
+      16.799999999999727,
+      16.800000000000182
+    ],
+    "fps": [
+      56.69737774627923,
+      56.22293385442701,
+      56.224155787213775
+    ],
+    "medianOfMedians": 16.699999999999818,
+    "baselineMedianOfMedians": 16.699999999999818,
+    "medianFrameTimeImprovementPercent": 0,
+    "ikVisibility": [
+      {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.5
+      },
+      {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.200000047683716
+      },
+      {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.200000047683716
+      }
+    ]
+  }
+}

--- a/.omo/qa/68-perf-fixed-1.json
+++ b/.omo/qa/68-perf-fixed-1.json
@@ -1,0 +1,89 @@
+{
+  "capturedAt": "2026-09-03T12:22:13.441Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "devicePixelRatio": 1,
+    "canvasWidth": 907,
+    "canvasHeight": 569,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 8.400000095367432
+  },
+  "run": {
+    "frameCount": 119,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 56.22489959839358,
+    "minFrameMs": 16.5,
+    "maxFrameMs": 100
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 3017922
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 256273
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 93976
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 59892
+    },
+    {
+      "function": "requestAnimationFrame",
+      "url": "",
+      "microseconds": 3802
+    },
+    {
+      "function": "compute",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+      "microseconds": 2607
+    },
+    {
+      "function": "intersect",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+      "microseconds": 2536
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2513
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2512
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2510
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2510
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2509
+    }
+  ]
+}

--- a/.omo/qa/68-perf-fixed-2.json
+++ b/.omo/qa/68-perf-fixed-2.json
@@ -1,0 +1,89 @@
+{
+  "capturedAt": "2026-09-03T12:22:21.120Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "devicePixelRatio": 1,
+    "canvasWidth": 908,
+    "canvasHeight": 570,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 7.700000047683716
+  },
+  "run": {
+    "frameCount": 119,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 56.223305741391684,
+    "minFrameMs": 16.5,
+    "maxFrameMs": 100.09999999999991
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 2995493
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 234450
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 82535
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 63537
+    },
+    {
+      "function": "(garbage collector)",
+      "url": "",
+      "microseconds": 3943
+    },
+    {
+      "function": "getTaskName",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2890
+    },
+    {
+      "function": "getListener",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+      "microseconds": 2876
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2565
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2524
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2514
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2510
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2509
+    }
+  ]
+}

--- a/.omo/qa/68-perf-fixed-3.json
+++ b/.omo/qa/68-perf-fixed-3.json
@@ -1,0 +1,89 @@
+{
+  "capturedAt": "2026-09-03T12:22:28.741Z",
+  "baseUrl": "http://127.0.0.1:5284/app/",
+  "renderer": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+    "devicePixelRatio": 1,
+    "canvasWidth": 907,
+    "canvasHeight": 569,
+    "webgl": "WebGL2RenderingContext",
+    "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+    "vendor": "Google Inc. (Apple)"
+  },
+  "ikVisibility": {
+    "passes": 1,
+    "skippedFrames": 2,
+    "raycasts": 15,
+    "lastPassMs": 7.699999928474426
+  },
+  "run": {
+    "frameCount": 122,
+    "medianFrameMs": 16.699999999999818,
+    "p95FrameMs": 16.800000000000182,
+    "fps": 57.64342345236858,
+    "minFrameMs": 16.5,
+    "maxFrameMs": 66.59999999999991
+  },
+  "topSelfTime": [
+    {
+      "function": "(idle)",
+      "url": "",
+      "microseconds": 3012652
+    },
+    {
+      "function": "(program)",
+      "url": "",
+      "microseconds": 242545
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 60135
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 55251
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 3760
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 3758
+    },
+    {
+      "function": "getListener",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+      "microseconds": 3241
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2510
+    },
+    {
+      "function": "exports.jsxDEV",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+      "microseconds": 2508
+    },
+    {
+      "function": "compute",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+      "microseconds": 1316
+    },
+    {
+      "function": "exports.createElement",
+      "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react.js?v=0569d781",
+      "microseconds": 1268
+    },
+    {
+      "function": "onMove",
+      "url": "http://127.0.0.1:5284/src/app-stage.jsx",
+      "microseconds": 1268
+    }
+  ]
+}

--- a/.omo/qa/68-perf-fixed.json
+++ b/.omo/qa/68-perf-fixed.json
@@ -1,0 +1,292 @@
+{
+  "phase": "fixed",
+  "runs": [
+    {
+      "capturedAt": "2026-09-03T12:22:13.441Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "devicePixelRatio": 1,
+        "canvasWidth": 907,
+        "canvasHeight": 569,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 8.400000095367432
+      },
+      "run": {
+        "frameCount": 119,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 56.22489959839358,
+        "minFrameMs": 16.5,
+        "maxFrameMs": 100
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 3017922
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 256273
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 93976
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 59892
+        },
+        {
+          "function": "requestAnimationFrame",
+          "url": "",
+          "microseconds": 3802
+        },
+        {
+          "function": "compute",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+          "microseconds": 2607
+        },
+        {
+          "function": "intersect",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+          "microseconds": 2536
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2513
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2512
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2510
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2510
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2509
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:22:21.120Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "devicePixelRatio": 1,
+        "canvasWidth": 908,
+        "canvasHeight": 570,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 7.700000047683716
+      },
+      "run": {
+        "frameCount": 119,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 56.223305741391684,
+        "minFrameMs": 16.5,
+        "maxFrameMs": 100.09999999999991
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 2995493
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 234450
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 82535
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 63537
+        },
+        {
+          "function": "(garbage collector)",
+          "url": "",
+          "microseconds": 3943
+        },
+        {
+          "function": "getTaskName",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2890
+        },
+        {
+          "function": "getListener",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+          "microseconds": 2876
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2565
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2524
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2514
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2510
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2509
+        }
+      ]
+    },
+    {
+      "capturedAt": "2026-09-03T12:22:28.741Z",
+      "baseUrl": "http://127.0.0.1:5284/app/",
+      "renderer": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36",
+        "devicePixelRatio": 1,
+        "canvasWidth": 907,
+        "canvasHeight": 569,
+        "webgl": "WebGL2RenderingContext",
+        "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        "vendor": "Google Inc. (Apple)"
+      },
+      "ikVisibility": {
+        "passes": 1,
+        "skippedFrames": 2,
+        "raycasts": 15,
+        "lastPassMs": 7.699999928474426
+      },
+      "run": {
+        "frameCount": 122,
+        "medianFrameMs": 16.699999999999818,
+        "p95FrameMs": 16.800000000000182,
+        "fps": 57.64342345236858,
+        "minFrameMs": 16.5,
+        "maxFrameMs": 66.59999999999991
+      },
+      "topSelfTime": [
+        {
+          "function": "(idle)",
+          "url": "",
+          "microseconds": 3012652
+        },
+        {
+          "function": "(program)",
+          "url": "",
+          "microseconds": 242545
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 60135
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 55251
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 3760
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 3758
+        },
+        {
+          "function": "getListener",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-dom_client.js?v=ecf90789",
+          "microseconds": 3241
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2510
+        },
+        {
+          "function": "exports.jsxDEV",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react_jsx-dev-runtime.js?v=0569d781",
+          "microseconds": 2508
+        },
+        {
+          "function": "compute",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react-three-fiber.esm-Bp-UeNQf.js?v=9291a32e",
+          "microseconds": 1316
+        },
+        {
+          "function": "exports.createElement",
+          "url": "http://127.0.0.1:5284/node_modules/.vite/deps/react.js?v=0569d781",
+          "microseconds": 1268
+        },
+        {
+          "function": "onMove",
+          "url": "http://127.0.0.1:5284/src/app-stage.jsx",
+          "microseconds": 1268
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "medianFrameMs": [
+      16.699999999999818,
+      16.699999999999818,
+      16.699999999999818
+    ],
+    "p95FrameMs": [
+      16.800000000000182,
+      16.800000000000182,
+      16.800000000000182
+    ],
+    "fps": [
+      56.22489959839358,
+      56.223305741391684,
+      57.64342345236858
+    ],
+    "medianOfMedians": 16.699999999999818,
+    "baselineMedianOfMedians": 16.699999999999818,
+    "medianFrameTimeImprovementPercent": 0
+  }
+}

--- a/.omo/report-68.md
+++ b/.omo/report-68.md
@@ -1,0 +1,197 @@
+# Issue #68 implementation report
+
+## Outcome
+
+Issue #68's camera-drag path was profiled on the real browser surface with Chrome's GPU enabled. The branch already contained the substantive camera-drag optimizations from commits `6daea2d`, `1401e0e`, `4be7cd7`, and `56baded`: camera gestures skip IK exposure work, the frozen inset/outline passes are deferred, DPR is reduced while navigating, and shadow-map updates are disabled. This change makes the exposure refresh policy explicit and unit-testable, and fixes the scoped IK-pick regression where an occluded handle could still capture focus.
+
+The fixed surface met the absolute acceptance fallback: 56.2-57.6 fps with a 16.7 ms median frame time. The measured median improvement over this branch's pre-change baseline was 0% because the existing camera-gesture optimization was already present; the change preserves it rather than pretending to add a second copy of the same optimization.
+
+## Root cause and profile evidence
+
+The expensive candidate was IK exposure/occlusion work, not a React render storm:
+
+- The first settled IK exposure pass took 7.8-8.2 ms and performed 15 handle ray tests.
+- During the right-button drag, the exposure counter showed one pass and skipped frames, confirming that camera movement reused the cached exposure result instead of walking the skinned proxy cloud every frame.
+- CPU sampling during the drag was dominated by `(idle)` and `(program)`; the largest named JS samples were React JSX construction samples, not a repeated App render loop. This matches the issue investigation note that a React re-render storm was not confirmed.
+- The browser reported `ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)` from WebGL2, so the run used the GPU/default path and not SwiftShader or `--disable-gpu`.
+- Motion trails were left intact and were not rewritten during camera movement. The scoped render wiring remains unchanged.
+
+Top CPU self-time entries from the captured Profiler sample (run 1):
+
+- `(idle)`: 2,953,562 us
+- `(program)`: 226,829 us
+- `exports.jsxDEV` (React JSX runtime): 65,819 us
+- `exports.jsxDEV` (React JSX runtime): 56,356 us
+- Remaining named samples were small React runtime / R3F entries; no exposure or trail function appeared as a repeated top self-time function because exposure was skipped during the gesture.
+
+The prior-work checks requested by the issue were run:
+
+```text
+git log --oneline origin/main..origin/fix/ik-camera-outline-jank
+# no output (remote ref has no commits relative to origin/main)
+
+git diff origin/main...origin/fix/ik-camera-outline-jank --stat
+# no diff (remote ref resolves to the same history for this checkout)
+```
+
+The relevant existing history is visible in the touched-path log, especially `56baded fix(studio): stabilize outlines during camera drag` and `6daea2d fix: separate IK tools and smooth camera navigation`.
+
+## Files changed
+
+- `src/use-render-activity.js`
+  - Added pure `shouldRefreshIkExposure(...)`, encoding the camera-gesture skip, immediate pose refresh, forced post-gesture refresh, and 100 ms camera-only throttle decisions.
+- `src/posestudio.jsx`
+  - Uses the pure exposure decision in the existing hot path.
+  - IK pointer picking now excludes handles whose computed `userData.ikExposed` is false. Occluded controls remain rendered, but cannot steal focus from an exposed control.
+- `test/verify-ik-camera-performance.mjs`
+  - Added deterministic node regression coverage for all exposure-refresh decisions.
+- `tools/perf/ik-camera-drag.mjs`
+  - Added CDP perf harness: loads `/demo/walk-then-stop.npz`, enables IK, dispatches 120 right-button moves over about 2 seconds, samples RAF deltas, records WebGL renderer, and captures a Profiler CPU sample.
+- `tools/run-tests.mjs`
+  - Added the new node test to `NODE_FILES`.
+- `.omo/qa/68-perf-baseline*.json`, `.omo/qa/68-perf-fixed*.json`, `.omo/qa/68-ik-browser-*.log`, `.omo/qa/68-build.log`, `.omo/qa/68-full-tests.log`, `.omo/qa/68-appearance.log`
+  - Reproducible QA artifacts.
+
+No files outside the requested scope were changed.
+
+## Regression test RED -> GREEN
+
+Failing-first command, run before implementing the export:
+
+```sh
+node test/verify-ik-camera-performance.mjs
+```
+
+RED excerpt, saved at `.omo/qa/68-ik-camera-performance-red.log`:
+
+```text
+SyntaxError: The requested module '../src/use-render-activity.js' does not provide an export named 'shouldRefreshIkExposure'
+Node.js v24.19.0
+```
+
+After implementation:
+
+```sh
+node test/verify-ik-camera-performance.mjs
+```
+
+GREEN excerpt, saved at `.omo/qa/68-ik-camera-performance-green.log`:
+
+```text
+PASS IK camera exposure refresh decisions
+```
+
+The static appearance regression also passed:
+
+```sh
+node test/verify-appearance.mjs
+# ...
+PASS unchanged IK frames reuse the previous exposure pass
+all screen-space NPR appearance checks PASS
+```
+
+## Perf commands and results
+
+Vite was started with the reserved ports:
+
+```sh
+npm run dev:ui -- --host 127.0.0.1 --port 5284 --strictPort
+```
+
+Each perf run used the required GPU/default Chrome path through `tools/qa-browser.mjs`:
+
+```sh
+QA_URL=http://127.0.0.1:5284/app/ CDP_PORT=9284 PERF_OUTPUT=.omo/qa/68-perf-baseline-1.json \
+  node tools/qa-browser.mjs -- node tools/perf/ik-camera-drag.mjs
+```
+
+The same command was repeated for baseline runs 1-3 and fixed runs 1-3. Aggregates:
+
+- Baseline: `.omo/qa/68-perf-baseline.json`
+  - Median frame times: 16.7, 16.7, 16.7 ms
+  - P95 frame times: 16.7, 16.8, 16.8 ms
+  - FPS: 57.17, 57.64, 56.67
+  - Median-of-medians: 16.7 ms
+- Fixed: `.omo/qa/68-perf-fixed.json`
+  - Median frame times: 16.7, 16.7, 16.7 ms
+  - P95 frame times: 16.8, 16.8, 16.8 ms
+  - FPS: 56.22, 56.22, 57.64
+  - Median-of-medians: 16.7 ms
+  - Median frame-time improvement: 0%
+  - Absolute fixed result: 16.7 ms median / over 55 fps, satisfying the acceptance fallback
+
+Per-run raw JSON files are retained beside each aggregate. The harness output includes renderer/vendor, DPR, RAF count, min/max frame time, IK visibility counters, and `topSelfTime`.
+
+## DPR 2 measurement
+
+The original harness was extended with `PERF_DPR` (default `1`). It now sends `Emulation.setDeviceMetricsOverride` with `{ width: 1920, height: 1200, deviceScaleFactor: PERF_DPR, mobile: false }` before navigation and records the requested/effective DPR and canvas dimensions. The matched campaign used `QA_WINDOW=1920,1200`, `PERF_DPR=2`, and separate Vite/CDP ports:
+
+- Base tree `8f0c5c7`: `/tmp/cclay-68-base`, Vite `5384`, CDP `9384`.
+- Fixed tree: `/Users/yun/CozyClay-i68`, Vite `5284`, CDP `9284`.
+- Both reported WebGL2 `ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)` and effective DPR `2`.
+- The app's layout produced a roughly `1223x853` canvas at the 1920x1200 browser viewport; this is the effective high-DPR canvas allocated by the app, not the browser viewport size.
+
+| Tree / run | Median ms | P95 ms | FPS | IK passes | Skipped | Raycasts | Last pass ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Base 1 | 16.7 | 16.8 | 56.69 | 1 | 2 | 15 | 7.8 |
+| Base 2 | 16.7 | 16.7 | 57.17 | 1 | 2 | 15 | 8.5 |
+| Base 3 | 16.7 | 16.8 | 56.67 | 1 | 2 | 15 | 8.1 |
+| Fixed 1 | 16.7 | 16.8 | 56.70 | 1 | 2 | 15 | 8.5 |
+| Fixed 2 | 16.7 | 16.8 | 56.22 | 1 | 2 | 15 | 8.2 |
+| Fixed 3 | 16.7 | 16.8 | 56.22 | 1 | 2 | 15 | 8.2 |
+
+Artifacts:
+
+- `.omo/qa/68-perf-dpr2-baseline.json`
+- `.omo/qa/68-perf-dpr2-fixed.json`
+- `.omo/qa/68-perf-dpr2-baseline-{1,2,3}.json` (generated in the temporary base worktree and copied beside the aggregate)
+- `.omo/qa/68-perf-dpr2-fixed-{1,2,3}.json`
+
+Verdict: the fixed DPR-2 result passes the conditional thresholds (`median 16.7 ms <= 18 ms`, `worst p95 16.8 ms <= 33 ms`, and every run is above 55 fps). The median frame-time reduction versus the 8f0c5c7 base is 0% because the base commit already contains the earlier camera-drag optimization commits. No additional DPR-2 hot-path change or second CPU profile was warranted by the stated threshold. The occasional maximum frame samples were 66.6-83.4 ms in both campaigns, but they did not recur in p95 and are retained in the per-run JSON for review.
+
+## Browser IK suite before/after
+
+Before command:
+
+```sh
+QA_URL=http://127.0.0.1:5284/app/ CDP_PORT=9284 \
+  node tools/qa-browser.mjs -- node test/verify-ik-browser.mjs
+```
+
+Log: `.omo/qa/68-ik-browser-before.log`.
+
+The before run reached the IK checks but failed at the existing hidden-shoulder/compound-manipulator sequence:
+
+```text
+FAIL hidden shoulder cannot take its own focus
+FAIL exposed shoulder remains clickable
+FAIL hand focus mounts its compound manipulator
+FAIL focused hand registers enlarged invisible axis hit volumes
+TypeError: Cannot read properties of undefined (reading 'x')
+```
+
+After the scoped exposure-aware pick change, the same command was rerun. Log: `.omo/qa/68-ik-browser-after.log`. The hidden-shoulder assertion became PASS; the remaining downstream manipulator sequence still fails at exposed-shoulder/hand setup, so this browser suite is not fully green on this checkout. No existing assertion was weakened or removed. The individual appearance and node regression suites are green.
+
+## Build and full manifest
+
+```sh
+npm run build
+```
+
+Passed. Vite emits the repository's existing warnings about unresolved `../fonts/inter-latin.woff2` at build time and a large minified app chunk; there were no source diagnostics or syntax/type errors in changed files. Full output: `.omo/qa/68-build.log`.
+
+```sh
+node tools/run-tests.mjs
+```
+
+Passed: `PASS 119 Node verification files`. Full output: `.omo/qa/68-full-tests.log`.
+
+LSP diagnostics were run on both changed source files and both new scripts; all returned `No diagnostics found`.
+
+## Merge notes
+
+- The remote prior-fix ref had no additional diff, while this checkout already included the main camera-drag optimizations. The commit therefore centralizes and tests the policy instead of duplicating a performance path.
+- Keep the `shouldRefreshIkExposure` call and the `ikExposed` pick filter together. Removing either reintroduces either an untestable hot-path decision or occluded-handle focus capture.
+- The fixed perf artifact's 0% delta is intentional and evidence-backed; the absolute result is above the 55 fps fallback. Do not report a fabricated 30% gain.
+- The browser suite's remaining manipulator failure is recorded in both logs and was not caused by the exposure-aware hidden-handle fix; the lead should decide whether to split that pre-existing fixture issue before merge.
+- No push or PR was performed.

--- a/src/posestudio.jsx
+++ b/src/posestudio.jsx
@@ -4,6 +4,7 @@ import * as THREE from "three";
 import { POSE_BONES, normalizeBoneName, primeBindPose } from "./poses.js";
 import { poseThumbnail, warmThumbnailModels } from "./pose-thumbs.js";
 import { IK_TRACKS, MID_TRACKS, ikControlIsExposed } from "./ardy/ik.js";
+import { shouldRefreshIkExposure } from "./use-render-activity.js";
 import { POSER_LAYER } from "./dualview.jsx";
 import { ko, isKo } from "./locale.js";
 
@@ -600,11 +601,18 @@ export function IkHandles({ chains, fkJoints, ikState, enabled, focus, onFocus, 
 		// Keep the last visibility result for a short interval during a gesture;
 		// this still follows a slow orbit without making every pointer sample
 		// pay the full proxy cost.
-		const cameraOnlyExposure = exposureDirty && !poseDirty;
-		const exposureThrottled = !cameraGestureEnded && cameraOnlyExposure && performance.now() - exposureLastPassAt.current < 100;
-		if (exposureThrottled) {
+		const refreshExposure = shouldRefreshIkExposure({
+			cameraGesture,
+			cameraGestureEnded,
+			exposureDirty,
+			poseDirty,
+			elapsedMs: performance.now() - exposureLastPassAt.current,
+		});
+		// No work is scheduled when `if (exposureDirty)` is false; camera-only
+		// changes use the pure decision above to keep this expensive pass cached.
+		if (!refreshExposure && exposureDirty) {
 			exposurePerfRef.current.skippedFrames += 1;
-		} else if (exposureDirty) {
+		} else if (refreshExposure) {
 			const passStartedAt = performance.now();
 			input.valid = true;
 			poseInput.valid = true;
@@ -899,7 +907,8 @@ const CLICK_PX = 4;
 			const focused = focusIdRef.current;
 			let picks = pickRefs.current.filter((p) =>
 				p.mesh?.visible &&
-				handleRefs.current[p.track.id]?.visible
+				handleRefs.current[p.track.id]?.visible &&
+				handleRefs.current[p.track.id]?.userData.ikExposed !== false
 			);
 			if (focused) picks = picks.filter((p) => p.track.id === focused);
 			else picks = picks.filter((p) => !p.axisDir); // spheres only

--- a/src/use-render-activity.js
+++ b/src/use-render-activity.js
@@ -15,6 +15,17 @@ export function hasContinuousRenderActivity(pointerIds, keyCodes, transient) {
 }
 
 /**
+ * Camera navigation cannot change the rig silhouette, so its exposure result
+ * can stay cached until the gesture settles. Pose changes remain immediate.
+ */
+export function shouldRefreshIkExposure({ cameraGesture, cameraGestureEnded, exposureDirty, poseDirty, elapsedMs, throttleMs = 100 }) {
+	if (!exposureDirty) return false;
+	if (cameraGesture) return false;
+	if (cameraGestureEnded || poseDirty) return true;
+	return elapsedMs >= throttleMs;
+}
+
+/**
  * Keep the WebGL loop hot only while the user is actively manipulating the
  * scene. React/R3F still invalidates demand frames for ordinary state changes;
  * this hook covers direct ref mutations such as IK drags, camera look/dolly,

--- a/test/verify-ik-camera-performance.mjs
+++ b/test/verify-ik-camera-performance.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/** Regression checks for the IK exposure work avoided during camera navigation. */
+import assert from "node:assert/strict";
+import { shouldRefreshIkExposure } from "../src/use-render-activity.js";
+
+assert.equal(
+	shouldRefreshIkExposure({ cameraGesture: true, cameraGestureEnded: false, exposureDirty: true, poseDirty: false, elapsedMs: 500 }),
+	false,
+	"camera motion keeps the cached exposure result",
+);
+assert.equal(
+	shouldRefreshIkExposure({ cameraGesture: false, cameraGestureEnded: true, exposureDirty: true, poseDirty: false, elapsedMs: 1 }),
+	true,
+	"the first settled frame refreshes after camera motion",
+);
+assert.equal(
+	shouldRefreshIkExposure({ cameraGesture: false, cameraGestureEnded: false, exposureDirty: true, poseDirty: true, elapsedMs: 1 }),
+	true,
+	"pose changes refresh immediately",
+);
+assert.equal(
+	shouldRefreshIkExposure({ cameraGesture: false, cameraGestureEnded: false, exposureDirty: true, poseDirty: false, elapsedMs: 99 }),
+	false,
+	"camera-only exposure remains throttled inside the interval",
+);
+assert.equal(
+	shouldRefreshIkExposure({ cameraGesture: false, cameraGestureEnded: false, exposureDirty: true, poseDirty: false, elapsedMs: 100 }),
+	true,
+	"camera-only exposure refreshes at the interval",
+);
+assert.equal(
+	shouldRefreshIkExposure({ cameraGesture: false, cameraGestureEnded: false, exposureDirty: false, poseDirty: true, elapsedMs: 500 }),
+	false,
+	"a clean input does not start an exposure pass",
+);
+console.log("PASS IK camera exposure refresh decisions");

--- a/tools/perf/ik-camera-drag.mjs
+++ b/tools/perf/ik-camera-drag.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Real-surface IK camera-drag frame-time probe. The browser is supplied by
+ * tools/qa-browser.mjs; this script only drives the page over CDP.
+ */
+import { writeFileSync } from "node:fs";
+
+const port = Number(process.env.CDP_PORT || 9284);
+const baseUrl = process.env.QA_URL || "http://127.0.0.1:5284/app/";
+const perfDpr = Number(process.env.PERF_DPR || 1);
+if (!(perfDpr > 0)) throw new Error(`PERF_DPR must be positive, got ${process.env.PERF_DPR}`);
+const perfWidth = 1920;
+const perfHeight = 1200;
+const target = (await (await fetch(`http://127.0.0.1:${port}/json`)).json()).find((item) => item.type === "page" && item.webSocketDebuggerUrl);
+if (!target) throw new Error(`no page target on CDP port ${port}`);
+const ws = new WebSocket(target.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const request = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) request.reject(new Error(JSON.stringify(message.error)));
+	else request.resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "browser evaluation failed");
+	return result.result.value;
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (expression, timeoutMs = 15000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression)) return;
+		await sleep(50);
+	}
+	throw new Error(`timed out waiting for ${expression}`);
+};
+
+await send("Runtime.enable");
+await send("Page.enable");
+// Match the reporter's high-resolution surface before the page creates its
+// renderer; setting this after navigation leaves canvas allocation at DPR 1.
+await send("Emulation.setDeviceMetricsOverride", {
+	width: perfWidth,
+	height: perfHeight,
+	deviceScaleFactor: perfDpr,
+	mobile: false,
+});
+await send("Profiler.enable");
+await send("Page.navigate", { url: `${baseUrl}?motion=/demo/walk-then-stop.npz` });
+await waitFor("!!window.__cozyclay?.rigA && !!window.__cozyclay?.motion");
+await evaluate(`(() => { const button = [...document.querySelectorAll("button")].find((item) => item.textContent.trim() === "IK off"); if (!button) throw new Error("IK toggle missing"); button.click(); return true; })()`);
+await waitFor("window.__cozyclay?.ikMode === true && !!window.__ikVisibilityPerformance");
+await sleep(500);
+const renderer = await evaluate(`(() => {
+	const canvas = document.querySelector("canvas");
+	const context = canvas?.getContext("webgl2") || canvas?.getContext("webgl");
+	const debug = context?.getExtension("WEBGL_debug_renderer_info");
+	return {
+		userAgent: navigator.userAgent,
+		requestedDevicePixelRatio: ${perfDpr},
+		effectiveDevicePixelRatio: devicePixelRatio,
+		viewportWidth: innerWidth,
+		viewportHeight: innerHeight,
+		canvasWidth: canvas?.width,
+		canvasHeight: canvas?.height,
+		webgl: context?.constructor?.name || null,
+		renderer: debug ? context.getParameter(debug.UNMASKED_RENDERER_WEBGL) : "unavailable",
+		vendor: debug ? context.getParameter(debug.UNMASKED_VENDOR_WEBGL) : "unavailable",
+	};
+})()`);
+const stage = await evaluate(`(() => { const rect = document.querySelector(".stage")?.getBoundingClientRect(); if (!rect) throw new Error("stage missing"); return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2, width: rect.width, height: rect.height }; })()`);
+const mouse = (type, x, y, button = "right", buttons = button === "right" ? 2 : 0) => send("Input.dispatchMouseEvent", {
+	type, x: Math.round(x), y: Math.round(y), button, buttons, clickCount: 1,
+});
+const profileStartedAt = new Date().toISOString();
+await send("Profiler.start");
+const sample = evaluate(`new Promise((resolve) => {
+	const frames = [];
+	let previous = performance.now();
+	const started = previous;
+	const tick = (now) => {
+		frames.push(now - previous);
+		previous = now;
+		if (now - started >= 2100) resolve(frames.slice(1));
+		else requestAnimationFrame(tick);
+	};
+	requestAnimationFrame(tick);
+})`);
+await mouse("mousePressed", stage.x, stage.y);
+for (let index = 1; index <= 120; index += 1) {
+	const angle = (index / 120) * Math.PI * 2;
+	await mouse("mouseMoved", stage.x + Math.cos(angle) * stage.width * 0.12, stage.y + Math.sin(angle) * stage.height * 0.08);
+	await sleep(2000 / 120);
+}
+await mouse("mouseReleased", stage.x + stage.width * 0.12, stage.y, "right", 0);
+const frameTimes = await sample;
+const profileResult = await send("Profiler.stop");
+const sorted = [...frameTimes].sort((a, b) => a - b);
+const percentile = (values, p) => values[Math.min(values.length - 1, Math.floor(values.length * p))] ?? null;
+const duration = frameTimes.reduce((sum, value) => sum + value, 0);
+const samples = profileResult.profile?.samples ?? [];
+const deltas = profileResult.profile?.timeDeltas ?? [];
+const nodes = new Map((profileResult.profile?.nodes ?? []).map((node) => [node.id, node]));
+const selfTime = new Map();
+for (let index = 0; index < samples.length; index += 1) selfTime.set(samples[index], (selfTime.get(samples[index]) || 0) + (deltas[index] || 0));
+const topSelfTime = [...selfTime.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12).map(([id, microseconds]) => {
+	const node = nodes.get(id);
+	return { function: node?.callFrame?.functionName || "(anonymous)", url: node?.callFrame?.url || "", microseconds };
+});
+const result = {
+	capturedAt: profileStartedAt,
+	baseUrl,
+	renderer,
+	ikVisibility: await evaluate("window.__ikVisibilityPerformance()"),
+	run: {
+		frameCount: frameTimes.length,
+		medianFrameMs: percentile(sorted, 0.5),
+		p95FrameMs: percentile(sorted, 0.95),
+		fps: duration > 0 ? frameTimes.length / (duration / 1000) : 0,
+		minFrameMs: sorted[0] ?? null,
+		maxFrameMs: sorted.at(-1) ?? null,
+	},
+	topSelfTime,
+};
+const outputPath = process.env.PERF_OUTPUT;
+if (outputPath) writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`);
+console.log(JSON.stringify(result, null, 2));
+ws.close();

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -32,6 +32,7 @@ const NODE_FILES = [
 	"test/ik/verify-fix-collisions.mjs",
 	"test/ik/verify-auto-physics.mjs",
 	"test/ik/verify-ik.mjs",
+	"test/verify-ik-camera-performance.mjs",
 	"test/process/verify-bridge-launch.mjs",
 	"test/process/verify-lifecycle.mjs",
 	"test/process/verify-mcp-package-isolation.mjs",


### PR DESCRIPTION
Closes #68.

## What was measured
Real Chrome (ANGLE Metal, Apple M4 Pro) over CDP with the new harness `tools/perf/ik-camera-drag.mjs`: character with motion loaded, IK ON, a 2 s synthetic right-button drag, frame times sampled via rAF. Three runs each on the unfixed tree and on this branch, at DPR 1 and at DPR 2 (1920x1200 viewport).

| tree | median | p95 | fps |
| --- | ---: | ---: | ---: |
| main 8f0c5c7 (DPR 2) | 16.7 ms | 16.8 ms | 56.7-57.2 |
| this branch (DPR 2) | 16.7 ms | 16.8 ms | 56.2-56.7 |

The camera-drag path is already vsync-bound on current main: the substantive optimisations for this issue landed after it was filed (6daea2d, 1401e0e, 4be7cd7, 56baded — exposure skipped during camera gestures, deferred outline passes, reduced DPR while navigating, frozen shadow maps). A CPU profile during the drag shows only `(idle)`/`(program)`/React JSX construction. So the honest relative improvement is 0%; the absolute result is above 55 fps.

## What this branch changes
- `shouldRefreshIkExposure()` (`src/use-render-activity.js`) makes the exposure refresh policy explicit and unit-testable; `posestudio.jsx` uses it in the existing hot path so a future change cannot silently reintroduce per-frame proxy scans during camera motion.
- Pointer picking now excludes handles whose `userData.ikExposed === false`: an occluded handle could still capture focus (`verify-ik-browser` case "hidden shoulder cannot take its own focus" now passes).
- `test/verify-ik-camera-performance.mjs` (node, in `npm test`) and the perf harness + recorded JSON artifacts under `.omo/qa/`.

Remaining `verify-ik-browser` failures (hand manipulator setup) are pre-existing on main and unrelated.
