### PR TITLE
feat: expose Save and Export in top bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2827,6 +2827,7 @@ globalThis.playMode = centerTab === "play";
 	 * cache; the file is the portable, user-owned document. */
 	const [projectName, setProjectName] = useState(() => loadProjectSession()?.name ?? null);
 	const [projectDirty, setProjectDirty] = useState(false);
+	const [projectSaveState, setProjectSaveState] = useState("idle");
 	const [projectMenuOpen, setProjectMenuOpen] = useState(false);
 	const [projectBrowserOpen, setProjectBrowserOpen] = useState(false);
 	const [projectNameDialog, setProjectNameDialog] = useState(null);
@@ -2936,6 +2937,7 @@ globalThis.playMode = centerTab === "play";
 			setProjectNameDialog({ kind: "save", initialName: "My Project" });
 			return;
 		}
+		setProjectSaveState("saving");
 		const name = (explicitName ?? projectName ?? "My Project").trim() || "My Project";
 		try {
 			const serialized = await collectProjectSerialized(name);
@@ -2953,9 +2955,14 @@ globalThis.playMode = centerTab === "play";
 				await writeProjectFile(handle, serialized);
 			}
 			markProjectClean(name);
+			setProjectSaveState("saved");
 			setToast(isKo ? `프로젝트 저장됨: ${name}${PROJECT_EXTENSION}` : `Project saved: ${name}${PROJECT_EXTENSION}`);
 		} catch (err) {
-			if (err?.name === "AbortError") return; // user closed the picker
+			if (err?.name === "AbortError") {
+				setProjectSaveState(projectDirty ? "dirty" : "saved");
+				return; // user closed the picker
+			}
+			setProjectSaveState("error");
 			setToast(ko("Could not save the project", "프로젝트를 저장하지 못했어요"));
 		}
 	}
@@ -3736,7 +3743,9 @@ globalThis.playMode = centerTab === "play";
 	useEffect(() => {
 		if (projectName === null) return; // untitled sessions are never "dirty"
 		const serialized = collectProjectSnapshot(projectName);
-		setProjectDirty(serialized !== projectSnapshotRef.current);
+		const dirty = serialized !== projectSnapshotRef.current;
+		setProjectDirty(dirty);
+		setProjectSaveState((current) => current === "saving" ? current : dirty ? "dirty" : "saved");
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [scenes, activeSceneId, workspaceLayout, customPoses, characters, shots, waypoints, promptClips, projectName, keyLight, sceneObjects, shotAspectKey, sensorId, tlFrameCount]);
 	const [selectedPromptId, setSelectedPromptId] = useState(null);
@@ -9335,6 +9344,16 @@ function resizePromptClip(id, edge, rawFrame) {
 		ardyAbortRef.current?.abort();
 	}
 
+	const projectStatus = projectSaveState === "saving"
+		? ko("Saving…", "저장 중…")
+		: projectSaveState === "error"
+			? ko("Save failed", "저장 실패")
+			: projectName === null
+				? ko("Not saved", "저장되지 않음")
+				: projectDirty
+					? ko("Unsaved changes", "저장되지 않은 변경사항")
+					: ko("Saved", "저장됨");
+
 	return (
 		<div className={"app" + (renderActive ? "" : " render-idle")} data-workflow-mode={workflowMode}>
 			<header className="topbar">
@@ -9364,6 +9383,35 @@ function resizePromptClip(id, edge, rawFrame) {
 					)}
 				</div>
 				<div className="topbar-actions">
+					<div className="project-actions" aria-label={ko("Project actions", "프로젝트 작업")}>
+						<button
+							type="button"
+							className="topbar-action project-save-action"
+							data-testid="topbar-save"
+							disabled={projectSaveState === "saving"}
+							onClick={() => void saveProject(false)}
+						>
+							{projectSaveState === "saving" ? ko("Saving…", "저장 중…") : ko("Save", "저장")}
+						</button>
+						<button
+							type="button"
+							className={"topbar-action project-export-action" + (recState === "recording" ? " recording" : "")}
+							data-testid="topbar-export"
+							disabled={recState !== "recording" && !hasCameraKeys && !motion}
+							onClick={toggleShotRecording}
+							title={ko("Export the current shot as an MP4", "현재 샷을 MP4로 내보내기")}
+						>
+							{recState === "recording" ? ko("■ Stop", "■ 정지") : ko("Export", "내보내기")}
+						</button>
+						<span
+							className={"project-save-status status-" + projectSaveState}
+							data-testid="project-save-status"
+							role="status"
+							aria-live="polite"
+						>
+							{projectStatus}
+						</span>
+					</div>
 					<button
 						type="button"
 						className="auto-color-toggle"

--- a/src/styles.css
+++ b/src/styles.css
@@ -176,6 +176,69 @@ select {
 	gap: 6px;
 }
 
+.project-actions {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	margin-right: 4px;
+	padding-right: 10px;
+	border-right: 1px solid var(--line2);
+}
+
+.topbar-action {
+	min-height: 28px;
+	padding: 3px 10px;
+	border: 1px solid var(--line2);
+	border-radius: 5px;
+	background: var(--card2);
+	color: var(--fg);
+	font-size: 12px;
+	font-weight: 650;
+	cursor: pointer;
+}
+
+.topbar-action:hover:not(:disabled) {
+	border-color: var(--accent);
+	background: var(--hover);
+}
+
+.topbar-action:disabled {
+	opacity: .55;
+	cursor: not-allowed;
+}
+
+.project-save-action {
+	background: var(--accent);
+	border-color: var(--accent);
+	color: #20180d;
+}
+
+.project-save-action:hover:not(:disabled) {
+	background: #f2c56d;
+	border-color: #f2c56d;
+}
+
+.project-export-action.recording {
+	border-color: #e87878;
+	color: #ffb1b1;
+}
+
+.project-save-status {
+	min-width: 74px;
+	color: var(--muted2);
+	font-size: 11px;
+	white-space: nowrap;
+}
+
+.project-save-status.status-dirty,
+.project-save-status.status-error {
+	color: #f5b453;
+}
+
+.project-save-status.status-saving {
+	color: #79c0ff;
+}
+
 /* Project menu (game-engine file workflow) */
 .project-menu-wrap {
 	position: relative;

--- a/test/verify-project-menu-browser.mjs
+++ b/test/verify-project-menu-browser.mjs
@@ -107,6 +107,12 @@ const openMenu = async () => {
 
 // Boot: wait for the studio topbar; the app document may still be loading.
 expect("the topbar renders the project menu trigger", await waitFor("!!document.querySelector('.project-menu-trigger')", 30000));
+expect("the topbar renders a direct Save action", await waitFor("!!document.querySelector('[data-testid=topbar-save]')"));
+expect("the topbar renders a direct Export action", await waitFor("!!document.querySelector('[data-testid=topbar-export]')"));
+expect(
+	"the topbar exposes an understandable save status",
+	Boolean(await evaluate("document.querySelector('[data-testid=project-save-status]')?.textContent.trim()")),
+);
 expect("the menu starts closed", !(await menuOpen()));
 
 /* ------------------------------------------------ Escape closes ------ */


### PR DESCRIPTION
## Summary
- expose direct Save and Export actions in the fixed top bar
- show readable save status for saved, unsaved, saving, and failed states
- keep existing project menu and PlayView export workflow available
- extend the browser contract to verify the new primary chrome

## Validation
- `npm test`
- `npm run test:project-menu`
- visual QA at `http://127.0.0.1:5180/app/` (1920px): Save, Export, and Unsaved changes are visible in the top bar

Resolves #99
