### PR TITLE
feat: expand round two analytics telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,13 @@ Events collected:
 | --- | --- |
 | `install:first_launch` | First run of the official npm package |
 | `app:session_started` | Start of an official npm package session |
+| `app:session_ended` | Session duration, action count, and scenes touched (bucketed) |
+| `feature:used` | One signal per feature per session |
 | `$pageview` | Funnel and drop-off analysis |
 | `scene:created` | Funnel and drop-off analysis |
 | `scene:loaded` | Funnel and drop-off analysis |
+| `project:saved` | User-owned project persistence |
+| `project:opened` | Return to a saved project (age bucket) |
 | `craft:first_action` | Funnel and drop-off analysis |
 | `motion:backend_state` | Motion capability at session start (`none`, `local_kimodo`, or `hosted`) |
 | `motion:generate_blocked` | Generate intent when no motion backend is available |
@@ -239,6 +243,8 @@ Events collected:
 | `motion:job_failed` | Motion reliability |
 | `export:blocking_frame_succeeded` | Funnel and drop-off analysis |
 | `activation:completed` | Funnel and drop-off analysis |
+| `hosted:composer_viewed`, `hosted:login_started`, `hosted:ticket_created` | Hosted demo funnel |
+| `hosted:result_opened`, `hosted:opened_in_studio` | Hosted result funnel |
 
 Geo data comes from ingest-time GeoIP country lookup only — no precise location is collected. Prompt text, asset names, file names, project content, local paths, and any user-entered text are never collected.
 
@@ -249,6 +255,14 @@ be counted across ports and browser storage resets. Source checkouts, forks,
 development servers, CI, and tests do not send analytics. Official npm
 artifacts carry a signature checked by the launcher, so copying or repackaging
 the source does not enable telemetry.
