### PR TITLE
feat: guide new projects to first success

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:camera-move": "node test/verify-camera-move.mjs",
     "test:cuts": "node test/verify-cuts.mjs",
     "test:project-menu": "node tools/qa-browser.mjs -- node test/verify-project-menu-browser.mjs",
+    "test:first-success-guide": "QA_STARTUP_CHOOSER=1 node tools/qa-browser.mjs -- node test/verify-first-success-guide-browser.mjs",
     "test:objects": "node tools/qa-browser.mjs -- node test/verify-object-gizmo.mjs",
     "test:theme": "node test/verify-theme.mjs",
     "test:appearance": "node test/verify-appearance.mjs",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -221,6 +221,7 @@ import {
 	PROJECT_EXTENSION,
 } from "./project.js";
 import ProjectBrowser, { ProjectNameDialog } from "./project-browser.jsx";
+import FirstSuccessGuide from "./first-success-guide.jsx";
 import ObjectGizmo from "./object-gizmo.jsx";
 import AssetPane from "./asset-pane.jsx";
 import AddObjectMenu from "./object-catalog.jsx";
@@ -2830,6 +2831,7 @@ globalThis.playMode = centerTab === "play";
 	const [projectMenuOpen, setProjectMenuOpen] = useState(false);
 	const [projectBrowserOpen, setProjectBrowserOpen] = useState(false);
 	const [projectNameDialog, setProjectNameDialog] = useState(null);
+	const [firstSuccessGuideOpen, setFirstSuccessGuideOpen] = useState(false);
 	// A first-run author should choose a document (or explicitly start a named
 	// local draft). Keep this as a light startup sheet so the studio remains
 	// inspectable while the choice is pending; it never traps the topbar.
@@ -3066,6 +3068,7 @@ globalThis.playMode = centerTab === "play";
 		setProjectName(name);
 		storeProjectSession(name);
 		setProjectStartupOpen(false);
+		setFirstSuccessGuideOpen(true);
 		setToast(ko(`New project: ${name}`, `새 프로젝트: ${name}`));
 	}
 
@@ -12319,6 +12322,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					else newProject(name);
 				}}
 			/>
