### PR TITLE
fix(package): verify npm tarball signature contents

### DIFF
--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -37,6 +37,7 @@ import {
 } from "./telemetry-state.mjs";
 
 const PKG_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const SOURCE_CHECKOUT = existsSync(join(PKG_ROOT, ".git"));
 let packageMetadata = {};
 try {
 	packageMetadata = JSON.parse(readFileSync(join(PKG_ROOT, "package.json"), "utf8"));
@@ -47,7 +48,7 @@ const DIST = join(PKG_ROOT, "dist");
 const BRIDGE = join(PKG_ROOT, "tools", "ardy", "bridge.mjs");
 const OFFICIAL_PACKAGE = (
 	packageMetadata.name === "cozyclay"
-	&& !existsSync(join(PKG_ROOT, ".git"))
+	&& !SOURCE_CHECKOUT
 	&& verifyPackageMarker(join(DIST, "cozyclay-package.json"), PKG_ROOT, packageMetadata)
 );
 // A bridge is optional. Keep the endpoint unset until this launcher owns a
@@ -262,7 +263,7 @@ if (argv[0] === "mcp") {
 	const state = readTelemetryState(STATE_FILE);
 	const effective = OFFICIAL_PACKAGE && effectiveTelemetryEnabled(state);
 	const reason = !OFFICIAL_PACKAGE
-		? " (source checkout)"
+		? ` (${SOURCE_CHECKOUT ? "source checkout" : "unofficial package: digest mismatch"})`
 		: state.telemetryEnabled && !effective
 			? " (environment override)"
 			: "";

--- a/bin/package-signature.mjs
+++ b/bin/package-signature.mjs
@@ -28,6 +28,8 @@ const CONTENT_ROOTS = [
 function ignored(relativePath) {
 	return relativePath === "dist/cozyclay-package.json"
 		|| (/^dist\/media\/[^/]+\.mp4$/i.test(relativePath))
+		|| relativePath === "dist/demo/index.html"
+		|| relativePath === "dist/d/index.html"
 		|| relativePath.startsWith("tools/ardy/out/")
 		|| /^tools\/qa-[^/]+\.mjs$/i.test(relativePath);
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:korean-ui": "node test/verify-korean-ui.mjs",
     "prepack": "npm run build && node tools/prepare-package.mjs",
     "postpack": "node tools/prepare-package.mjs --clean",
-    "prepublishOnly": "node tools/prepare-package.mjs --check-key",
+    "prepublishOnly": "npm run build && node tools/prepare-package.mjs --check-key && node tools/prepare-package.mjs && node tools/verify-package-tarball.mjs",
     "metrics:traffic": "node tools/metrics/archive-traffic.mjs",
     "test:multimodel": "node test/verify-multimodel-ingest.mjs",
     "test:video-frames": "node test/verify-video-frames.mjs",

--- a/test/verify-package-signature.mjs
+++ b/test/verify-package-signature.mjs
@@ -9,7 +9,11 @@ import { computePackageDigest, verifyPackageMarker } from "../bin/package-signat
 
 const directory = mkdtempSync(join(tmpdir(), "cozyclay-package-signature-"));
 mkdirSync(join(directory, "dist"));
+mkdirSync(join(directory, "dist", "demo"));
+mkdirSync(join(directory, "dist", "d"));
 writeFileSync(join(directory, "README.md"), "signed package\n");
+writeFileSync(join(directory, "dist", "demo", "index.html"), "demo build\n");
+writeFileSync(join(directory, "dist", "d", "index.html"), "d build\n");
 const marker = join(directory, "dist", "cozyclay-package.json");
 const metadata = { version: "1.5.0" };
 const { privateKey, publicKey } = generateKeyPairSync("ed25519");
@@ -28,6 +32,14 @@ try {
 		signature: sign(null, Buffer.from(payload), privateKey).toString("base64"),
 	}));
 	assert.equal(verifyPackageMarker(marker, directory, metadata, publicDer), true);
+
+	writeFileSync(join(directory, "dist", "demo", "index.html"), "rebuilt demo\n");
+	writeFileSync(join(directory, "dist", "d", "index.html"), "rebuilt d\n");
+	assert.equal(
+		verifyPackageMarker(marker, directory, metadata, publicDer),
+		true,
+		"files excluded by package.json#files do not invalidate the package marker",
+	);
 
 	writeFileSync(join(directory, "README.md"), "forked package\n");
 	assert.equal(verifyPackageMarker(marker, directory, metadata, publicDer), false, "modified package content is rejected");

--- a/tools/verify-package-tarball.mjs
+++ b/tools/verify-package-tarball.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const temporaryRoot = mkdtempSync(join(tmpdir(), "cozyclay-package-check-"));
+const extractionRoot = join(temporaryRoot, "extracted");
+
+try {
+	mkdirSync(extractionRoot);
+	execFileSync("npm", [
+		"pack",
+		"--ignore-scripts",
+		"--pack-destination", temporaryRoot,
+	], { cwd: packageRoot, stdio: "pipe" });
+
+	const tarball = readdirSync(temporaryRoot)
+		.filter((entry) => entry.endsWith(".tgz"))
+		.map((entry) => join(temporaryRoot, entry))[0];
+	if (!tarball) throw new Error("npm pack did not produce a tarball");
+	execFileSync("tar", ["-xzf", tarball, "-C", extractionRoot]);
+
+	const packedRoot = join(extractionRoot, "package");
+	const metadataPath = join(packedRoot, "package.json");
+	const markerPath = join(packedRoot, "dist", "cozyclay-package.json");
+	const signatureModulePath = join(packedRoot, "bin", "package-signature.mjs");
+	if (!existsSync(metadataPath) || !existsSync(markerPath) || !existsSync(signatureModulePath)) {
+		throw new Error("npm tarball is missing package metadata or its signature marker");
+	}
+	const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+	const { verifyPackageMarker } = await import(pathToFileURL(signatureModulePath).href);
+	if (!verifyPackageMarker(markerPath, packedRoot, metadata)) {
+		throw new Error("npm tarball signature digest does not match the files npm ships");
+	}
+	console.log(`package tarball signature PASS (${metadata.name}@${metadata.version})`);
+} finally {
+	rmSync(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

Fix npm package signature drift that made CozyClay 1.7.0 installs report `officialPackage=false` and silently disable telemetry.

- Align `computePackageDigest()` with `package.json#files` exclusions for `dist/demo/index.html` and `dist/d/index.html`.
- Add a `prepublishOnly` guard that builds/signs, packs with npm, extracts the tarball, and verifies the shipped marker before publishing.
- Make `cclay telemetry status` explain invalid packaged markers as `unofficial package: digest mismatch`.
- Add a regression test proving excluded build pages do not invalidate the marker.

## Validation

- `npm test` (116 Node verification files): PASS
- `npm run prepublishOnly`: PASS (`package tarball signature PASS (cozyclay@1.7.0)`)
- `node test/verify-package-signature.mjs`: PASS
- `node test/verify-telemetry-state.mjs`: PASS
