### PR TITLE
fix: consolidate Transform controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9487,7 +9487,8 @@ function resizePromptClip(id, edge, rawFrame) {
 							{ko("Motion mode · edit the timeline below", "모션 모드 · 아래 타임라인에서 편집하세요")}
 						</span>
 					)}
-						<div className="tool-switch workflow-scene-context" role="group" aria-label={ko("Gizmo tool", "기즈모 도구")}>
+						<span className="transform-toolbar-label workflow-scene-context">{ko("Transform", "변환")}</span>
+						<div className="tool-switch workflow-scene-context" role="group" aria-label={ko("Transform tools", "변환 도구")} data-transform-controls>
 							<button
 								type="button"
 								className={gizmoMode === "move" ? "active" : ""}
@@ -10421,6 +10422,22 @@ function resizePromptClip(id, edge, rawFrame) {
 						)}
 					</Foldout>
 
+				<Foldout hidden={!isCharacterSelection} title={ko("Transform", "변환")}>
+					<p className="inspector-hint">
+						{ko("Edit the selected subject's placement, turn and size. Drag the Transform tool in the viewport for direct manipulation.", "선택한 인물의 위치·회전·크기를 편집합니다. 뷰포트의 변환 도구를 드래그해 바로 조작할 수도 있어요.")}
+					</p>
+					<Vector3Row
+						label={ko("Position", "위치")}
+						fields={[
+							{ axis: "X", value: activeChar.x, step: 0.05, precision: 2, scrubRange: 5, onChange: (x) => updateCharacterAt(activeCharIndex, { x }) },
+							{ axis: "Y", value: activeChar.y ?? 0, step: 0.05, precision: 2, scrubRange: 5, onChange: (y) => updateCharacterAt(activeCharIndex, { y: Math.max(0, y) }) },
+							{ axis: "Z", value: activeChar.z, step: 0.05, precision: 2, scrubRange: 5, onChange: (z) => updateCharacterAt(activeCharIndex, { z }) },
+						]}
+					/>
+					<Slider compact label={ko("Rotation", "회전")} min={-180} max={180} step={1} value={activeChar.rot ?? 0} unit="°" onChange={(rot) => updateCharacterAt(activeCharIndex, { rot })} />
+					<Slider compact label={ko("Scale", "크기")} min={0.2} max={3} step={0.05} value={activeChar.scale ?? 1} unit="×" onChange={(scale) => updateCharacterAt(activeCharIndex, { scale })} />
+				</Foldout>
+
 				{/* Rig and Pose are chosen once when a character is cast and then left
 				    alone, so they open on demand — Subject and Prompt are the panels
 				    you actually work in. */}
@@ -11320,7 +11337,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					</div>
 					</Foldout>
 