+			<FirstSuccessGuide open={firstSuccessGuideOpen} onDismiss={() => setFirstSuccessGuideOpen(false)} />
 			<Toast message={toast} onDone={() => setToast("")} />
 			{pwaUpdate && (
 				<div className="scene-delete-toast" role="status">

--- a/src/first-success-guide.jsx
+++ b/src/first-success-guide.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { ko } from "./locale.js";
+
+const STEPS = [
+	{
+		en: "Select a character in the Hierarchy panel.",
+		ko: "계층 패널에서 캐릭터를 선택하세요.",
+		hintEn: "Click Character 1 (or its row) to make it active.",
+		hintKo: "캐릭터 1(또는 캐릭터 행)을 클릭하면 활성화됩니다.",
+	},
+	{
+		en: "Move it in the Scene view.",
+		ko: "장면 보기에서 캐릭터를 움직이세요.",
+		hintEn: "Drag the character marker on the floor to place it.",
+		hintKo: "바닥의 캐릭터 마커를 드래그해 배치하세요.",
+	},
+	{
+		en: "Press K to set a key at the current frame.",
+		ko: "현재 프레임에서 K를 눌러 키를 설정하세요.",
+		hintEn: "The key appears on the timeline as your first pose checkpoint.",
+		hintKo: "첫 포즈 체크포인트가 타임라인에 표시됩니다.",
+	},
+	{
+		en: "Scrub the timeline or press Space to play.",
+		ko: "타임라인을 문지르거나 Space를 눌러 재생하세요.",
+		hintEn: "Seeing the playhead move is your first visible result.",
+		hintKo: "재생 헤드가 움직이면 첫 결과를 확인한 것입니다.",
+	},
+];
+
+/** A small, dismissible first-run checklist shown after creating a project. */
+export default function FirstSuccessGuide({ open, onDismiss }) {
+	const [step, setStep] = useState(0);
+	useEffect(() => {
+		if (open) setStep(0);
+	}, [open]);
+	if (!open) return null;
+	const complete = step >= STEPS.length;
+
+	return (
+		<aside className="first-success-guide" role="dialog" aria-labelledby="first-success-guide-title" aria-describedby="first-success-guide-description">
+			<div className="first-success-guide-head">
+				<div>
+					<strong id="first-success-guide-title">{ko("Your first 60 seconds", "첫 60초")}</strong>
+					<span>{complete ? ko("Core loop complete", "핵심 흐름 완료") : ko(`Step ${step + 1} of ${STEPS.length}`, `${step + 1} / ${STEPS.length} 단계`)}</span>
+				</div>
+				<button type="button" className="first-success-guide-close" onClick={onDismiss} aria-label={ko("Dismiss guide", "가이드 닫기")}>×</button>
+			</div>
+			{complete ? (
+				<div className="first-success-guide-complete" id="first-success-guide-description" role="status">
+					<div className="first-success-guide-check">✓</div>
+					<strong>{ko("You made your first shot.", "첫 샷을 만들었어요.")}</strong>
+					<p>{ko("Select, move, key, and play are the core CozyClay loop. You can close this guide and keep blocking.", "선택하고, 움직이고, 키를 찍고, 재생하는 것이 CozyClay의 핵심 흐름입니다. 가이드를 닫고 계속 블로킹하세요.")}</p>
+					<button type="button" className="btn primary" onClick={onDismiss}>{ko("Continue editing", "편집 계속하기")}</button>
+				</div>
+			) : (
+				<>
+					<p id="first-success-guide-description" className="first-success-guide-intro">{ko("Follow these four actions to see a result quickly.", "네 가지 동작으로 빠르게 결과를 확인해 보세요.")}</p>
+					<ol className="first-success-guide-steps">
+						{STEPS.map((item, index) => (
+							<li key={item.en} className={index < step ? "done" : index === step ? "current" : ""}>
+								<span className="first-success-guide-step-mark">{index < step ? "✓" : index + 1}</span>
+								<div><strong>{ko(item.en, item.ko)}</strong>{index === step && <span>{ko(item.hintEn, item.hintKo)}</span>}</div>
+							</li>
+						))}
+					</ol>
+					<button type="button" className="btn primary first-success-guide-next" onClick={() => setStep((value) => value + 1)}>
+						{ko(step === STEPS.length - 1 ? "Mark complete" : "I did this", step === STEPS.length - 1 ? "완료로 표시" : "했어요")}
+					</button>
+				</>
+			)}
+			<button type="button" className="first-success-guide-skip" onClick={onDismiss}>{ko("Skip guide", "가이드 건너뛰기")}</button>
+		</aside>
+	);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -387,6 +387,194 @@ select {
 	gap: 8px;
 }
 
+/* ------------------------------------------------ first success guide ----- */
+
+.first-success-guide {
+	position: fixed;
+	right: 18px;
+	bottom: 208px;
+	z-index: 70;
+	width: min(330px, calc(100vw - 36px));
+	padding: 16px;
+	background: color-mix(in srgb, var(--panel) 96%, #101218);
+	border: 1px solid var(--accent);
+	border-radius: 14px;
+	box-shadow: 0 18px 58px rgba(0, 0, 0, .58), 0 0 0 1px rgba(255, 255, 255, .04);
+	animation: rise .28s var(--ease) both;
+}
+
+.first-success-guide-head {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.first-success-guide-head > div {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.first-success-guide-head strong {
+	font-size: 15px;
+	letter-spacing: -.01em;
+}
+
+.first-success-guide-head span {
+	font-size: 10px;
+	color: var(--accent);
+	font-weight: 700;
+	letter-spacing: .07em;
+	text-transform: uppercase;
+}
+
+.first-success-guide-close {
+	padding: 0 3px;
+	border: 0;
+	background: transparent;
+	color: var(--muted);
+	font-size: 19px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.first-success-guide-close:hover,
+.first-success-guide-close:focus-visible {
+	color: var(--fg);
+}
+
+.first-success-guide-intro {
+	margin: 12px 0 10px;
+	color: var(--muted);
+	font-size: 11.5px;
+	line-height: 1.45;
+}
+
+.first-success-guide-steps {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin: 0 0 14px;
+	padding: 0;
+	list-style: none;
+}
+
+.first-success-guide-steps li {
+	display: flex;
+	align-items: flex-start;
+	gap: 9px;
+	padding: 8px;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	color: var(--muted);
+	font-size: 11.5px;
+	line-height: 1.35;
+}
+
+.first-success-guide-steps li.current {
+	background: color-mix(in srgb, var(--accent) 10%, transparent);
+	border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+	color: var(--fg);
+}
+
+.first-success-guide-steps li.done {
+	color: var(--fg);
+	opacity: .72;
+}
+
+.first-success-guide-steps li strong,
+.first-success-guide-steps li span {
+	display: block;
+}
+
+.first-success-guide-steps li span {
+	margin-top: 3px;
+	color: var(--muted);
+	font-size: 10.5px;
+}
+
+.first-success-guide-step-mark {
+	display: inline-flex !important;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	flex: 0 0 18px;
+	margin-top: 1px;
+	border: 1px solid var(--line2);
+	border-radius: 50%;
+	font-size: 10px !important;
+	font-weight: 700;
+}
+
+.first-success-guide-steps li.current .first-success-guide-step-mark {
+	border-color: var(--accent);
+	color: var(--accent);
+}
+
+.first-success-guide-steps li.done .first-success-guide-step-mark {
+	border-color: #65c18c;
+	color: #65c18c;
+}
+
+.first-success-guide-next {
+	width: 100%;
+}
+
+.first-success-guide-skip {
+	display: block;
+	width: 100%;
+	margin-top: 9px;
+	padding: 3px;
+	border: 0;
+	background: transparent;
+	color: var(--muted);
+	font-size: 10px;
+	cursor: pointer;
+}
+
+.first-success-guide-skip:hover,
+.first-success-guide-skip:focus-visible {
+	color: var(--fg);
+}
+
+.first-success-guide-complete {
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	gap: 8px;
+	padding-top: 18px;
+	text-align: center;
+}
+
+.first-success-guide-check {
+	display: grid;
+	place-items: center;
+	width: 38px;
+	height: 38px;
+	border-radius: 50%;
+	background: #65c18c22;
+	color: #65c18c;
+	font-size: 22px;
+	font-weight: 700;
+}
+
+.first-success-guide-complete p {
+	margin: 0 0 6px;
+	color: var(--muted);
+	font-size: 11.5px;
+	line-height: 1.5;
+}
+
+@media (max-width: 700px) {
+	.first-success-guide {
+		right: 10px;
+		bottom: 202px;
+		width: min(330px, calc(100vw - 20px));
+	}
+}
+
 .project-browser-head {
 	display: flex;
 	align-items: center;

--- a/test/verify-first-success-guide-browser.mjs
+++ b/test/verify-first-success-guide-browser.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Browser contract for the first-run checklist. It drives the same named
+// controls a new author sees: create a project, read the four actions, mark
+// them complete, and dismiss the guide without blocking the editor.
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (expression, timeoutMs = 15000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		await sleep(100);
+	}
+	return false;
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+expect("the first-run project chooser renders", await waitFor("!!document.querySelector('.project-browser.startup')"));
+expect("New Project is available", await waitFor("!!document.querySelector('.project-browser.startup .project-browser-foot .btn.primary')"));
+await evaluate("document.querySelector('.project-browser.startup .project-browser-foot .btn.primary').click()");
+expect("the project name dialog opens", await waitFor("!!document.querySelector('.project-name-dialog')"));
+await evaluate("document.querySelector('.project-name-dialog button[type=submit]').click()");
+expect("guidance starts after project creation", await waitFor("!!document.querySelector('.first-success-guide')"));
+const guideText = await evaluate("document.querySelector('.first-success-guide')?.textContent || ''");
+expect("guidance names selection, movement, key, and playback", /Select a character.*Move it.*Press K.*Scrub the timeline.*Space/s.test(guideText), guideText);
+
+for (let index = 0; index < 4; index += 1) {
+	await evaluate("document.querySelector('.first-success-guide-next')?.click()");
+	// React commits each click on the next task; a short yield keeps this check
+	// deterministic without spending a full polling window per checklist step.
+	await sleep(120);
+}
+expect("the guide exposes a completion state", await waitFor("document.querySelector('.first-success-guide')?.textContent.includes('You made your first shot.')"));
+await evaluate("document.querySelector('.first-success-guide-close').click()");
+expect("the guide can be dismissed", await waitFor("!document.querySelector('.first-success-guide')"));
+expect("the editor remains available after dismissal", await waitFor("!!document.querySelector('.timeline')"));
+
+ws.close();
+if (failures > 0) {
+	console.error(`\n${failures} first-success guide browser check(s) failed`);
+	process.exit(1);
+}
+console.log("\nAll first-success guide browser checks passed");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -137,6 +137,7 @@ const NODE_FILES = [
 const BROWSER_FILES = [
 	"test/verify-camera-rail-browser.mjs",
 	"test/verify-cutout-browser.mjs",
+	"test/verify-first-success-guide-browser.mjs",
 	"test/verify-ik-browser.mjs",
 	"test/verify-motion-edit-browser.mjs",
 	"test/verify-number-field-scrub-browser.mjs",


### PR DESCRIPTION
## What changed
- show a non-blocking 60-second checklist immediately after creating a new project
- name the concrete first actions: select a character, move it, press K, then scrub or play with Space
- expose progress, a visible completion state, and dismiss/skip controls

## Validation
- `npm run build`
- `QA_URL=http://127.0.0.1:5188/app/ npm run test:first-success-guide`
- manual Chrome QA: created a project, verified the guide, advanced all four steps, captured the completion state, and dismissed it

Closes #98
