### PR TITLE
feat(analytics): record motion backend availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Events collected:
 | `scene:created` | Funnel and drop-off analysis |
 | `scene:loaded` | Funnel and drop-off analysis |
 | `craft:first_action` | Funnel and drop-off analysis |
+| `motion:backend_state` | Motion capability at session start (`none`, `local_kimodo`, or `hosted`) |
+| `motion:generate_blocked` | Generate intent when no motion backend is available |
 | `motion:job_started` | Motion reliability |
 | `motion:job_succeeded` | Motion reliability |
 | `motion:job_failed` | Motion reliability |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -235,7 +235,7 @@ import {
 	MAX_PATH_POINTS,
 } from "./object-path.js";
 import LocaleToggle from "./locale-toggle.jsx";
-import { bucketMs, track, trackActivation } from "./analytics.js";
+import { bucketMs, motionBackendState, track, trackActivation } from "./analytics.js";
 import { ko, isKo } from "./locale.js";
 import {
 	DEFAULT_POSE,
@@ -6428,7 +6428,14 @@ globalThis.playMode = centerTab === "play";
 		};
 	}, []);
 
-	function addPromptClip(frame) {
+	function trackGenerateBlocked(surface = "timeline") {
+		if (motionBackendState(bridge).backend === "none") {
+			track("motion:generate_blocked", { surface });
+		}
+	}
+
+	function addPromptClip(frame, surface = "timeline") {
+		trackGenerateBlocked(surface);
 		const snapped = Math.max(0, Math.round(frame / ARDY_PROMPT_HORIZON_FRAMES) * ARDY_PROMPT_HORIZON_FRAMES);
 		// Add at the playhead when the spot is free; only fall through to
 		// after-the-last-block when the playhead slot is taken. The old
@@ -8297,6 +8304,7 @@ function resizePromptClip(id, edge, rawFrame) {
 	 * curve as the last preview; only `preview: true` is absent, which is what
 	 * buys the full step count. */
 	function runLineEdit() {
+		trackGenerateBlocked("timeline");
 		if (ardyRunning) return;
 		if (!takeSourceUrl) {
 			setToast(ko("The current take has no bridge source — generate it once before editing a path", "현재 테이크에 브리지 원본이 없어요 — 궤적을 편집하기 전에 한 번 생성하세요"));
@@ -8390,6 +8398,7 @@ function resizePromptClip(id, edge, rawFrame) {
 		// the current take's lineage and carries both.
 		fresh = false,
 	} = {}) {
+		trackGenerateBlocked("timeline");
 		// A line-edit draft is not a take, and every source this function reads
 		// (preserve, motionEdit, the recipe) is about THE take. Refusing here is
 		// the last line of defence behind sceneDisabledReason, which already
@@ -8825,6 +8834,7 @@ function resizePromptClip(id, edge, rawFrame) {
 	 * keys inside the window ride as hard constraints (their tracks), and the
 	 * deformed line contributes the grab-frame pose as a root guide. */
 	function runTrailRegeneration() {
+		trackGenerateBlocked("timeline");
 		if (!trailEdit || ardyRunning) return;
 		// Same rule as runArdy: motionEdit rewrites a span of THE take, and a
 		// draft on the viewport is not it.
@@ -8951,8 +8961,9 @@ function resizePromptClip(id, edge, rawFrame) {
 		// Replay notices belong to ONE run; the next run re-earns them.
 		setReplayNotices([]);
 		const inputMode = job.hasBlockEdits ? "edit" : job.body.posePin ? "pose" : "prompt";
+		const backend = motionBackendState(bridge).backend;
 		const startedAt = Date.now();
-		track("motion:job_started", { input_mode: inputMode });
+		track("motion:job_started", { backend, input_mode: inputMode });
 		let editCommitReport = null;
 		try {
 			const done = await ardyGenerate(
@@ -8987,7 +8998,7 @@ function resizePromptClip(id, edge, rawFrame) {
 				throw new Error(ko("ARDY returned motion without verified authored IK keys", "ARDY가 검증된 수동 IK 키 없이 모션을 반환했어요"));
 			}
 			setArdyOutcome({ ok: true, output: done.output, bytes: done.bytes, motionUrl: done.motionUrl, rotationDeg: job.rootRotationDeg });
-			track("motion:job_succeeded", { latency_bucket: bucketMs(Date.now() - startedAt), input_mode: inputMode });
+			track("motion:job_succeeded", { backend, duration_bucket: bucketMs(Date.now() - startedAt), input_mode: inputMode });
 			trackActivation("motion");
 			// Fetch and decode the real npz right away; decode errors are shown
 			// in the card, playback is never faked. The clip lands on the
@@ -9024,7 +9035,8 @@ function resizePromptClip(id, edge, rawFrame) {
 				message: err?.name === "AbortError" ? ko("Cancelled", "취소됨") : err?.message || String(err),
 			});
 			track("motion:job_failed", {
-				latency_bucket: bucketMs(Date.now() - startedAt),
+				backend,
+				duration_bucket: bucketMs(Date.now() - startedAt),
 				input_mode: inputMode,
 				error_code: err?.name === "AbortError" ? "aborted" : (err?.name || "error"),
 			});

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -10,9 +10,11 @@ const EVENT_PROPERTIES = Object.freeze({
 	"scene:created": ["scene_source"],
 	"scene:loaded": ["scene_source"],
 	"craft:first_action": ["action_kind"],
-	"motion:job_started": ["input_mode"],
-	"motion:job_succeeded": ["latency_bucket", "input_mode"],
-	"motion:job_failed": ["latency_bucket", "input_mode", "error_code"],
+	"motion:backend_state": ["backend", "host_configured"],
+	"motion:generate_blocked": ["surface"],
+	"motion:job_started": ["backend", "input_mode", "duration_bucket"],
+	"motion:job_succeeded": ["backend", "duration_bucket", "input_mode"],
+	"motion:job_failed": ["backend", "duration_bucket", "input_mode", "error_code"],
 	"export:blocking_frame_succeeded": ["format"],
 	"export:video_succeeded": ["format"],
 	"sample:played": ["from"],
@@ -85,6 +87,30 @@ export function sanitizeProps(event, props) {
 		if (isSafePropertyValue(props[key])) sanitized[key] = props[key];
 	}
 	return sanitized;
+}
+
+/**
+ * Convert the bridge health payload into the analytics contract. The bridge
+ * only exposes a safe location label; the configured host itself never leaves
+ * the local process. A missing/unhealthy bridge is the useful `none` bucket.
+ */
+export function motionBackendState(health) {
+	if (!health || health.ok !== true) return { backend: "none", host_configured: false };
+	if (typeof health.backend === "string" && ["none", "local_kimodo", "hosted"].includes(health.backend)) {
+		return {
+			backend: health.backend,
+			host_configured: health.host_configured === true
+				|| (typeof health.host === "string" && health.host.trim().length > 0),
+		};
+	}
+	const host = typeof health.host === "string" ? health.host.trim() : "";
+	return {
+		// The current /ardy bridge is the local Kimodo integration even when it
+		// dispatches to a configured GPU box over SSH. A future hosted API can
+		// opt into the explicit `backend: "hosted"` field above.
+		backend: "local_kimodo",
+		host_configured: Boolean(host),
+	};
 }
 
 export function bucketMs(ms) {
@@ -357,13 +383,31 @@ export async function initAnalytics() {
 			posthog.capture("$pageview");
 			if (resolved.distribution === "npm") {
 				track("app:session_started");
+				// This follows the session marker so the two events form one
+				// capability baseline in funnel queries.
+				void recordMotionBackendState();
 				if (resolved.firstLaunch) track("install:first_launch");
+			} else {
+				// Hosted sessions have PostHog's native session marker rather than
+				// the npm-only custom event above.
+				void recordMotionBackendState();
 			}
 		} catch {
 			console.info("[analytics] initialization failed");
 		}
 	})();
 	await initPromise;
+}
+
+async function recordMotionBackendState() {
+	let health = null;
+	try {
+		const response = await fetch("/ardy/health", { signal: AbortSignal.timeout(5000) });
+		if (response.ok) health = await response.json();
+	} catch {
+		// No bridge is a normal hosted/demo state.
+	}
+	track("motion:backend_state", motionBackendState(health));
 }
 
 export function track(event, props = {}) {

--- a/test/verify-analytics.mjs
+++ b/test/verify-analytics.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
 	bucketMs,
 	scrubEventUrls,
@@ -7,6 +8,7 @@ import {
 	normalizeOrigin,
 	parseAllowlist,
 	resolveAnalyticsRuntime,
+	motionBackendState,
 	sanitizeProps,
 } from "../src/analytics.js";
 
@@ -29,13 +31,14 @@ assert.equal(isOriginAllowed("https://cozyclay.org.evil.example", allowlist), fa
 
 assert.deepEqual(
 	sanitizeProps("motion:job_succeeded", {
-		latency_bucket: "1-3s",
+		backend: "hosted",
+		duration_bucket: "1-3s",
 		input_mode: "pose",
 		prompt: "secret prompt",
 		name: "private name",
 		unknown: "discarded",
 	}),
-	{ latency_bucket: "1-3s", input_mode: "pose" },
+	{ backend: "hosted", duration_bucket: "1-3s", input_mode: "pose" },
 );
 assert.deepEqual(
 	sanitizeProps("scene:created", {
@@ -49,13 +52,29 @@ assert.deepEqual(
 );
 assert.deepEqual(
 	sanitizeProps("motion:job_failed", {
-		latency_bucket: "gte30s",
+		backend: "local_kimodo",
+		duration_bucket: "gte30s",
 		input_mode: true,
 		error_code: 503,
 	}),
-	{ latency_bucket: "gte30s", input_mode: true, error_code: 503 },
+	{ backend: "local_kimodo", duration_bucket: "gte30s", input_mode: true, error_code: 503 },
 );
 assert.deepEqual(sanitizeProps("motion:job_failed", { error_code: Number.POSITIVE_INFINITY }), {});
+assert.deepEqual(motionBackendState(null), { backend: "none", host_configured: false });
+assert.deepEqual(motionBackendState({ ok: true, host: "local" }), { backend: "local_kimodo", host_configured: true });
+assert.deepEqual(motionBackendState({ ok: true, host: "user@gpu-box" }), { backend: "local_kimodo", host_configured: true });
+assert.deepEqual(motionBackendState({ ok: true, backend: "hosted", host_configured: false }), { backend: "hosted", host_configured: false });
+assert.deepEqual(
+	sanitizeProps("motion:backend_state", { backend: "hosted", host_configured: true, host: "user@gpu-box" }),
+	{ backend: "hosted", host_configured: true },
+);
+assert.deepEqual(sanitizeProps("motion:generate_blocked", { surface: "timeline", prompt: "private" }), { surface: "timeline" });
+
+const appSource = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+assert.match(appSource, /motion:job_started.*backend/);
+assert.match(appSource, /motion:job_succeeded[\s\S]*?duration_bucket/);
+assert.match(appSource, /motion:job_failed[\s\S]*?duration_bucket/);
+assert.doesNotMatch(appSource, /latency_bucket/);
 
 assert.equal(bucketMs(0), "lt1s");
 assert.equal(bucketMs(999), "lt1s");


### PR DESCRIPTION
## Summary
- record `motion:backend_state` once at session start with safe backend and host-configured properties
- record blocked Generate/prompt-block intent when no motion backend is available
- add backend and `duration_bucket` to motion job events, replacing `latency_bucket`
- keep host names and prompt text out of the allowlisted analytics payload

Closes #105

## Validation
- `npm run test:analytics`
- `npm test` (116 Node verification files passed; browser/MCP dependency suites excluded by the repository test manifest)
- `npm run build`