-				<Foldout hidden={!selectedSceneObject} title={ko("Object Transform", "오브젝트 변환")}>
+				<Foldout hidden={!selectedSceneObject} title={ko("Transform", "변환")}>
 						{selectedSceneObject && (
 							<>
 								<p className="inspector-hint">
@@ -12430,7 +12447,6 @@ function Foldout({ title, hidden, defaultOpen = true, openSignal = 0, children }
 }
 
 function SubjectBox({ label, value, onChange, onRemove, onPose, posing, color, onColorChange, onColorEditStart }) {
-	const set = (key) => (v) => onChange((prev) => ({ ...prev, [key]: v }));
 	return (
 		<div className="subject-box">
 			<div className="subject-box-head">
@@ -12471,15 +12487,6 @@ function SubjectBox({ label, value, onChange, onRemove, onPose, posing, color, o
 					)}
 				</div>
 			</div>
-			<Vector3Row
-				label={ko("Position", "위치")}
-				fields={[
-					{ axis: "X", value: value.x, step: 0.05, precision: 2, onChange: (x) => set("x")(x) },
-					{ axis: "Y", value: value.y ?? 0, step: 0.05, precision: 2, onChange: (y) => set("y")(Math.max(0, y)) },
-					{ axis: "Z", value: value.z, step: 0.05, precision: 2, onChange: (z) => set("z")(z) },
-				]}
-			/>
-			<Slider compact label={ko("Rotate", "회전")} min={-180} max={180} step={1} value={value.rot} unit="°" onChange={set("rot")} />
 		</div>
 	);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -8344,6 +8344,20 @@ input[type=range] {
 	background: transparent;
 }
 
+/* Direct manipulation and numeric fields share the Transform concept. Keep
+   the name visible beside the icon-only tool buttons so the beginner path has
+   one vocabulary for both ways of editing a selection. */
+.editor-toolbar.scene-tools .transform-toolbar-label {
+	align-self: center;
+	flex: none;
+	padding: 0 8px;
+	color: var(--muted);
+	font-size: 9px;
+	font-weight: 700;
+	letter-spacing: .04em;
+	text-transform: uppercase;
+}
+
 .editor-toolbar.scene-tools .tool-switch button,
 .editor-toolbar.scene-tools .snap-switch {
 	height: 26px;

--- a/test/verify-korean-ui.mjs
+++ b/test/verify-korean-ui.mjs
@@ -120,7 +120,7 @@ for (const path of ["src/result-modal.jsx", "src/hierarchy-panel.jsx", "src/obje
 // The PR's Korean copy is preserved, now living inside the locale constructs.
 includesAll("src/locale-toggle.jsx", ["한국어로 전환", "한국어", "Switch to English"]);
 includesAll("src/result-modal.jsx", ["장면이 준비됐어요", "프롬프트 복사", "프레임 다운로드", "AI에 넣는 순서", "AI에 이미지 첨부"]);
-includesAll("src/App.jsx", ["장면", "재생 보기", "속성", "모션 생성", "오브젝트 변환", "카메라 레일 완성", "연결 중…"]);
+includesAll("src/App.jsx", ["장면", "재생 보기", "속성", "모션 생성", "변환", "카메라 레일 완성", "연결 중…"]);
 includesAll("src/ardy/client.js", ["브리지 상태가 좋지 않아요", "브리지에 연결할 수 없어요", "생성 응답에 본문 스트림이 없어요"]);
 includesAll("src/hierarchy-panel.jsx", ["이름 바꾸기", "장면 구조", "장면 계층", "프레임 맞추기", "장면 문서", "+ 새 장면", "장면은 최소 하나 필요합니다"]);
 includesAll("src/ardy/timeline.jsx", ["애니메이션 타임라인", "프롬프트", "타임라인 펼치기"]);

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -238,14 +238,14 @@ expect(
 // and the readout shows the true stored value. Both write paths (head
 // scrub, viewport gizmo) agree on max(0, y).
 expect(
-	"Subject position uses the same X Y Z numeric row as scene objects",
-	app.includes('label={ko("Position", "위치")}') &&
-		app.includes('{ axis: "X", value: value.x, step: 0.05') &&
-		app.includes('{ axis: "Y", value: value.y ?? 0, step: 0.05') &&
-		app.includes('{ axis: "Z", value: value.z, step: 0.05') &&
-		!app.includes('<Slider compact label={ko("Left / right", "좌 / 우")}') &&
-		!app.includes('<Slider compact softMax label={ko("Height", "높이")}') &&
-		!app.includes('<Slider compact label={ko("Depth", "깊이")}'),
+	"Subject transforms have one inspector home with the direct tools",
+	app.includes('<Foldout hidden={!isCharacterSelection} title={ko("Transform", "변환")}>') &&
+	app.includes('{ axis: "X", value: activeChar.x, step: 0.05') &&
+	app.includes('{ axis: "Y", value: activeChar.y ?? 0, step: 0.05') &&
+	app.includes('{ axis: "Z", value: activeChar.z, step: 0.05') &&
+	app.includes('label={ko("Rotation", "회전")}') &&
+	app.includes('label={ko("Scale", "크기")}') &&
+	app.includes('data-transform-controls'),
 );
 expect(
 	"the character gizmo no longer caps lift at 4 m",


### PR DESCRIPTION
## Summary
- give the viewport gizmo tools and inspector fields one visible Transform vocabulary
- move character placement, rotation, and scale values into a dedicated Transform inspector foldout
- keep object transform values under the same Transform heading and preserve direct gizmo operations

## Validation
- `npm run build`
- `node test/verify-layout.mjs`
- `node test/verify-scene-objects.mjs`
- visual QA in the local Studio at 1600x1000: Transform toolbar label, character Transform panel, Rotate/Scale selection, and object Transform inspector

Closes #101
