### PR TITLE
feat(ui): add beginner first-shot entry screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1039,6 +1039,7 @@ globalThis.playMode = centerTab === "play";
 		const next = !advancedMode;
 		try { globalThis.localStorage?.setItem("cozyclay.advanced", String(next)); } catch {}
 		setAdvancedMode(next);
+		if (!next) setSelectedHierarchyId("characterA");
 	}
 	function selectWorkflowMode(next) {
 		setWorkflowMode(next);
@@ -9482,6 +9483,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					sceneObjects={sceneObjects}
 					scenes={scenes}
 					activeSceneId={activeSceneId}
+					beginnerMode={!advancedMode}
 					onSceneSelect={selectSceneDocument}
 					onSceneCreate={createSceneDocumentFromUi}
 					onSceneDuplicate={duplicateSceneDocumentFromUi}
@@ -10417,7 +10419,7 @@ function resizePromptClip(id, edge, rawFrame) {
 
 					{/* Camera animation is authored against the same playhead as motion,
 					    so keep its controls beside the Motion tools as well as Shot setup. */}
-					<Foldout hidden={!keyLightSelected} title={ko("Light", "조명")}>
+					<Foldout hidden={!advancedMode || !keyLightSelected} title={ko("Light", "조명")}>
 						<p className="hint">{ko("Drag the sun in the scene to move the light. Shadows and warmth follow it.", "씬의 해를 드래그해 조명을 옮깁니다. 그림자와 빛의 방향이 따라옵니다.")}</p>
 						<Slider label={ko("Brightness", "밝기")} min={0} max={4} step={0.05} value={keyLight.intensity} onChange={(value) => setKeyLight((current) => createKeyLight({ ...current, intensity: value }))} />
 						<Slider label={ko("Warm ↔ Cool", "따뜻함 ↔ 차가움")} min={0} max={1} step={0.05} value={keyLight.warmth ?? 0.5} onChange={(value) => setKeyLight((current) => createKeyLight({ ...current, warmth: value }))} />
@@ -11242,7 +11244,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						</button>
 					</Foldout>
 
-				<Foldout hidden={!isRigSelection} title={ko("Rig Control", "리그 제어")}>
+					<Foldout hidden={!advancedMode || !isRigSelection} title={ko("Rig Control", "리그 제어")}>
 						<p className="inspector-hint">
 							{rigSelection && rigSelection.token !== "rig"
 							? (isKo ? `${HIERARCHY_INSPECTOR_TITLES[rigSelection.token]}이 활성 제어 그룹입니다.` : `${HIERARCHY_INSPECTOR_TITLES[rigSelection.token]} is the active control group.`)
@@ -11357,7 +11359,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						)}
 					</Foldout>
 
-				<Foldout hidden={selectedHierarchyId !== "environment"} title={ko("Environment", "환경")}>
+				<Foldout hidden={!advancedMode || selectedHierarchyId !== "environment"} title={ko("Environment", "환경")}>
 						<label className="check">
 							<input type="checkbox" checked={hasEnvSheet} onChange={(event) => setHasEnvSheet(event.target.checked)} />
 						<span>{ko("I have an environment sheet", "환경 시트가 있어요")}</span>
@@ -11372,7 +11374,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						</Field>
 					</Foldout>
 
-				<Foldout hidden={selectedHierarchyId !== "props"} title={ko("Props", "소품")}>
+				<Foldout hidden={!advancedMode || selectedHierarchyId !== "props"} title={ko("Props", "소품")}>
 					<div className="props-drop" data-drop={inspectorDrop.over ? "over" : "target"} {...inspectorDrop.handlers}>
 					<p className="inspector-hint">{ko("Everything you add to the set lives here. Pick one to edit it, or click it in the shot view. Drop a picture anywhere here — or on the shot view — to stand it up as a cutout.", "세트에 추가한 모든 소품이 여기에 모입니다. 편집하려면 하나를 고르거나 샷 뷰에서 클릭하세요. 사진을 이 영역이나 샷 뷰에 끌어다 놓으면 컷아웃으로 세워집니다.")}</p>
 					<AddObjectMenu onAdd={addSceneObject} label={ko("Add object to the set", "세트에 오브젝트 추가")} />

--- a/src/hierarchy-panel.jsx
+++ b/src/hierarchy-panel.jsx
@@ -558,12 +558,15 @@ export default function HierarchyPanel({
 		return labelled.map((node) => {
 			if (node.id !== "shot") return node;
 			const charactersGroup = node.children?.find((child) => child.id === "characters");
-			return {
-				...node,
-				children: charactersGroup
-					? [{ ...charactersGroup, children: (charactersGroup.children ?? []).map(({ children, ...character }) => character) }]
-					: [],
-			};
+			const propsGroup = node.children?.find((child) => child.id === "props");
+			// Keep the beginner tree focused on the cast while still exposing
+			// objects after the user creates one. This preserves direct selection
+			// for viewport/object workflows without surfacing empty expert groups.
+			const children = charactersGroup
+				? [{ ...charactersGroup, children: (charactersGroup.children ?? []).map(({ children, ...character }) => character) }]
+				: [];
+			if (propsGroup?.children?.length) children.push(propsGroup);
+			return { ...node, children };
 		});
 	}, [activeSceneName, sceneObjects, characters, beginnerMode]);
 	const parents = useMemo(() => indexParents(hierarchyNodes), [hierarchyNodes]);

--- a/src/hierarchy-panel.jsx
+++ b/src/hierarchy-panel.jsx
@@ -530,6 +530,7 @@ export default function HierarchyPanel({
 	onSceneDuplicate,
 	onSceneRename,
 	onSceneDelete,
+	beginnerMode = false,
 }) {
 	const [expanded, setExpanded] = useState(() => new Set(["shot", "characters", "characterA"]));
 	const [contextMenu, setContextMenu] = useState(null);
@@ -550,8 +551,21 @@ export default function HierarchyPanel({
 	}, [activeSceneId, scenes]);
 	const hierarchyNodes = useMemo(() => {
 		const nodes = buildHierarchyNodes(sceneObjects, characters);
-		return nodes.map((node) => node.kind === "scene" ? { ...node, label: activeSceneName } : node);
-	}, [activeSceneName, sceneObjects, characters]);
+		const labelled = nodes.map((node) => node.kind === "scene" ? { ...node, label: activeSceneName } : node);
+		if (!beginnerMode) return labelled;
+		// Beginner mode keeps the cast as the only editable hierarchy surface.
+		// Rig and bone rows are expert controls; they return with Advanced.
+		return labelled.map((node) => {
+			if (node.id !== "shot") return node;
+			const charactersGroup = node.children?.find((child) => child.id === "characters");
+			return {
+				...node,
+				children: charactersGroup
+					? [{ ...charactersGroup, children: (charactersGroup.children ?? []).map(({ children, ...character }) => character) }]
+					: [],
+			};
+		});
+	}, [activeSceneName, sceneObjects, characters, beginnerMode]);
 	const parents = useMemo(() => indexParents(hierarchyNodes), [hierarchyNodes]);
 
 	useEffect(() => {

--- a/src/project-browser.jsx
+++ b/src/project-browser.jsx
@@ -104,13 +104,30 @@ export default function ProjectBrowser({ currentName, onOpen, onOpenFile, onNew,
 		<div className={`project-browser-backdrop${startup ? " startup" : ""}`} onPointerDown={(e) => { if (!startup && e.target === e.currentTarget) onClose(); }}>
 			<div className={`project-browser${startup ? " startup" : ""}`} role="dialog" aria-label={ko("Choose project", "프로젝트 선택")}>
 				<div className="project-browser-head">
-					<strong>{startup ? ko("Choose a project to begin", "시작할 프로젝트를 선택하세요") : ko("Projects", "프로젝트")}</strong>
+					<strong>{startup ? ko("Create your first shot", "첫 샷 만들기") : ko("Projects", "프로젝트")}</strong>
 					{!startup && <button type="button" className="x" onClick={onClose} aria-label={ko("Close", "닫기")}>✕</button>}
 				</div>
 				{startup && <p className="project-browser-intro">{ko(
-					"Your work is saved in the selected project. You can open a recent file, choose a project folder, or start a named local draft.",
-					"작업 내용은 선택한 프로젝트에 저장됩니다. 최근 파일을 열거나 프로젝트 폴더를 지정하거나, 이름을 정한 새 초안으로 시작하세요.",
+					"Start with a named project, then place a character and frame the shot. Your work is saved in that project.",
+					"프로젝트 이름을 정하고 인물을 배치한 다음 샷 구도를 잡아 보세요. 작업 내용은 이 프로젝트에 저장됩니다.",
 				)}</p>}
+				{startup && (
+					<section className="beginner-start" aria-label={ko("First shot steps", "첫 샷 단계")}>
+						<div className="beginner-start-actions">
+							<button type="button" className="btn primary beginner-create" onClick={onNew}>
+								{ko("Create a project", "프로젝트 만들기")}
+							</button>
+							<button type="button" className="btn ghost beginner-open" onClick={onOpenFile}>
+								{ko("Open a project", "프로젝트 열기")}
+							</button>
+						</div>
+						<div className="beginner-step-grid">
+							<div className="beginner-step"><b>1</b><strong>{ko("Place", "배치")}</strong><span>{ko("Choose a character and move it on the stage.", "인물을 고르고 무대에서 움직여요.")}</span></div>
+							<div className="beginner-step"><b>2</b><strong>{ko("Frame", "구도")}</strong><span>{ko("Set the camera view for your shot.", "샷의 카메라 구도를 정해요.")}</span></div>
+							<div className="beginner-step"><b>3</b><strong>{ko("Play", "재생")}</strong><span>{ko("Press play to see the scene come alive.", "재생을 눌러 장면을 확인해요.")}</span></div>
+						</div>
+					</section>
+				)}
 
 				<section>
 					<div className="project-browser-section-head">

--- a/src/styles.css
+++ b/src/styles.css
@@ -397,6 +397,77 @@ select {
 	color: var(--muted);
 }
 
+/* The first-run sheet gives a new author one obvious starting action and a
+ * small mental model of the editor before the full studio is opened. */
+.beginner-start {
+	display: grid;
+	gap: 16px;
+	padding: 16px;
+	border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--line2));
+	border-radius: 12px;
+	background: color-mix(in srgb, var(--accent) 7%, var(--panel));
+}
+
+.beginner-start-actions {
+	display: flex;
+	gap: 10px;
+	align-items: center;
+}
+
+.beginner-create {
+	min-height: 42px;
+	padding-inline: 18px;
+	font-size: 13px;
+}
+
+.beginner-open {
+	min-height: 42px;
+}
+
+.beginner-step-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 10px;
+}
+
+.beginner-step {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	column-gap: 8px;
+	row-gap: 2px;
+	padding: 10px;
+	border: 1px solid var(--line2);
+	border-radius: 9px;
+	background: color-mix(in srgb, var(--panel) 82%, transparent);
+}
+
+.beginner-step b {
+	grid-row: span 2;
+	display: grid;
+	place-items: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: var(--accent);
+	color: #fff;
+	font-size: 11px;
+}
+
+.beginner-step strong {
+	font-size: 12px;
+}
+
+.beginner-step span {
+	font-size: 10.5px;
+	line-height: 1.35;
+	color: var(--muted);
+}
+
+@media (max-width: 620px) {
+	.beginner-step-grid { grid-template-columns: 1fr; }
+	.beginner-start-actions { flex-direction: column; align-items: stretch; }
+}
+
 .project-name-dialog-backdrop {
 	position: fixed;
 	inset: 0;

--- a/test/verify-beginner-screen.mjs
+++ b/test/verify-beginner-screen.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+const hierarchy = readFileSync(new URL("../src/hierarchy-panel.jsx", import.meta.url), "utf8");
+const browser = readFileSync(new URL("../src/project-browser.jsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
+let failures = 0;
+function expect(name, condition) {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}`);
+	if (!condition) failures += 1;
+}
+
+expect("startup chooser has one primary create action", browser.includes('className="btn primary beginner-create"') && browser.includes("Create a project"));
+expect("startup chooser offers project open", browser.includes('className="btn ghost beginner-open"') && browser.includes("Open a project"));
+expect("startup chooser explains the three-step path", browser.includes("beginner-step-grid") && browser.includes('>1</b>') && browser.includes('>2</b>') && browser.includes('>3</b>'));
+expect("beginner hierarchy keeps characters and removes rig rows", hierarchy.includes("beginnerMode = false") && hierarchy.includes("Beginner mode keeps the cast") && hierarchy.includes("map(({ children, ...character }) => character)"));
+expect("Advanced toggle returns selection to Character 1", app.includes('if (!next) setSelectedHierarchyId("characterA")'));
+expect("beginner chooser has responsive step cards", css.includes(".beginner-step-grid") && css.includes("grid-template-columns: repeat(3"));
+
+if (failures) process.exitCode = 1;
+else console.log("all beginner first-screen checks PASS");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -76,6 +76,7 @@ const NODE_FILES = [
 	"test/verify-korean-ui.mjs",
 	"test/verify-label-tooltips.mjs",
 	"test/verify-layout.mjs",
+	"test/verify-beginner-screen.mjs",
 	"test/verify-line-edit-draw.mjs",
 	"test/verify-line-edit-pins.mjs",
 	"test/verify-live-control.mjs",


### PR DESCRIPTION
## Summary
- add a first-run beginner entry surface with a clear Create/Open project action
- show the three-step Place → Frame → Play path before the full editor workflow
- keep beginner hierarchy and inspector focused on Characters and transform controls; Advanced restores expert rows and panels

## Validation
- `npm test` (117 Node verification files passed)
- `node test/verify-beginner-screen.mjs`
- browser QA at `http://127.0.0.1:5197/app/` verified the chooser and beginner surface at 1440×900; the rendered state showed only Characters in the hierarchy and Subject transform controls while Advanced was off

Closes #97
