### PR TITLE
feat(ui): advanced toggle hides expert panels for first-time users

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1033,6 +1033,12 @@ globalThis.playMode = centerTab === "play";
 	// Keep the underlying selection model intact, but use this small workflow
 	// state to surface only the tools that belong to the current job.
 	const [workflowMode, setWorkflowMode] = useState("scene");
+	const [advancedMode, setAdvancedMode] = useState(() => { try { return globalThis.localStorage?.getItem("cozyclay.advanced") === "true"; } catch { return false; } });
+	function toggleAdvancedMode() {
+		const next = !advancedMode;
+		try { globalThis.localStorage?.setItem("cozyclay.advanced", String(next)); } catch {}
+		setAdvancedMode(next);
+	}
 	function selectWorkflowMode(next) {
 		setWorkflowMode(next);
 		setCenterTab("scene");
@@ -9381,6 +9387,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						</span>
 					)}
 					<LocaleToggle />
+					<button type="button" className="auto-color-toggle advanced-toggle" aria-pressed={advancedMode} onClick={toggleAdvancedMode}>{ko("Advanced", "고급")}</button>
 					<AnalyticsToggle />
 				</div>
 			</header>
@@ -10417,7 +10424,7 @@ function resizePromptClip(id, edge, rawFrame) {
 				{/* Rig and Pose are chosen once when a character is cast and then left
 				    alone, so they open on demand — Subject and Prompt are the panels
 				    you actually work in. */}
-				<Foldout hidden={!isCharacterSelection} defaultOpen={false} title={ko("Rig", "리그")}>
+				<Foldout hidden={!advancedMode || !isCharacterSelection} defaultOpen={false} title={ko("Rig", "리그")}>
 					{/* The rig is a property of the character, and swapping it is a
 					    look decision made while blocking — so it belongs beside the
 					    subject, not buried in the project file. */}
@@ -10443,7 +10450,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					</div>
 				</Foldout>
 
-				<Foldout hidden={!isCharacterSelection} defaultOpen={false} title={ko("Pose", "포즈")}>
+				<Foldout hidden={!advancedMode || !isCharacterSelection} defaultOpen={false} title={ko("Pose", "포즈")}>
 					{/* Tiles, not a dropdown: a pose read out of a photograph has no
 					    name worth reading — it is recognisable only as a shape. This
 					    is the same grid the studio shows, applied to whichever
@@ -10501,7 +10508,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					</button>
 				</Foldout>
 
-				<Foldout hidden={!isCharacterSelection} defaultOpen={false} title={ko("Video capture", "영상 모캡")}>
+				<Foldout hidden={!advancedMode || !isCharacterSelection} defaultOpen={false} title={ko("Video capture", "영상 모캡")}>
 					<div className="multimodel-card">
 						<div className="multimodel-card-head">
 							<div>
@@ -10845,7 +10852,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						</>
 					)}
 				</Foldout>}
-				<Foldout hidden={!isCharacterSelection} defaultOpen={false} openSignal={promptBlocksReveal} title={ko("Prompt Blocks", "프롬프트 블록")}>
+				<Foldout hidden={!advancedMode || !isCharacterSelection} defaultOpen={false} openSignal={promptBlocksReveal} title={ko("Prompt Blocks", "프롬프트 블록")}>
 					<p className="inspector-hint">{ko("Blocks define what ARDY generates over each frame range. Selecting one also moves editing context to that prompt.", "블록은 각 프레임 범위에서 ARDY가 생성할 내용을 정합니다. 블록을 선택하면 편집 기준도 해당 프롬프트로 이동합니다.")}</p>
 						<div className="inspector-list">
 							{promptClips.map((clip) => (
@@ -12101,6 +12108,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					frameCount={tlFrameCount}
 					fps={tlFps}
 					playbackSpeed={DEFAULT_PLAYBACK_SPEED}
+					advancedMode={advancedMode}
 				trackOwner={characters.length > 1 ? `S${activeCharIndex + 1}` : null}
 				ghostLayers={ghostLayers}
 				pathSpeed={pathSpeed}

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -952,6 +952,7 @@ export default function Timeline({
 	// cast's schedule is visible while only the active layer is editable.
 	ghostLayers = [], // [{ owner, promptClips: [], waypointFrames: [] }]
 	waypointMode,
+	advancedMode = true,
 	waypoints = [],
 	pathSpeed = null, // { min, max, warn } in m/s, shown on the 2D Root label
 	badge,
@@ -1756,7 +1757,7 @@ export default function Timeline({
 							>
 								{zoom.toFixed(2)}×
 							</button>
-							<button
+							{advancedMode && <button
 								type="button"
 								className={"tl-btn wp" + (waypointMode ? " on" : "")}
 								aria-pressed={waypointMode}
@@ -1765,7 +1766,7 @@ export default function Timeline({
 								onClick={() => handlers.current.onWaypointToggle?.()}
 							>
 								{isKo ? `웨이포인트 ${waypointMode ? "켜짐" : "꺼짐"}` : `Waypoint ${waypointMode ? "on" : "off"}`}
-							</button>
+							</button>}
 						</div>
 						<div className="tl-head-group tl-pose-tools" role="group" aria-label={ko("Pose correction tools", "포즈 보정 도구")} style={TL_HEAD_GROUP_STYLE}>
 							<button
@@ -1943,7 +1944,7 @@ export default function Timeline({
 								onTimingGestureEnd={() => handlers.current.onObjectTimingGestureEnd?.()}
 							/>
 						) : TRACKS.map((name) => (
-							<div className={"tl-track" + (name === "Prompts" ? " prompts" : "") + (name === IK_LANE ? " ik" : "") + (name === SHOTS_LANE ? " shots" : "")} key={name}>
+							<div style={!advancedMode && name !== IK_LANE ? { display: "none" } : undefined} className={"tl-track" + (name === "Prompts" ? " prompts" : "") + (name === IK_LANE ? " ik" : "") + (name === SHOTS_LANE ? " shots" : "")} key={name}>
 								<span className="tl-track-label">
 									{TRACK_LABELS_KO[name]}
 									{trackOwner && (name === "Prompts" || name === "2D Root") && <em className="tl-track-owner">{trackOwner}</em>}

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -1959,7 +1959,7 @@ export default function Timeline({
 										</em>
 									)}
 									{name === "Prompts" && <button className="tl-track-add" type="button" title={ko("Add a 2–4 second prompt clip — one action per block", "2–4초 프롬프트 클립 추가 — 한 블록에 한 동작")} onClick={() => handlers.current.onPromptAdd?.(frame)}>+</button>}
-									{advancedMode && name === SHOTS_LANE && (
+									{name === SHOTS_LANE && (
 										<button
 											type="button"
 											className="tl-track-add cut"

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -1944,7 +1944,7 @@ export default function Timeline({
 								onTimingGestureEnd={() => handlers.current.onObjectTimingGestureEnd?.()}
 							/>
 						) : TRACKS.map((name) => (
-							<div className={"tl-track" + (name === "Prompts" ? " prompts" : "") + (name === IK_LANE ? " ik" : "") + (name === SHOTS_LANE ? " shots" : "")} key={name}>
+							<div style={!advancedMode && (name === "Prompts" || name === "2D Root") ? { display: "none" } : undefined} className={"tl-track" + (name === "Prompts" ? " prompts" : "") + (name === IK_LANE ? " ik" : "") + (name === SHOTS_LANE ? " shots" : "")} key={name}>
 								<span className="tl-track-label">
 									{TRACK_LABELS_KO[name]}
 									{trackOwner && (name === "Prompts" || name === "2D Root") && <em className="tl-track-owner">{trackOwner}</em>}
@@ -1958,7 +1958,7 @@ export default function Timeline({
 												: `${pathSpeed.min.toFixed(1)}–${pathSpeed.max.toFixed(1)} m/s`}
 										</em>
 									)}
-									{name === "Prompts" && <button className="tl-track-add" type="button" title={ko("Add a 2–4 second prompt clip — one action per block", "2–4초 프롬프트 클립 추가 — 한 블록에 한 동작")} onClick={() => handlers.current.onPromptAdd?.(frame)}>+</button>}
+									{advancedMode && name === "Prompts" && <button className="tl-track-add" type="button" title={ko("Add a 2–4 second prompt clip — one action per block", "2–4초 프롬프트 클립 추가 — 한 블록에 한 동작")} onClick={() => handlers.current.onPromptAdd?.(frame)}>+</button>}
 									{name === SHOTS_LANE && (
 										<button
 											type="button"

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -1959,7 +1959,7 @@ export default function Timeline({
 										</em>
 									)}
 									{name === "Prompts" && <button className="tl-track-add" type="button" title={ko("Add a 2–4 second prompt clip — one action per block", "2–4초 프롬프트 클립 추가 — 한 블록에 한 동작")} onClick={() => handlers.current.onPromptAdd?.(frame)}>+</button>}
-									{name === SHOTS_LANE && (
+									{advancedMode && name === SHOTS_LANE && (
 										<button
 											type="button"
 											className="tl-track-add cut"

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -1944,7 +1944,7 @@ export default function Timeline({
 								onTimingGestureEnd={() => handlers.current.onObjectTimingGestureEnd?.()}
 							/>
 						) : TRACKS.map((name) => (
-							<div style={!advancedMode && name !== IK_LANE ? { display: "none" } : undefined} className={"tl-track" + (name === "Prompts" ? " prompts" : "") + (name === IK_LANE ? " ik" : "") + (name === SHOTS_LANE ? " shots" : "")} key={name}>
+							<div className={"tl-track" + (name === "Prompts" ? " prompts" : "") + (name === IK_LANE ? " ik" : "") + (name === SHOTS_LANE ? " shots" : "")} key={name}>
 								<span className="tl-track-label">
 									{TRACK_LABELS_KO[name]}
 									{trackOwner && (name === "Prompts" || name === "2D Root") && <em className="tl-track-owner">{trackOwner}</em>}

--- a/test/qa-advanced-toggle-browser.mjs
+++ b/test/qa-advanced-toggle-browser.mjs
@@ -17,7 +17,10 @@ try {
  const expert = [...sections, ...lanes, page.getByRole('button', { name: 'Root path mode', exact: true }), page.getByRole('button', { name: '+ Add shot', exact: true })];
  async function verify(on) {
   assert.equal(await toggle.getAttribute('aria-pressed'), String(on));
-  for (const locator of expert) assert.equal(await locator.isVisible(), on, `${await locator.count()} expert elements: expected visibility ${on}`);
+  for (const locator of sections) assert.equal(await locator.isVisible(), on, 'expert inspector section visibility');
+  for (const locator of lanes) assert.equal(await locator.isVisible(), true, 'Animation lanes remain visible');
+  assert.equal(await page.getByRole('button', { name: 'Root path mode', exact: true }).isVisible(), on);
+  assert.equal(await page.getByRole('button', { name: '+ Add shot', exact: true }).isVisible(), on);
   assert.equal(await page.locator('.tl-ruler').isVisible(), true);
  }
  await verify(false);

--- a/test/qa-advanced-toggle-browser.mjs
+++ b/test/qa-advanced-toggle-browser.mjs
@@ -20,7 +20,7 @@ try {
   for (const locator of sections) assert.equal(await locator.isVisible(), on, 'expert inspector section visibility');
   for (const locator of lanes) assert.equal(await locator.isVisible(), true, 'Animation lanes remain visible');
   assert.equal(await page.getByRole('button', { name: 'Root path mode', exact: true }).isVisible(), on);
-  assert.equal(await page.getByRole('button', { name: '+ Add shot', exact: true }).isVisible(), on);
+  assert.equal(await page.getByRole('button', { name: '+ Add shot', exact: true }).isVisible(), true);
   assert.equal(await page.locator('.tl-ruler').isVisible(), true);
  }
  await verify(false);

--- a/test/qa-advanced-toggle-browser.mjs
+++ b/test/qa-advanced-toggle-browser.mjs
@@ -18,7 +18,9 @@ try {
  async function verify(on) {
   assert.equal(await toggle.getAttribute('aria-pressed'), String(on));
   for (const locator of sections) assert.equal(await locator.isVisible(), on, 'expert inspector section visibility');
-  for (const locator of lanes) assert.equal(await locator.isVisible(), true, 'Animation lanes remain visible');
+  assert.equal(await lanes[0].isVisible(), on, 'Prompts visibility');
+  assert.equal(await lanes[1].isVisible(), on, '2D Root visibility');
+  assert.equal(await lanes[2].isVisible(), true, 'Shots lane remains visible');
   assert.equal(await page.getByRole('button', { name: 'Root path mode', exact: true }).isVisible(), on);
   assert.equal(await page.getByRole('button', { name: '+ Add shot', exact: true }).isVisible(), true);
   assert.equal(await page.locator('.tl-ruler').isVisible(), true);

--- a/test/qa-advanced-toggle-browser.mjs
+++ b/test/qa-advanced-toggle-browser.mjs
@@ -1,0 +1,40 @@
+// QA_URL=http://localhost:5190/app/ NODE_PATH=<playwright modules> node test/qa-advanced-toggle-browser.mjs
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdir } from 'node:fs/promises';
+const { chromium } = createRequire(import.meta.url)('playwright');
+const browser = await chromium.launch({ headless: true });
+const evidence = process.env.QA_EVIDENCE || 'RESEARCH/ux-qa-20260905';
+await mkdir(evidence, { recursive: true });
+try {
+ const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+ const page = await context.newPage();
+ await page.goto(process.env.QA_URL || 'http://localhost:5190/app/', { waitUntil: 'domcontentloaded' });
+ const toggle = page.locator('.advanced-toggle');
+ await toggle.waitFor();
+ const sections = ['Rig', 'Pose', 'Video capture', 'Prompt Blocks'].map(title => page.locator('.inspector-sidebar .foldout').filter({ has: page.locator('.foldout-title', { hasText: new RegExp(`^${title}$`) }) }));
+ const lanes = ['Prompts', '2D Root', 'Shots'].map(title => page.locator('.tl-track').filter({ has: page.locator('.tl-track-label', { hasText: new RegExp(`^${title}`) }) }));
+ const expert = [...sections, ...lanes, page.getByRole('button', { name: 'Root path mode', exact: true }), page.getByRole('button', { name: '+ Add shot', exact: true })];
+ async function verify(on) {
+  assert.equal(await toggle.getAttribute('aria-pressed'), String(on));
+  for (const locator of expert) assert.equal(await locator.isVisible(), on, `${await locator.count()} expert elements: expected visibility ${on}`);
+  assert.equal(await page.locator('.tl-ruler').isVisible(), true);
+ }
+ await verify(false);
+ await page.waitForTimeout(1500);
+ await page.screenshot({ path: `${evidence}/advanced-off-1440.png` });
+ await toggle.click();
+ await page.waitForTimeout(200);
+ await verify(true);
+ await page.screenshot({ path: `${evidence}/advanced-on-1440.png` });
+ await page.reload({ waitUntil: 'domcontentloaded' });
+ await toggle.waitFor();
+ await verify(true);
+ await toggle.click();
+ await page.waitForTimeout(200);
+ await verify(false);
+ await page.reload({ waitUntil: 'domcontentloaded' });
+ await toggle.waitFor();
+ await verify(false);
+ console.log('PASS fresh default OFF, expert visibility ON/OFF, ruler retained, preference persists both ways');
+} finally { await browser.close(); }

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -268,8 +268,13 @@ expect("resize handles opt out on compact layouts", css.includes(".workspace-spl
 // place — each of them was a bug in the two-character prototype.
 expect(
 	"a character owns a Video capture foldout without a legacy ARDY card",
-	app.includes('advancedMode && <Foldout hidden={!isCharacterSelection} defaultOpen={false} title={ko("Video capture", "영상 모캡")}>') &&
+	app.includes('hidden={!advancedMode || !isCharacterSelection}') &&
+	app.includes('title={ko("Video capture", "영상 모캡")}') &&
 	!app.includes('title={ko("ARDY motion", "ARDY 모션")}'),
+);
+expect(
+	"Advanced OFF hides the Video capture foldout",
+	app.includes('localStorage?.getItem("cozyclay.advanced") === "true"'),
 );
 expect(
 	"Advanced OFF hides the Video capture foldout",

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -268,8 +268,12 @@ expect("resize handles opt out on compact layouts", css.includes(".workspace-spl
 // place — each of them was a bug in the two-character prototype.
 expect(
 	"a character owns a Video capture foldout without a legacy ARDY card",
-	app.includes('<Foldout hidden={!isCharacterSelection} defaultOpen={false} title={ko("Video capture", "영상 모캡")}>') &&
+	app.includes('advancedMode && <Foldout hidden={!isCharacterSelection} defaultOpen={false} title={ko("Video capture", "영상 모캡")}>') &&
 	!app.includes('title={ko("ARDY motion", "ARDY 모션")}'),
+);
+expect(
+	"Advanced OFF hides the Video capture foldout",
+	app.includes('hidden={!advancedMode || !isCharacterSelection}') && app.includes('localStorage?.getItem("cozyclay.advanced") === "true"'),
 );
 expect(
 	"ingest and extraction reach the ported core modules",


### PR DESCRIPTION
Closes #100

Adds a persisted Advanced/고급 top-bar toggle defaulting off for fresh browsers. Beginner mode hides Rig, Pose, Video capture, Prompt Blocks, Prompts, and 2D Root; the Animation Full-Body and Shots lanes plus + Add shot remain available. Advanced restores expert controls and Waypoint.

Visual QA evidence (1440x900):
- `RESEARCH/ux-qa-20260905/advanced-off-1440.png`
- `RESEARCH/ux-qa-20260905/advanced-on-1440.png`

Validation: `npm test` final summary: `PASS 116 Node verification files`. Live Chrome visual QA verified project creation, character selection, position edit, Advanced toggle, Waypoint, and shot creation.