+
+Each event is registered with `origin_kind` (`local` or `hosted`), a coarse
+operating-system label, and (for npm sessions) `install_kind` (`npx` or
+`global`). Source checkouts are classified as `clone` and remain telemetry-off.
+The first npm launch may optionally answer a one-line channel question
+(`x`, `hn`, `reddit`, `github`, `friend`, `other`, or `skip`); `skip` sends no
+acquisition value. Session duration and action counts are buckets, and project
+events never include names, paths, prompts, or timestamps.
 
 The npm package prints this disclosure once on first launch. Control it at any
 time:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -105,6 +105,14 @@ as third-party content that this licence does not cover.
 
 The hosted site at cozyclay.org uses [posthog-js](https://posthog.com/docs/libraries/js) for anonymous usage analytics.
 
+The disclosed wire events include session start/end (bucketed duration and
+actions), one-per-session feature usage, project save/open buckets, and the
+hosted composer/login/ticket/result funnel. Events carry only the registered
+`origin_kind`, coarse `os`, and npm `install_kind`; prompts, filenames, paths,
+project names, and timestamps are excluded. Source checkouts keep telemetry
+disabled. See the Analytics & privacy section in `README.md` for the complete
+event table and opt-out controls.
+
 - Copyright PostHog Inc.
 - License: Apache-2.0 AND MIT
 - Source: https://github.com/PostHog/posthog-js

--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -29,6 +29,7 @@ import { verifyPackageMarker } from "./package-signature.mjs";
 import {
 	markTelemetryNoticeShown,
 	markTelemetryFirstLaunch,
+	setTelemetryFirstLaunchSource,
 	effectiveTelemetryEnabled,
 	readTelemetryState,
 	setTelemetryEnabled,
@@ -51,6 +52,10 @@ const OFFICIAL_PACKAGE = (
 	&& !SOURCE_CHECKOUT
 	&& verifyPackageMarker(join(DIST, "cozyclay-package.json"), PKG_ROOT, packageMetadata)
 );
+const INSTALL_KIND = process.env.npm_config_global === "true"
+	|| (PKG_ROOT.includes("/node_modules/") && !PKG_ROOT.includes("/_npx/"))
+	? "global"
+	: "npx";
 // A bridge is optional. Keep the endpoint unset until this launcher owns a
 // sidecar; otherwise /ardy requests could accidentally reach an unrelated
 // process that happens to be listening on the bridge's historical default
@@ -114,6 +119,18 @@ const STATE_FILE = join(STATE_DIR, "state.json");
 // Only worth asking someone who actually used the thing. A prompt three
 // seconds in is a popup; a prompt after a real session is a question.
 const STAR_AFTER_MS = Number(process.env.COZYCLAY_STAR_AFTER_MS ?? 60_000);
+
+async function askFirstLaunchSource() {
+	if (!process.stdin.isTTY || !process.stdout.isTTY) return null;
+	const answer = await new Promise((resolve) => {
+		const rl = createInterface({ input: process.stdin, output: process.stdout });
+		rl.question("How did you hear about CozyClay? [x/hn/reddit/github/friend/other/skip] ", (value) => {
+			rl.close();
+			resolve(value.trim().toLowerCase());
+		});
+	});
+	return ["x", "hn", "reddit", "github", "friend", "other"].includes(answer) ? answer : null;
+}
 
 const HELP = `cozyclay - browser-based 3D staging studio
 
@@ -284,7 +301,19 @@ if (opts.version) {
 let runtimeTelemetry = takeRuntimeTelemetryConfig(STATE_FILE, {
 	appVersion: version,
 	officialPackage: OFFICIAL_PACKAGE,
+	installKind: INSTALL_KIND,
 });
+if (runtimeTelemetry.firstLaunch && !readTelemetryState(STATE_FILE).firstLaunchHeardFrom) {
+	const heardFrom = await askFirstLaunchSource();
+	if (heardFrom) {
+		setTelemetryFirstLaunchSource(STATE_FILE, heardFrom);
+	runtimeTelemetry = takeRuntimeTelemetryConfig(STATE_FILE, {
+		appVersion: version,
+		officialPackage: OFFICIAL_PACKAGE,
+		installKind: INSTALL_KIND,
+	});
+	}
+}
 const telemetryState = readTelemetryState(STATE_FILE);
 if (
 	runtimeTelemetry.telemetryEnabled
@@ -384,6 +413,7 @@ server = createServer((req, res) => {
 					runtimeTelemetry = takeRuntimeTelemetryConfig(STATE_FILE, {
 						appVersion: version,
 						officialPackage: OFFICIAL_PACKAGE,
+						installKind: INSTALL_KIND,
 					});
 					res.writeHead(200, {
 						"content-type": "application/json; charset=utf-8",
@@ -438,6 +468,7 @@ server = createServer((req, res) => {
 		runtimeTelemetry = takeRuntimeTelemetryConfig(STATE_FILE, {
 			appVersion: version,
 			officialPackage: OFFICIAL_PACKAGE,
+			installKind: INSTALL_KIND,
 		});
 		const runtime = runtimeTelemetry;
 		if (runtime.firstLaunch) {

--- a/bin/telemetry-state.mjs
+++ b/bin/telemetry-state.mjs
@@ -11,6 +11,7 @@ const DEFAULT_STATE = Object.freeze({
 	telemetryEnabled: true,
 	firstLaunchedAt: null,
 	noticeVersion: 0,
+	firstLaunchHeardFrom: null,
 });
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -35,6 +36,9 @@ function normalizedState(value) {
 		noticeVersion: Number.isInteger(value.telemetryNoticeVersion)
 			? value.telemetryNoticeVersion
 			: 0,
+		firstLaunchHeardFrom: ["x", "hn", "reddit", "github", "friend", "other"].includes(value.telemetryFirstLaunchHeardFrom)
+			? value.telemetryFirstLaunchHeardFrom
+			: null,
 	};
 }
 
@@ -77,11 +81,18 @@ export function markTelemetryFirstLaunch(stateFile, now = () => new Date().toISO
 	writeState(stateFile, { telemetryFirstLaunchedAt: now() });
 }
 
+export function setTelemetryFirstLaunchSource(stateFile, heardFrom) {
+	if (!["x", "hn", "reddit", "github", "friend", "other"].includes(heardFrom)) return readTelemetryState(stateFile);
+	writeState(stateFile, { telemetryFirstLaunchHeardFrom: heardFrom });
+	return readTelemetryState(stateFile);
+}
+
 export function takeRuntimeTelemetryConfig(
 	stateFile,
 	{
 		appVersion,
 		officialPackage = true,
+		installKind = null,
 		env = process.env,
 		now = () => new Date().toISOString(),
 		randomUUID = nodeRandomUUID,
@@ -107,5 +118,9 @@ export function takeRuntimeTelemetryConfig(
 		apiKey: POSTHOG_PROJECT_TOKEN,
 		apiHost: POSTHOG_API_HOST,
 		firstLaunch,
+		firstLaunchHeardFrom: existing.firstLaunchHeardFrom,
+		installKind: ["npx", "global", "clone"].includes(installKind)
+			? installKind
+			: env.npm_config_global === "true" || env.npm_config_global === true ? "global" : "npx",
 	};
 }

--- a/d/ticket.js
+++ b/d/ticket.js
@@ -1,4 +1,7 @@
 import { API_BASE } from "../demo/config.js";
+import { initAnalytics, track } from "../src/analytics.js";
+
+void initAnalytics();
 
 const POSITION_POLL_MS = 30_000;
 const ETA_FALLBACK_TEXT = "Usually a few minutes while the generator is online.";
@@ -7,6 +10,7 @@ let ticketToken = null;
 let pollTimer = null;
 let pollInFlight = false;
 let lastState = null;
+let resultOpenedTracked = false;
 
 function byId(id) {
   return typeof document === "undefined" ? null : document.getElementById(id);
@@ -113,6 +117,10 @@ function renderRunning(state = null) {
 }
 
 function renderDone(state) {
+	if (!resultOpenedTracked) {
+		resultOpenedTracked = true;
+		track("hosted:result_opened");
+	}
   setText("ticket-state-title", "Ready");
   setText("ticket-position", "Your motion is ready.");
   setText("ticket-eta", "Open it in CozyClay to play it back.");
@@ -287,7 +295,8 @@ function onVisibilityChange() {
 }
 
 function bindTicket() {
-  byId("copy-link")?.addEventListener("click", copyShareLink);
+	byId("copy-link")?.addEventListener("click", copyShareLink);
+	byId("open-result")?.addEventListener("click", () => track("hosted:opened_in_studio"));
   if (ticketToken) {
     const report = byId("report-link");
     if (report) report.href = `mailto:hello@cozyclay.org?subject=${encodeURIComponent(`CozyClay ticket ${ticketToken}`)}`;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,4 +1,7 @@
 import { API_BASE, DEMO_DISABLED, TURNSTILE_SITE_KEY, configuredPromptLimit } from "./config.js";
+import { initAnalytics, track } from "../src/analytics.js";
+
+void initAnalytics().then(() => track("hosted:composer_viewed"));
 
 const DISABLED_MESSAGE = "아직 동작하지 않는 기능입니다. This feature is not available yet.";
 
@@ -259,7 +262,8 @@ function returnPath() {
 }
 
 function signIn(provider, promptValue) {
-  if (provider !== "google") return;
+	if (provider !== "google") return;
+	track("hosted:login_started");
   const field = byId("prompt");
   if (typeof promptValue === "string") savePrompt(promptValue);
   else if (field) savePrompt(field.value ?? "");
@@ -341,6 +345,7 @@ async function submit({ prompt: suppliedPrompt, turnstileToken: suppliedToken } 
     });
     const data = await responseJson(response);
     if (response.status === 201) {
+		track("hosted:ticket_created");
       redirectToTicket(data.token);
       return data;
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -236,7 +236,7 @@ import {
 	MAX_PATH_POINTS,
 } from "./object-path.js";
 import LocaleToggle from "./locale-toggle.jsx";
-import { bucketMs, motionBackendState, track, trackActivation } from "./analytics.js";
+import { bucketCount, bucketMs, bucketProjectAge, motionBackendState, track, trackActivation, trackFeature } from "./analytics.js";
 import { ko, isKo } from "./locale.js";
 import {
 	DEFAULT_POSE,
@@ -2453,6 +2453,7 @@ globalThis.playMode = centerTab === "play";
 			...points.slice(gapIndex + 1),
 		];
 		changeActiveCamera({ craneHeight: { points: added } }, shotId);
+		trackFeature("crane_graph");
 		setCraneSelectedIndex(gapIndex + 1);
 	}
 	function deleteSelectedCranePoint() {
@@ -2494,6 +2495,7 @@ globalThis.playMode = centerTab === "play";
 	}
 	function commitManualCameraFraming() {
 		if (ikMode || playMode) return;
+		trackFeature("orbit");
 		manualCameraOverrideRef.current = true;
 		syncActiveCameraFraming();
 	}
@@ -2541,6 +2543,7 @@ globalThis.playMode = centerTab === "play";
 			});
 		}
 		const next = !railDraw;
+		trackFeature("dolly_rail");
 		setRailDraw(next);
 		if (next) {
 			setWorkspaceLayout((current) => ({ ...current, insetCollapsed: false }));
@@ -2894,7 +2897,7 @@ globalThis.playMode = centerTab === "play";
 					? `참조된 사진 ${missing.length}개를 찾지 못해보내기에서 빠졌어요`
 					: `${missing.length} referenced image${missing.length > 1 ? "s" : ""} missing — left out of the export`);
 			}
-			return JSON.stringify(createProjectDocument({ ...input, assets }), null, 2);
+			return JSON.stringify(createProjectDocument({ ...input, assets, savedAt: Date.now() }), null, 2);
 		} finally {
 			db.close();
 		}
@@ -2958,6 +2961,10 @@ globalThis.playMode = centerTab === "play";
 			}
 			markProjectClean(name);
 			setProjectSaveState("saved");
+			track("project:saved", {
+				object_count_bucket: bucketCount(projectStateRef.current.sceneObjects?.length ?? 0),
+				shot_count_bucket: bucketCount(shots.length),
+			});
 			setToast(isKo ? `프로젝트 저장됨: ${name}${PROJECT_EXTENSION}` : `Project saved: ${name}${PROJECT_EXTENSION}`);
 		} catch (err) {
 			if (err?.name === "AbortError") {
@@ -2990,6 +2997,7 @@ globalThis.playMode = centerTab === "play";
 		setProjectName(project.name);
 		storeProjectSession(project.name);
 		setProjectStartupOpen(false);
+		track("project:opened", { age_bucket: bucketProjectAge(Date.now() - (project.savedAt ?? Date.now())) });
 	}
 
 	async function openProject() {
@@ -3008,6 +3016,7 @@ globalThis.playMode = centerTab === "play";
 				setToast(isKo ? `프로젝트를 열 수 없어요: ${result.reason}` : `Cannot open project: ${result.reason}`);
 				return;
 			}
+			result.project.savedAt = result.project.savedAt ?? file.savedAt ?? null;
 			projectHandleRef.current = handle;
 			if (handle) await rememberRecentProject(handle, result.project.name);
 			await rehydrateProjectAssets(result.project, result.warnings);
@@ -3037,6 +3046,7 @@ globalThis.playMode = centerTab === "play";
 				setToast(isKo ? `프로젝트를 열 수 없어요: ${result.reason}` : `Cannot open project: ${result.reason}`);
 				return;
 			}
+			result.project.savedAt = result.project.savedAt ?? file.savedAt ?? null;
 			projectHandleRef.current = handle;
 			await rememberRecentProject(handle, result.project.name);
 			await rehydrateProjectAssets(result.project, result.warnings);
@@ -3089,6 +3099,7 @@ globalThis.playMode = centerTab === "play";
 			const file = await readProjectFile(record.handle);
 			const result = readProjectDocument(file.text);
 			if (!result.ok) return;
+			result.project.savedAt = result.project.savedAt ?? file.savedAt ?? null;
 			projectHandleRef.current = record.handle;
 			await rehydrateProjectAssets(result.project, result.warnings);
 			applyProject(result.project);
@@ -4143,7 +4154,10 @@ globalThis.playMode = centerTab === "play";
 			stopShotRecording();
 			return;
 		}
-		runShotExport().then(() => track("export:video_succeeded", { format: "mp4" })).catch((error) => {
+		runShotExport().then(() => {
+			track("export:video_succeeded", { format: "mp4" });
+			trackFeature("export_video");
+		}).catch((error) => {
 			if (error?.name !== "AbortError") setToast(error?.message || String(error));
 		});
 	}
@@ -4244,6 +4258,7 @@ globalThis.playMode = centerTab === "play";
 		if (next === shots) return;
 		recordShotUndo();
 		setShots(next);
+		trackFeature("shot_add");
 	}
 
 	function splitTimelineShot(shotId) {
@@ -4255,6 +4270,7 @@ globalThis.playMode = centerTab === "play";
 		if (next === shots) return;
 		recordShotUndo();
 		setShots(next);
+		trackFeature("shot_cut");
 	}
 
 	function selectTimelineShot(shotId) {
@@ -6005,6 +6021,7 @@ globalThis.playMode = centerTab === "play";
 	 * character: a running take must survive having its best frame bottled. */
 	function saveCurrentPose() {
 		if (!activeRig) return;
+		trackFeature("pose_edit");
 		const pose = {
 			id: `custom_${Date.now()}`,
 			label: isKo ? `내 포즈 ${customPoses.length + 1}` : `My Pose ${customPoses.length + 1}`,
@@ -6027,6 +6044,7 @@ globalThis.playMode = centerTab === "play";
 	function savePose() {
 		const rig = posedRig();
 		if (!rig) return;
+		trackFeature("pose_edit");
 		const pose = {
 			id: `custom_${Date.now()}`,
 		label: isKo ? `내 포즈 ${customPoses.length + 1}` : `My Pose ${customPoses.length + 1}`,
@@ -6374,6 +6392,7 @@ globalThis.playMode = centerTab === "play";
 			setToast(ko("Start & end frames downloaded", "시작·끝 프레임 다운로드됨"));
 			setResult((current) => current ? { ...current, downloaded: true } : current);
 			track("export:blocking_frame_succeeded", { format: "png" });
+			trackFeature("export_frame");
 			trackActivation("export");
 			return;
 		}
@@ -6381,6 +6400,7 @@ globalThis.playMode = centerTab === "play";
 		setToast(ko("Frame downloaded", "프레임 다운로드됨"));
 		setResult((current) => current ? { ...current, downloaded: true } : current);
 		track("export:blocking_frame_succeeded", { format: "png" });
+		trackFeature("export_frame");
 		trackActivation("export");
 	}
 	function downloadArdyPose() {
@@ -6389,6 +6409,7 @@ globalThis.playMode = centerTab === "play";
 			setToast(ko("Character not loaded yet", "캐릭터가 아직 로드되지 않았어요"));
 			return;
 		}
+		trackFeature("export_pose");
 		const pose = buildArdyPose({
 			rig,
 			camRef: shotCamRef,
@@ -6421,6 +6442,7 @@ globalThis.playMode = centerTab === "play";
 		// periodic hitch while orbiting/flying the camera.
 		const refreshBridge = () => checkBridge().then((state) => {
 			if (!alive) return;
+			if (state.ok) trackFeature("mcp_connected");
 			setBridge((previous) => (
 				previous &&
 				previous.ok === state.ok &&
@@ -6462,6 +6484,7 @@ globalThis.playMode = centerTab === "play";
 		setSelectedPromptId(clip.id);
 		setTlFrameCount((count) => Math.max(count, clip.endFrame));
 		setArdyDuration(Math.max(ARDY_DURATION_MIN, clip.endFrame / TIMELINE_FPS));
+		trackFeature("prompt_block_add");
 	}
 
 	function changePromptClip(id, text) {
@@ -9435,9 +9458,10 @@ function resizePromptClip(id, edge, rawFrame) {
 							"Distinct display colors per object — captures include them while on",
 							"오브젝트별 구분 색 — 켜둔 동안 캡처에도 포함됩니다",
 						)}
-						onClick={() => {
+						 onClick={() => {
 							setAutoColor((on) => {
 								saveAutoColor(!on);
+								trackFeature("auto_color");
 								return !on;
 							});
 						}}
@@ -9927,9 +9951,10 @@ function resizePromptClip(id, edge, rawFrame) {
 									const size = objectSize(selectedSceneObject);
 									return { x: selectedSceneObject.x, y: (selectedSceneObject.y ?? 0) + size.height / 2, z: selectedSceneObject.z };
 								}}
-								onFlyStateChange={(flying) => {
-									flyingRef.current = flying;
-								}}
+							onFlyStateChange={(flying) => {
+								flyingRef.current = flying;
+								if (flying) trackFeature("camera_fly");
+							}}
 								onCameraChange={lookThroughShot && !ikMode ? commitManualCameraFraming : undefined}
 							/>
 							<PoseHandles
@@ -12271,7 +12296,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						return !v;
 					});
 				}}
-				onScrub={setTlFrame}
+				onScrub={(frame) => { trackFeature("timeline_scrub"); setTlFrame(frame); }}
 				onAdvance={advanceFrame}
 				onStep={stepFrame}
 				onPlayToggle={() => {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -5,10 +5,19 @@ const DEFAULT_ALLOWED_ORIGINS = Object.freeze([
 	"https://www.cozyclay.org",
 ]);
 const EVENT_PROPERTIES = Object.freeze({
-	"install:first_launch": [],
+	"install:first_launch": ["heard_from"],
 	"app:session_started": [],
+	"app:session_ended": ["duration_bucket", "action_count_bucket", "scenes_touched"],
+	"feature:used": ["name"],
+	"hosted:composer_viewed": [],
+	"hosted:login_started": [],
+	"hosted:ticket_created": [],
+	"hosted:result_opened": [],
+	"hosted:opened_in_studio": [],
 	"scene:created": ["scene_source"],
 	"scene:loaded": ["scene_source"],
+	"project:saved": ["object_count_bucket", "shot_count_bucket"],
+	"project:opened": ["age_bucket"],
 	"craft:first_action": ["action_kind"],
 	"motion:backend_state": ["backend", "host_configured"],
 	"motion:generate_blocked": ["surface"],
@@ -20,7 +29,13 @@ const EVENT_PROPERTIES = Object.freeze({
 	"sample:played": ["from"],
 	"activation:completed": ["activation_path"],
 });
-const DENIED_PROPERTY_KEYS = new Set(["prompt", "text", "name", "url", "path", "file"]);
+const FEATURE_NAMES = new Set([
+	"pose_edit", "camera_fly", "orbit", "dolly_rail", "crane_graph", "timeline_scrub",
+	"prompt_block_add", "shot_add", "shot_cut", "export_pose", "export_frame", "export_video",
+	"mcp_connected", "auto_color", "plan_view",
+]);
+const HEARD_FROM_VALUES = new Set(["x", "hn", "reddit", "github", "friend", "other"]);
+const DENIED_PROPERTY_KEYS = new Set(["prompt", "text", "url", "path", "file"]);
 
 let posthog = null;
 let initialized = false;
@@ -28,6 +43,12 @@ let enabled = false;
 let initPromise = null;
 let activationFired = false;
 let disabledLogged = false;
+let sessionStartedAt = 0;
+let sessionActionCount = 0;
+let sessionScenesTouched = 0;
+let sessionEnded = false;
+let sessionEndListenersInstalled = false;
+const featureNamesSeen = new Set();
 
 function storage() {
 	try {
@@ -84,6 +105,8 @@ export function sanitizeProps(event, props) {
 	const sanitized = {};
 	for (const key of allowedKeys) {
 		if (DENIED_PROPERTY_KEYS.has(key) || !Object.hasOwn(props, key)) continue;
+		if (event === "feature:used" && (key !== "name" || !FEATURE_NAMES.has(props[key]))) continue;
+		if (event === "install:first_launch" && (key !== "heard_from" || !HEARD_FROM_VALUES.has(props[key]))) continue;
 		if (isSafePropertyValue(props[key])) sanitized[key] = props[key];
 	}
 	return sanitized;
@@ -111,6 +134,42 @@ export function motionBackendState(health) {
 		backend: "local_kimodo",
 		host_configured: Boolean(host),
 	};
+}
+
+export const FEATURE_USAGE_NAMES = Object.freeze([...FEATURE_NAMES]);
+
+export function bucketCount(value) {
+	const count = Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+	if (count === 0) return "0";
+	if (count <= 3) return "1-3";
+	if (count <= 10) return "4-10";
+	return "gte11";
+}
+
+export function bucketSessionDuration(ms) {
+	if (!Number.isFinite(ms) || ms < 60_000) return "lt1m";
+	if (ms < 5 * 60_000) return "1-5m";
+	if (ms < 15 * 60_000) return "5-15m";
+	if (ms < 30 * 60_000) return "15-30m";
+	return "gte30m";
+}
+
+export function bucketProjectAge(ms) {
+	if (!Number.isFinite(ms) || ms < 0 || ms < 60 * 60_000) return "lt1h";
+	if (ms < 24 * 60 * 60_000) return "1-24h";
+	if (ms < 7 * 24 * 60 * 60_000) return "1-7d";
+	if (ms < 30 * 24 * 60 * 60_000) return "7-30d";
+	return "gte30d";
+}
+
+function detectOs() {
+	const platform = String(globalThis.navigator?.userAgentData?.platform || globalThis.navigator?.platform || "").toLowerCase();
+	if (platform.includes("mac")) return "macos";
+	if (platform.includes("win")) return "windows";
+	if (platform.includes("linux")) return "linux";
+	if (platform.includes("android")) return "android";
+	if (platform.includes("iphone") || platform.includes("ipad") || platform.includes("ios")) return "ios";
+	return "unknown";
 }
 
 export function bucketMs(ms) {
@@ -300,6 +359,9 @@ export function resolveAnalyticsRuntime({
 			appVersion: runtime.appVersion || null,
 			installationId: runtime.installationId || null,
 			firstLaunch: runtime.firstLaunch === true,
+			firstLaunchHeardFrom: HEARD_FROM_VALUES.has(runtime.firstLaunchHeardFrom) ? runtime.firstLaunchHeardFrom : null,
+			installKind: ["npx", "global", "clone"].includes(runtime.installKind) ? runtime.installKind : "npx",
+			originKind: "local",
 		};
 	}
 	if (!env.VITE_POSTHOG_KEY) return { kind: "disabled", reason: "no key" };
@@ -314,6 +376,9 @@ export function resolveAnalyticsRuntime({
 		appVersion: env.VITE_APP_VERSION || null,
 		installationId: null,
 		firstLaunch: false,
+		firstLaunchHeardFrom: null,
+		installKind: null,
+		originKind: "hosted",
 	};
 }
 
@@ -376,17 +441,25 @@ export async function initAnalytics() {
 			posthog.register({
 				distribution: resolved.distribution,
 				...(resolved.appVersion ? { app_version: resolved.appVersion } : {}),
+				origin_kind: resolved.originKind,
+				os: detectOs(),
+				...(resolved.installKind ? { install_kind: resolved.installKind } : {}),
 			});
 			// Test hook, mirroring the window.__cozyclay convention: lets QA
 			// drivers inspect the live SDK without shipping a real global API.
 			globalThis.__cozyclayAnalytics = { instance: posthog };
 			posthog.capture("$pageview");
+			sessionStartedAt = Date.now();
+			installSessionEndListeners(resolved);
 			if (resolved.distribution === "npm") {
 				track("app:session_started");
 				// This follows the session marker so the two events form one
 				// capability baseline in funnel queries.
 				void recordMotionBackendState();
-				if (resolved.firstLaunch) track("install:first_launch");
+				if (resolved.firstLaunch) {
+					const heardFrom = resolved.firstLaunchHeardFrom;
+					track("install:first_launch", heardFrom ? { heard_from: heardFrom } : {});
+				}
 			} else {
 				// Hosted sessions have PostHog's native session marker rather than
 				// the npm-only custom event above.
@@ -413,10 +486,57 @@ async function recordMotionBackendState() {
 export function track(event, props = {}) {
 	if (!initialized || !enabled || !posthog) return;
 	try {
-		posthog.capture(event, sanitizeProps(event, props));
+		const sanitized = sanitizeProps(event, props);
+		if (event !== "app:session_started" && event !== "app:session_ended" && event !== "install:first_launch") {
+			sessionActionCount += 1;
+			if (event === "scene:created" || event === "scene:loaded") sessionScenesTouched += 1;
+		}
+		posthog.capture(event, sanitized);
 	} catch {
 		// Analytics must never affect app behavior.
 	}
+}
+
+export function trackFeature(name) {
+	if (!initialized || !enabled || !posthog || !FEATURE_NAMES.has(name) || featureNamesSeen.has(name)) return false;
+	featureNamesSeen.add(name);
+	track("feature:used", { name });
+	return true;
+}
+
+function installSessionEndListeners(resolved) {
+	if (sessionEndListenersInstalled || typeof window === "undefined") return;
+	sessionEndListenersInstalled = true;
+	const finish = () => {
+		if (sessionEnded || !sessionStartedAt) return;
+		sessionEnded = true;
+		const payload = {
+			api_key: resolved.apiKey,
+			event: "app:session_ended",
+			properties: {
+				distinct_id: posthog?.get_distinct_id?.(),
+				duration_bucket: bucketSessionDuration(Date.now() - sessionStartedAt),
+				action_count_bucket: bucketCount(sessionActionCount),
+				scenes_touched: Math.min(20, sessionScenesTouched),
+				origin_kind: resolved.originKind,
+				os: detectOs(),
+				...(resolved.installKind ? { install_kind: resolved.installKind } : {}),
+			},
+		};
+		try {
+			const body = JSON.stringify(payload);
+			const endpoint = `${resolved.apiHost.replace(/\/$/, "")}/e/`;
+			if (typeof globalThis.navigator?.sendBeacon === "function") {
+				globalThis.navigator.sendBeacon(endpoint, new Blob([body], { type: "application/json" }));
+			} else {
+				void fetch(endpoint, { method: "POST", body, keepalive: true, headers: { "content-type": "application/json" } });
+			}
+		} catch {
+			// Unload telemetry is best effort.
+		}
+	};
+	window.addEventListener("pagehide", finish, { once: true });
+	window.addEventListener("beforeunload", finish, { once: true });
 }
 
 export function trackActivation(path) {

--- a/src/project.js
+++ b/src/project.js
@@ -93,7 +93,7 @@ function readEmbeddedAssets(value) {
 	return { assets, warnings };
 }
 
-export function createProjectDocument({ scenesDocument, workspaceLayout, customPoses, name, assets }) {
+export function createProjectDocument({ scenesDocument, workspaceLayout, customPoses, name, assets, savedAt }) {
 	const assetRecords = new Map();
 	for (const record of Array.isArray(assets) ? assets : []) {
 		const asset = embeddedAsset(record);
@@ -109,6 +109,7 @@ export function createProjectDocument({ scenesDocument, workspaceLayout, customP
 		kind: "project",
 		version: PROJECT_VERSION,
 		name: typeof name === "string" && name.trim() ? name.trim() : "Untitled",
+		...(Number.isFinite(savedAt) && savedAt > 0 ? { savedAt } : {}),
 		scenes: scenesDocument,
 		workspace: workspaceLayout ?? null,
 		poseLibrary: Array.isArray(customPoses) ? customPoses : [],
@@ -138,6 +139,7 @@ export function readProjectDocument(raw) {
 		warnings: embedded.warnings,
 		project: {
 			name: typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : "Untitled",
+			savedAt: Number.isFinite(parsed.savedAt) && parsed.savedAt > 0 ? parsed.savedAt : null,
 			scenesDocument: { version: scenes.version, activeSceneId: scenes.activeSceneId ?? null, scenes: scenes.scenes },
 			workspaceLayout: parsed.workspace && typeof parsed.workspace === "object" ? parsed.workspace : null,
 			customPoses: Array.isArray(parsed.poseLibrary)
@@ -182,7 +184,7 @@ export async function writeProjectFile(handle, serialized) {
 
 export async function readProjectFile(handle) {
 	const file = await handle.getFile();
-	return { name: file.name.replace(/\.cclayproject$|\.json$/i, ""), text: await file.text() };
+	return { name: file.name.replace(/\.cclayproject$|\.json$/i, ""), text: await file.text(), savedAt: file.lastModified };
 }
 
 /* --------------------------- fallback (no FS API) ------------------------ */
@@ -205,7 +207,7 @@ export function openProjectFallback() {
 		input.onchange = async () => {
 			const file = input.files?.[0];
 			if (!file) return resolve(null);
-			resolve({ name: file.name.replace(/\.cclayproject$|\.json$/i, ""), text: await file.text() });
+			resolve({ name: file.name.replace(/\.cclayproject$|\.json$/i, ""), text: await file.text(), savedAt: file.lastModified });
 		};
 		input.oncancel = () => resolve(null);
 		input.click();

--- a/test/verify-analytics.mjs
+++ b/test/verify-analytics.mjs
@@ -10,6 +10,9 @@ import {
 	resolveAnalyticsRuntime,
 	motionBackendState,
 	sanitizeProps,
+	bucketCount,
+	bucketProjectAge,
+	bucketSessionDuration,
 } from "../src/analytics.js";
 
 assert.equal(normalizeOrigin("HTTPS://CozyClay.Org/"), "https://cozyclay.org");
@@ -75,6 +78,14 @@ assert.match(appSource, /motion:job_started.*backend/);
 assert.match(appSource, /motion:job_succeeded[\s\S]*?duration_bucket/);
 assert.match(appSource, /motion:job_failed[\s\S]*?duration_bucket/);
 assert.doesNotMatch(appSource, /latency_bucket/);
+assert.deepEqual(sanitizeProps("feature:used", { name: "pose_edit", prompt: "secret" }), { name: "pose_edit" });
+assert.deepEqual(sanitizeProps("feature:used", { name: "private-feature" }), {});
+assert.deepEqual(sanitizeProps("install:first_launch", { heard_from: "github" }), { heard_from: "github" });
+assert.deepEqual(sanitizeProps("install:first_launch", { heard_from: "skip" }), {});
+assert.equal(bucketCount(0), "0");
+assert.equal(bucketCount(4), "4-10");
+assert.equal(bucketSessionDuration(0), "lt1m");
+assert.equal(bucketProjectAge(2 * 24 * 60 * 60 * 1000), "1-7d");
 
 assert.equal(bucketMs(0), "lt1s");
 assert.equal(bucketMs(999), "lt1s");
@@ -146,6 +157,9 @@ assert.deepEqual(
 		appVersion: null,
 		installationId: null,
 		firstLaunch: false,
+		firstLaunchHeardFrom: null,
+		installKind: null,
+		originKind: "hosted",
 	},
 );
 assert.deepEqual(
@@ -170,6 +184,9 @@ assert.deepEqual(
 		appVersion: "1.5.0",
 		installationId,
 		firstLaunch: true,
+		firstLaunchHeardFrom: null,
+		installKind: "npx",
+		originKind: "local",
 	},
 	"the official package can enable localhost with its injected runtime contract",
 );

--- a/test/verify-telemetry-state.mjs
+++ b/test/verify-telemetry-state.mjs
@@ -36,6 +36,8 @@ try {
 		apiKey: "phc_CpizzZ8VhSorSS8yEeQhdpUcvB2erp5xkCbnFD8HTJ5m",
 		apiHost: "https://t.cozyclay.org",
 		firstLaunch: true,
+		firstLaunchHeardFrom: null,
+		installKind: "npx",
 	});
 	assert.equal(JSON.parse(readFileSync(stateFile, "utf8")).installationId, installationId);
 	assert.equal(
@@ -95,7 +97,7 @@ try {
 	writeFileSync(stateFile, "{ broken json");
 	assert.deepEqual(
 		readTelemetryState(stateFile),
-		{ installationId: null, telemetryEnabled: false, firstLaunchedAt: null, noticeVersion: 0 },
+		{ installationId: null, telemetryEnabled: false, firstLaunchedAt: null, noticeVersion: 0, firstLaunchHeardFrom: null },
 		"a corrupt state file fails closed without resurrecting telemetry",
 	);
 	writeFileSync(stateFile, JSON.stringify({ installationId: "person@example.com" }));


### PR DESCRIPTION
## Summary
- add bucketed app session end telemetry through pagehide/beforeunload Beacon
- add deduplicated feature usage, project save/open retention signals, and hosted composer funnel events
- register origin/os/install metadata and add optional first launch acquisition prompt
- document the disclosed wire contract in README and THIRD_PARTY_NOTICES

## Validation
- `npm test` (build + 116 Node verification files)
- `npm run test:analytics`
- `node test/verify-telemetry-state.mjs`
- `node test/verify-project.mjs`
