### PR TITLE
fix(ux): standardize labels and icon tooltips

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9383,7 +9383,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					</button>
 					{liveWorkspaceHandle && (
 						<span className="live-workspace-handle" data-live-workspace={liveWorkspaceHandle} title={liveWorkspaceHandle}>
-							Live workspace {liveWorkspaceHandle}
+							{ko("Live workspace", "라이브 작업공간")} {liveWorkspaceHandle}
 						</span>
 					)}
 					<LocaleToggle />
@@ -9603,18 +9603,31 @@ function resizePromptClip(id, edge, rawFrame) {
 						<span className="viewport-readout">FOV {Math.round(fovDeg)}° · {shot.focalMm}mm</span>
 						<span className="viewport-toolbar-spacer" />
 						<button type="button" onClick={() => stepFrame(-1)} aria-label={ko("Previous frame", "이전 프레임")}>◀</button>
-						<button type="button" onClick={() => setTlPlaying((value) => !value)}>
+						<button
+							type="button"
+							aria-label={tlPlaying ? ko("Pause playback", "재생 일시중지") : ko("Play playback", "재생 시작")}
+							title={tlPlaying ? ko("Pause playback", "재생 일시중지") : ko("Play playback", "재생 시작")}
+							onClick={() => setTlPlaying((value) => !value)}
+						>
 							{tlPlaying ? "Ⅱ" : "▶"}
 						</button>
 						<button type="button" onClick={() => stepFrame(1)} aria-label={ko("Next frame", "다음 프레임")}>▶│</button>
 						<span className="viewport-readout">1.00×</span>
 						<span className="viewport-toolbar-separator" aria-hidden="true" />
-						<button type="button" disabled={!shots.length} onClick={downloadOtioCutList}>
+						<button
+							type="button"
+							disabled={!shots.length}
+							aria-label={ko("Download OTIO cut list", "OTIO 컷 목록 다운로드")}
+							title={ko("Download OTIO cut list", "OTIO 컷 목록 다운로드")}
+							onClick={downloadOtioCutList}
+						>
 							OTIO
 						</button>
 						<button
 							type="button"
 							className={recState === "recording" ? "recording" : ""}
+							aria-label={recState === "recording" ? ko("Stop recording", "녹화 중지") : ko("Record shot", "샷 녹화")}
+							title={recState === "recording" ? ko("Stop recording", "녹화 중지") : ko("Record shot", "샷 녹화")}
 							disabled={recState !== "recording" && !hasCameraKeys && !motion}
 							onClick={toggleShotRecording}
 						>
@@ -12458,6 +12471,7 @@ function SubjectBox({ label, value, onChange, onRemove, onPose, posing, color, o
 						<button
 							type="button"
 							className={"cam-toggle" + (posing ? " active" : "")}
+							aria-label={isKo ? `${label} 포즈 열기` : `Open pose studio for ${label}`}
 							title={isKo ? `${label} 포즈` : `Pose ${label}`}
 							onClick={onPose}
 						>

--- a/test/verify-label-tooltips.mjs
+++ b/test/verify-label-tooltips.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Issue #102: labels use the selected locale and icon-only actions explain
+// themselves to both mouse and keyboard users.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+
+assert.match(app, /ko\("Live workspace", "라이브 작업공간"\)/, "workspace status needs a Korean label");
+assert.match(app, /aria-label=\{tlPlaying \? ko\("Pause playback", "재생 일시중지"\) : ko\("Play playback", "재생 시작"\)\}/, "PlayView icon needs an accessible name");
+assert.match(app, /title=\{tlPlaying \? ko\("Pause playback", "재생 일시중지"\) : ko\("Play playback", "재생 시작"\)\}/, "PlayView icon needs a tooltip");
+assert.match(app, /aria-label=\{ko\("Download OTIO cut list", "OTIO 컷 목록 다운로드"\)\}/, "OTIO export needs a descriptive label");
+assert.match(app, /title=\{ko\("Download OTIO cut list", "OTIO 컷 목록 다운로드"\)\}/, "OTIO export needs a tooltip");
+assert.match(app, /aria-label=\{isKo \? `\$\{label\} 포즈 열기` : `Open pose studio for \$\{label\}`\}/, "pose glyph needs an accessible name");
+assert.match(app, /title=\{isKo \? `\$\{label\} 포즈` : `Pose \$\{label\}`\}/, "pose glyph keeps a visible tooltip");
+
+console.log("label and icon tooltip checks PASS");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -74,6 +74,7 @@ const NODE_FILES = [
 	"test/verify-motion-trail.mjs",
 	"test/verify-kimodo-waypoints.mjs",
 	"test/verify-korean-ui.mjs",
+	"test/verify-label-tooltips.mjs",
 	"test/verify-layout.mjs",
 	"test/verify-line-edit-draw.mjs",
 	"test/verify-line-edit-pins.mjs",


### PR DESCRIPTION
## Summary
- localize the live workspace status in Korean mode
- give PlayView playback, OTIO export, recording, and pose glyph controls accessible names and native tooltips
- add a regression check for issue #102 and include it in the test manifest

## Validation
- `npm test` (117 Node verification files passed; browser suites excluded because the QA wrapper is not part of this checkout)
- Browser QA on `http://127.0.0.1:5183/app/` in English and Korean modes: PlayView controls expose localized names; pose glyph exposes a localized name and tooltip; screenshot captured during verification.
