### PR TITLE
feat(agent): codex backend client (#124)

### DIFF
--- a/bin/agent/codex-client.mjs
+++ b/bin/agent/codex-client.mjs
@@ -1,0 +1,287 @@
+// Codex backend client (issue #124): a zero-dependency Node 20+ module that
+// talks to https://chatgpt.com/backend-api/codex with a ChatGPT OAuth bearer.
+//
+// Facts verified against the live backend (2026-09-06):
+// - POST /responses MUST send store:false, stream:true and an array `input`;
+//   the backend rejects max_output_tokens, previous_response_id, background,
+//   store:true and stream:false — so those keys are never sent.
+// - Reasoning items may only be replayed verbatim (never fabricated).
+// - The account allows ~1 concurrent request: parallel calls get 429 with
+//   Retry-After 5-8s → every request is serialized and 429s sleep Retry-After.
+
+const CODEX_BASE = "https://chatgpt.com/backend-api/codex";
+const CLIENT_VERSION = "0.153.4";
+
+function defaultSleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Normalizes missing/absent header values. */
+function readHeader(headersLike, name) {
+	if (!headersLike) return undefined;
+	if (typeof headersLike.get === "function") {
+		const value = headersLike.get(name);
+		return value === null ? undefined : value;
+	}
+	return headersLike[name];
+}
+
+function toNumber(value) {
+	if (value === undefined || value === null || value === "") return undefined;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toFlag(value) {
+	if (value === undefined) return false;
+	return String(value).trim().toLowerCase() === "true";
+}
+
+/** Parses an SSE byte stream into parsed JSON events. */
+async function* parseSseEvents(body) {
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buffer += decoder.decode(value, { stream: true });
+		let boundary;
+		while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+			const frame = buffer.slice(0, boundary);
+			buffer = buffer.slice(boundary + 2);
+			const data = frame
+				.split("\n")
+				.filter((line) => line.startsWith("data:"))
+				.map((line) => line.slice(5).replace(/^ /, ""))
+				.join("\n");
+			if (!data || data === "[DONE]") continue;
+			try {
+				yield JSON.parse(data);
+			} catch {
+				// Malformed frame: skip rather than kill the stream.
+			}
+		}
+	}
+}
+
+function messageText(item) {
+	return (item.content ?? [])
+		.filter((part) => part.type === "output_text")
+		.map((part) => part.text)
+		.join("");
+}
+
+/** Width/height from a PNG IHDR chunk: bytes 16..24, big-endian. */
+function pngDimensions(base64) {
+	const buffer = Buffer.from(base64, "base64");
+	return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
+export function createCodexClient({
+	getAccessToken,
+	getAccountId,
+	fetch = globalThis.fetch,
+	originator = "cozyclay",
+	sleep = defaultSleep,
+}) {
+	// The account allows ~1 concurrent request: chain every backend request so
+	// at most one is in flight, regardless of how callers interleave calls.
+	let chain = Promise.resolve();
+	function enqueue(task) {
+		const run = chain.then(task);
+		chain = run.then(() => {}, () => {});
+		return run;
+	}
+
+	async function requestHeaders(extra = {}) {
+		const [accessToken, accountId] = await Promise.all([getAccessToken(), getAccountId()]);
+		return {
+			authorization: `Bearer ${accessToken}`,
+			"chatgpt-account-id": accountId,
+			originator,
+			"openai-beta": "responses=experimental",
+			...extra,
+		};
+	}
+
+	/** POST/GET with 429 Retry-After backoff; returns the final Response. */
+	async function fetchWithRetry(url, init) {
+		while (true) {
+			const response = await fetch(url, init);
+			if (response.status === 429) {
+				const retryAfter = toNumber(response.headers.get("retry-after")) ?? 5;
+				await sleep(retryAfter * 1000);
+				continue;
+			}
+			if (!response.ok) {
+				const detail = await response.text();
+				const error = new Error(`codex request failed (${response.status}): ${detail}`);
+				error.status = response.status;
+				if (response.status === 401) error.code = "unauthorized"; // bearer expired → re-login
+				throw error;
+			}
+			return response;
+		}
+	}
+
+	function postJson(path, body, signal) {
+		return enqueue(async () =>
+			fetchWithRetry(`${CODEX_BASE}${path}`, {
+				method: "POST",
+				headers: await requestHeaders({ "content-type": "application/json" }),
+				body: JSON.stringify(body),
+				signal,
+			}));
+	}
+
+	function buildResponsesBody(request) {
+		return {
+			instructions: request.instructions ?? "",
+			input: request.input ?? [],
+			tools: request.tools ?? [],
+			include: ["reasoning.encrypted_content"],
+			store: false,
+			stream: true,
+			...(request.model ? { model: request.model } : {}),
+		};
+	}
+
+	/**
+	 * POST /responses and stream the parsed SSE events.
+	 * Returns { headers, [Symbol.asyncIterator] } — `headers` resolves with the
+	 * Response headers as soon as they are available (including quota headers).
+	 */
+	function streamResponses(request) {
+		let resolveHeaders;
+		let rejectHeaders;
+		const headers = new Promise((resolve, reject) => {
+			resolveHeaders = resolve;
+			rejectHeaders = reject;
+		});
+		let started;
+		const start = () => {
+			if (!started) {
+				started = postJson("/responses", buildResponsesBody(request), request.signal)
+					.then((response) => {
+						resolveHeaders(response.headers);
+						return parseSseEvents(response.body);
+					});
+				started.catch(rejectHeaders);
+			}
+			return started;
+		};
+		return {
+			headers,
+			async *[Symbol.asyncIterator]() {
+				yield* await start();
+			},
+		};
+	}
+
+	/**
+	 * Runs a full agent turn: consumes `history`, executes tool calls through
+	 * `executeTool`, appends the function_call item plus a function_call_output
+	 * item and re-POSTs until the model produces a final assistant message.
+	 * Reasoning items are replayed verbatim exactly as the backend emitted them.
+	 */
+	async function runAgentTurn({ history, tools = [], executeTool, onEvent, signal, instructions, model }) {
+		const continued = [...history];
+		let finalText = "";
+		while (true) {
+			const stream = streamResponses({ input: continued, tools, instructions, model, signal });
+			const outputItems = [];
+			for await (const event of stream) {
+				if (onEvent) onEvent(event);
+				if (event.type === "response.output_item.done") outputItems.push(event.item);
+			}
+			let calledTool = false;
+			for (const item of outputItems) {
+				if (item.type === "message" && item.role === "assistant") {
+					finalText += messageText(item);
+				}
+			}
+			for (const item of outputItems) {
+				if (item.type === "function_call") {
+					calledTool = true;
+					let parsedArguments = item.arguments;
+					try {
+						parsedArguments = JSON.parse(item.arguments);
+					} catch {
+						// Non-JSON arguments: hand the raw string to the executor.
+					}
+					const result = await executeTool({
+						call_id: item.call_id,
+						name: item.name,
+						arguments: parsedArguments,
+					});
+					continued.push(item);
+					continued.push({
+						type: "function_call_output",
+						call_id: item.call_id,
+						output: typeof result === "string" ? result : JSON.stringify(result),
+					});
+				} else {
+					continued.push(item); // message/reasoning replayed verbatim
+				}
+			}
+			if (!calledTool) break;
+		}
+		return { history: continued, finalText };
+	}
+
+	async function editImage({ prompt, imageDataUrl, quality = "auto", signal }) {
+		const response = await postJson("/images/edits", {
+			model: "gpt-image-2",
+			prompt,
+			images: [{ image_url: imageDataUrl }],
+			quality,
+		}, signal);
+		const payload = await response.json();
+		const pngBase64 = payload.data[0].b64_json;
+		return { pngBase64, ...pngDimensions(pngBase64), headers: response.headers };
+	}
+
+	async function generateImage({ prompt, quality = "auto", signal }) {
+		const response = await postJson("/images/generations", {
+			model: "gpt-image-2",
+			prompt,
+			quality,
+		}, signal);
+		const payload = await response.json();
+		const pngBase64 = payload.data[0].b64_json;
+		return { pngBase64, ...pngDimensions(pngBase64), headers: response.headers };
+	}
+
+	async function listModels() {
+		const response = await enqueue(async () => fetchWithRetry(`${CODEX_BASE}/models?client_version=${CLIENT_VERSION}`, {
+			headers: await requestHeaders(),
+		}));
+		return response.json();
+	}
+
+	function parseQuotaHeaders(headersLike) {
+		return {
+			planType: readHeader(headersLike, "x-codex-plan-type"),
+			primary: {
+				usedPercent: toNumber(readHeader(headersLike, "x-codex-primary-used-percent")),
+				windowMinutes: toNumber(readHeader(headersLike, "x-codex-primary-window-minutes")),
+				resetAfterSeconds: toNumber(readHeader(headersLike, "x-codex-primary-reset-after-seconds")),
+				resetAt: readHeader(headersLike, "x-codex-primary-reset-at"),
+			},
+			secondary: {
+				usedPercent: toNumber(readHeader(headersLike, "x-codex-secondary-used-percent")),
+				windowMinutes: toNumber(readHeader(headersLike, "x-codex-secondary-window-minutes")),
+				resetAfterSeconds: toNumber(readHeader(headersLike, "x-codex-secondary-reset-after-seconds")),
+				resetAt: readHeader(headersLike, "x-codex-secondary-reset-at"),
+			},
+			credits: {
+				balance: toNumber(readHeader(headersLike, "x-codex-credits-balance")),
+				hasCredits: toFlag(readHeader(headersLike, "x-codex-credits-has-credits")),
+				unlimited: toFlag(readHeader(headersLike, "x-codex-credits-unlimited")),
+			},
+		};
+	}
+
+	return { streamResponses, runAgentTurn, editImage, generateImage, listModels, parseQuotaHeaders };
+}

--- a/test/verify-codex-client.mjs
+++ b/test/verify-codex-client.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+// Verifies the Codex backend client (issue #124) against a mocked fetch.
+// No network: every request is recorded and answered with canned SSE/JSON.
+import assert from "node:assert/strict";
+import { createCodexClient } from "../bin/agent/codex-client.mjs";
+
+function pass(label) { console.log(`PASS ${label}`); }
+
+// 1x1 transparent PNG; IHDR width/height live at byte offsets 16..24 (big-endian).
+const PNG_1X1_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+/** Builds a fetch mock that records requests and replays scripted responses. */
+function mockFetch(script) {
+	const calls = [];
+	const queue = [...script];
+	async function fakeFetch(url, init = {}) {
+		const entry = {
+			url,
+			method: init.method ?? "GET",
+			headers: init.headers ?? {},
+			body: typeof init.body === "string" ? JSON.parse(init.body) : undefined,
+			rawBody: init.body,
+		};
+		calls.push(entry);
+		const next = queue.shift();
+		if (!next) throw new Error(`unexpected request #${calls.length}: ${entry.method} ${url}`);
+		return next(entry);
+	}
+	fakeFetch.calls = calls;
+	return fakeFetch;
+}
+
+function sseResponse(events, headers = {}) {
+	const payload = events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join("");
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream", ...headers },
+	});
+}
+
+function jsonResponse(body, headers = {}) {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json", ...headers },
+	});
+}
+
+const COMPLETED = { type: "response.completed", response: {} };
+
+const USER_ITEM = { type: "message", role: "user", content: [{ type: "input_text", text: "list the files" }] };
+
+// --- 1. streamResponses: body shape + header set ----------------------------
+{
+	const fetch = mockFetch([
+		() => sseResponse([
+			{ type: "response.created", response: { id: "r1" } },
+			COMPLETED,
+		]),
+	]);
+	const client = createCodexClient({ getAccessToken: async () => "tok-123", getAccountId: async () => "acct-9", fetch });
+	const stream = await client.streamResponses({ instructions: "be terse", input: [USER_ITEM], tools: [] });
+	const events = [];
+	for await (const event of stream) events.push(event);
+	const responseHeaders = await stream.headers;
+
+	assert.equal(events[0].type, "response.created");
+	assert.equal(events[0].response.id, "r1");
+	assert.equal(events[1].type, "response.completed");
+	assert.equal(responseHeaders.get("content-type"), "text/event-stream");
+
+	const call = fetch.calls[0];
+	assert.equal(call.url, "https://chatgpt.com/backend-api/codex/responses");
+	assert.equal(call.method, "POST");
+	assert.equal(call.headers.authorization, "Bearer tok-123");
+	assert.equal(call.headers["chatgpt-account-id"], "acct-9");
+	assert.equal(call.headers.originator, "cozyclay");
+	assert.equal(call.headers["openai-beta"], "responses=experimental");
+	assert.equal(call.headers["content-type"], "application/json");
+
+	assert.equal(call.body.store, false);
+	assert.equal(call.body.stream, true);
+	assert.ok(Array.isArray(call.body.input), "input must be an array of items");
+	assert.equal(call.body.instructions, "be terse");
+	assert.deepEqual(call.body.include, ["reasoning.encrypted_content"]);
+	for (const forbidden of ["max_output_tokens", "previous_response_id", "background"]) {
+		assert.ok(!(forbidden in call.body), `must never send ${forbidden}`);
+	}
+	pass("streamResponses sends codex /responses shape + headers");
+}
+
+// --- 2. SSE parsing of function_call items ----------------------------------
+{
+	const fetch = mockFetch([
+		() => sseResponse([
+			{ type: "response.created", response: {} },
+			{ type: "response.output_item.added", output_index: 0, item: { type: "function_call", id: "fc1", call_id: "call_abc", name: "list_files", arguments: "" } },
+			{ type: "response.function_call_arguments.delta", item_id: "fc1", delta: "{\"path\"" },
+			{ type: "response.function_call_arguments.delta", item_id: "fc1", delta: ":\"src\"}" },
+			{ type: "response.function_call_arguments.done", item_id: "fc1", arguments: "{\"path\":\"src\"}" },
+			{ type: "response.output_item.done", output_index: 0, item: { type: "function_call", id: "fc1", call_id: "call_abc", name: "list_files", arguments: "{\"path\":\"src\"}" } },
+			COMPLETED,
+		]),
+	]);
+	const client = createCodexClient({ getAccessToken: async () => "t", getAccountId: async () => "a", fetch });
+	const events = [];
+	for await (const event of client.streamResponses({ input: [USER_ITEM] })) events.push(event);
+
+	const done = events.find((event) => event.type === "response.output_item.done");
+	assert.equal(done.item.type, "function_call");
+	assert.equal(done.item.call_id, "call_abc");
+	assert.equal(done.item.name, "list_files");
+	assert.equal(done.item.arguments, "{\"path\":\"src\"}");
+	const deltas = events.filter((event) => event.type === "response.function_call_arguments.delta");
+	assert.equal(deltas.map((event) => event.delta).join(""), "{\"path\":\"src\"}");
+	pass("SSE function_call events parsed with call_id/name/arguments");
+}
+
+// --- 3. runAgentTurn: tool loop appends function_call + function_call_output --
+{
+	const fetch = mockFetch([
+		// Turn 1: model asks for a tool call.
+		() => sseResponse([
+			{ type: "response.created", response: {} },
+			{ type: "response.output_item.done", output_index: 0, item: { type: "reasoning", id: "rs1", summary: [], encrypted_content: "ENC" } },
+			{ type: "response.output_item.done", output_index: 1, item: { type: "function_call", id: "fc1", call_id: "call_abc", name: "list_files", arguments: "{\"path\":\"src\"}" } },
+			COMPLETED,
+		]),
+		// Turn 2: model answers after the tool output.
+		() => sseResponse([
+			{ type: "response.created", response: {} },
+			{ type: "response.output_item.done", output_index: 0, item: { type: "message", id: "m1", role: "assistant", content: [{ type: "output_text", text: "there are 3 files" }] } },
+			COMPLETED,
+		]),
+	]);
+	const client = createCodexClient({ getAccessToken: async () => "t", getAccountId: async () => "a", fetch });
+
+	const seenEvents = [];
+	const toolCalls = [];
+	const { history, finalText } = await client.runAgentTurn({
+		history: [USER_ITEM],
+		tools: [{ type: "function", name: "list_files", description: "list", parameters: { type: "object", properties: {} } }],
+		executeTool: async (call) => {
+			toolCalls.push(call);
+			return ["a.mjs", "b.mjs", "c.mjs"];
+		},
+		onEvent: (event) => seenEvents.push(event),
+	});
+
+	assert.equal(finalText, "there are 3 files");
+	assert.deepEqual(toolCalls, [{ call_id: "call_abc", name: "list_files", arguments: { path: "src" } }]);
+	assert.equal(seenEvents.length > 0, true, "onEvent should see every SSE event");
+
+	// Two POSTs: turn 1 (initial history) and turn 2 (with tool result appended).
+	assert.equal(fetch.calls.length, 2);
+	const firstInput = fetch.calls[0].body.input;
+	assert.deepEqual(firstInput, [USER_ITEM]);
+
+	const secondInput = fetch.calls[1].body.input;
+	const callItem = secondInput.find((item) => item.type === "function_call");
+	assert.ok(callItem, "re-POST must include the assistant function_call item");
+	assert.equal(callItem.call_id, "call_abc");
+	assert.equal(callItem.name, "list_files");
+	assert.equal(callItem.arguments, "{\"path\":\"src\"}");
+	const outputItem = secondInput.find((item) => item.type === "function_call_output");
+	assert.ok(outputItem, "re-POST must include the function_call_output item");
+	assert.equal(outputItem.call_id, "call_abc");
+	assert.ok(String(outputItem.output).includes("a.mjs"));
+
+	// Reasoning item replayed verbatim from the model output.
+	const reasoning = secondInput.find((item) => item.type === "reasoning");
+	assert.ok(reasoning, "reasoning item must be replayed");
+	assert.equal(reasoning.encrypted_content, "ENC");
+	assert.equal(reasoning.summary.length, 0);
+
+	// Returned history is the full continued conversation.
+	const historyTypes = history.map((item) => item.type);
+	assert.ok(historyTypes.includes("function_call") && historyTypes.includes("function_call_output") && historyTypes.includes("message"));
+	assert.equal(finalText, "there are 3 files");
+	pass("runAgentTurn appends function_call + function_call_output and re-POSTs");
+}
+
+// --- 4. editImage: /images/edits body + PNG IHDR dims ------------------------
+{
+	const fetch = mockFetch([
+		() => jsonResponse({ data: [{ b64_json: PNG_1X1_BASE64 }] }, { "x-codex-plan-type": "plus" }),
+	]);
+	const client = createCodexClient({ getAccessToken: async () => "t", getAccountId: async () => "a", fetch });
+	const dataUrl = `data:image/png;base64,${PNG_1X1_BASE64}`;
+	const result = await client.editImage({ prompt: "make it cozy", imageDataUrl: dataUrl, quality: "low" });
+
+	const call = fetch.calls[0];
+	assert.equal(call.url, "https://chatgpt.com/backend-api/codex/images/edits");
+	assert.equal(call.method, "POST");
+	assert.deepEqual(call.body.images, [{ image_url: dataUrl }]);
+	assert.equal(call.body.model, "gpt-image-2");
+	assert.equal(call.body.prompt, "make it cozy");
+	assert.equal(call.body.quality, "low");
+	assert.deepEqual(call.body, {
+		model: "gpt-image-2",
+		prompt: "make it cozy",
+		images: [{ image_url: dataUrl }],
+		quality: "low",
+	});
+
+	assert.equal(result.pngBase64, PNG_1X1_BASE64);
+	assert.equal(result.width, 1, "dims must come from the real PNG IHDR");
+	assert.equal(result.height, 1);
+	assert.equal(result.headers.get("x-codex-plan-type"), "plus");
+	pass("editImage body shape + IHDR dims");
+}
+
+// --- 5. generateImage: /images/generations body ------------------------------
+{
+	const fetch = mockFetch([
+		() => jsonResponse({ data: [{ b64_json: PNG_1X1_BASE64 }] }),
+	]);
+	const client = createCodexClient({ getAccessToken: async () => "t", getAccountId: async () => "a", fetch });
+	const result = await client.generateImage({ prompt: "a clay cat", quality: "high" });
+	const call = fetch.calls[0];
+	assert.equal(call.url, "https://chatgpt.com/backend-api/codex/images/generations");
+	assert.deepEqual(call.body, { model: "gpt-image-2", prompt: "a clay cat", quality: "high" });
+	assert.equal(result.width, 1);
+	assert.equal(result.height, 1);
+	pass("generateImage body shape + dims");
+}
+
+// --- 6. listModels ------------------------------------------------------------
+{
+	const fetch = mockFetch([
+		() => jsonResponse({ data: [{ slug: "gpt-5.1-codex", input_modalities: ["text", "image"] }] }),
+	]);
+	const client = createCodexClient({ getAccessToken: async () => "t", getAccountId: async () => "a", fetch });
+	const models = await client.listModels();
+	const call = fetch.calls[0];
+	assert.equal(call.url, "https://chatgpt.com/backend-api/codex/models?client_version=0.153.4");
+	assert.equal(call.method, "GET");
+	assert.equal(call.headers.authorization, "Bearer t");
+	assert.equal(models.data[0].slug, "gpt-5.1-codex");
+	pass("listModels GET with client_version");
+}
+
+// --- 7. parseQuotaHeaders ------------------------------------------------------
+{
+	const client = createCodexClient({ getAccessToken: async () => "t", getAccountId: async () => "a", fetch: async () => { throw new Error("no network"); } });
+	const quota = client.parseQuotaHeaders({
+		"x-codex-plan-type": "pro",
+		"x-codex-primary-used-percent": "42.5",
+		"x-codex-primary-window-minutes": "300",
+		"x-codex-primary-reset-after-seconds": "1234",
+		"x-codex-primary-reset-at": "2026-09-06T18:00:00Z",
+		"x-codex-secondary-used-percent": "7",
+		"x-codex-secondary-window-minutes": "10080",
+		"x-codex-secondary-reset-after-seconds": "600000",
+		"x-codex-secondary-reset-at": "2026-09-13T00:00:00Z",
+		"x-codex-credits-balance": "12.5",
+		"x-codex-credits-has-credits": "True",
+		"x-codex-credits-unlimited": "False",
+	});
+	assert.equal(quota.planType, "pro");
+	assert.equal(quota.primary.usedPercent, 42.5);
+	assert.equal(quota.primary.windowMinutes, 300);
+	assert.equal(quota.primary.resetAfterSeconds, 1234);
+	assert.equal(quota.primary.resetAt, "2026-09-06T18:00:00Z");
+	assert.equal(quota.secondary.usedPercent, 7);
+	assert.equal(quota.secondary.windowMinutes, 10080);
+	assert.equal(quota.secondary.resetAfterSeconds, 600000);
+	assert.equal(quota.secondary.resetAt, "2026-09-13T00:00:00Z");
+	assert.equal(quota.credits.balance, 12.5);
+	assert.equal(quota.credits.hasCredits, true);
+	assert.equal(quota.credits.unlimited, false);
+	// Missing headers must not crash.
+	const empty = client.parseQuotaHeaders({});
+	assert.equal(empty.planType, undefined);
+	assert.equal(empty.primary.usedPercent, undefined);
+	assert.equal(empty.credits.hasCredits, false);
+	pass("parseQuotaHeaders numbers/booleans");
+}
+
+// --- 8. 429 Retry-After honored (injected sleep, serialized) --------------------
+{
+	const sleeps = [];
+	const fetch = mockFetch([
+		(entry) => new Response(JSON.stringify({ detail: "rate limited" }), {
+			status: 429,
+			headers: { "retry-after": "6" },
+		}),
+		() => sseResponse([
+			{ type: "response.created", response: {} },
+			{ type: "response.output_item.done", output_index: 0, item: { type: "message", id: "m1", role: "assistant", content: [{ type: "output_text", text: "ok" }] } },
+			COMPLETED,
+		]),
+	]);
+	const client = createCodexClient({
+		getAccessToken: async () => "t",
+		getAccountId: async () => "a",
+		fetch,
+		sleep: async (ms) => { sleeps.push(ms); },
+	});
+	const { finalText } = await client.runAgentTurn({ history: [USER_ITEM], tools: [], executeTool: async () => null });
+	assert.equal(finalText, "ok");
+	assert.deepEqual(sleeps, [6000], "must sleep Retry-After seconds after a 429");
+	assert.equal(fetch.calls.length, 2);
+	pass("429 Retry-After honored via injected sleep");
+}
+
+// --- 9. two overlapping calls are serialized (one in flight) ---------------------
+{
+	let inFlight = 0;
+	let maxInFlight = 0;
+	const fetch = mockFetch([
+		() => sseResponse([COMPLETED]),
+		() => sseResponse([COMPLETED]),
+	]);
+	const wrappedFetch = async (url, init) => {
+		inFlight += 1;
+		maxInFlight = Math.max(maxInFlight, inFlight);
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			return await fetch(url, init);
+		} finally {
+			inFlight -= 1;
+		}
+	};
+	const client = createCodexClient({ getAccessToken: async () => "t", getAccountId: async () => "a", fetch: wrappedFetch });
+	const consume = async (stream) => { for await (const _ of stream); };
+	await Promise.all([
+		consume(client.streamResponses({ input: [USER_ITEM] })),
+		consume(client.streamResponses({ input: [USER_ITEM] })),
+	]);
+	assert.equal(maxInFlight, 1, "codex account allows ~1 concurrent request; calls must serialize");
+	pass("overlapping requests serialized");
+}
+
+console.log("PASS test/verify-codex-client.mjs");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -55,6 +55,7 @@ const NODE_FILES = [
 	"test/verify-camera-move.mjs",
 	"test/verify-camera-rail-schedule.mjs",
 	"test/verify-cuts.mjs",
+	"test/verify-codex-client.mjs",
 	"test/verify-shot-guides.mjs",
 	"test/verify-error-boundary.mjs",
 	"test/verify-footage-bridge.mjs",


### PR DESCRIPTION
Closes #124. Dependency-free Node 20+ client for the ChatGPT Codex backend.

## What
- `bin/agent/codex-client.mjs` (new, zero dependencies): `createCodexClient({ getAccessToken, getAccountId, fetch, originator, sleep })` exporting
  - `streamResponses(req)` — POST `https://chatgpt.com/backend-api/codex/responses` with `store:false`, `stream:true`, array `input`, `include:["reasoning.encrypted_content"]`; never sends `max_output_tokens`/`previous_response_id`/`background`; returns an async iterator of parsed SSE events plus a `.headers` promise (quota headers available pre-iteration).
  - `runAgentTurn({ history, tools, executeTool, onEvent, signal })` — appends the assistant `function_call` item + `{type:"function_call_output",call_id,output}` and re-POSTs; reasoning items replayed verbatim; returns `{history, finalText}`.
  - `editImage` / `generateImage` — `gpt-image-2` JSON payloads (`images:[{image_url}]` for edits); PNG dims parsed from IHDR bytes 16–24.
  - `listModels()` — GET `/models?client_version=0.153.4`.
  - `parseQuotaHeaders(headersLike)` — numeric primary/secondary windows + credit booleans.
  - All backend requests serialized through a queue; 429 → sleep `Retry-After` seconds and retry (account allows ~1 concurrent call). 401 surfaces `code:"unauthorized"` for re-login.
- `test/verify-codex-client.mjs` (new): mocked-fetch RED→GREEN suite — body shape, header set incl. `originator: cozyclay`, SSE `function_call` parsing, tool-loop re-POST shape, images body + real 1×1 PNG IHDR dims, quota header numbers/booleans, 429 Retry-After via injected sleep, request serialization. No network.
- `tools/run-tests.mjs`: ONE added line registering the new verify file as a Node test.

<details><summary>RED capture (test written first, before the implementation existed)</summary>
<pre><code>$ node test/verify-codex-client.mjs
node:internal/modules/esm/resolve:271
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/yun/CozyClay-wt/124/bin/agent/codex-client.mjs' imported from /Users/yun/CozyClay-wt/124/test/verify-codex-client.mjs
    at finalizeResolution (node:internal/modules/esm/resolve:271)
    ...
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/yun/CozyClay-wt/124/bin/agent/codex-client.mjs'

Node.js v24.19.0
exit=1</code></pre>
</details>

<details><summary>GREEN capture (test/verify-codex-client.mjs, mocked fetch, no network)</summary>
<pre><code>$ node test/verify-codex-client.mjs
PASS streamResponses sends codex /responses shape + headers
PASS SSE function_call events parsed with call_id/name/arguments
PASS runAgentTurn appends function_call + function_call_output and re-POSTs
PASS editImage body shape + IHDR dims
PASS generateImage body shape + dims
PASS listModels GET with client_version
PASS parseQuotaHeaders numbers/booleans
PASS 429 Retry-After honored via injected sleep
PASS overlapping requests serialized
PASS test/verify-codex-client.mjs
exit=0</code></pre>
</details>

## QA evidence
`node tools/run-tests.mjs` (after `npm run build` in the fresh worktree), exit 0:

```
PASS workflow import returns the stored asset
PASS workflow import announces same-tab changes
PASS workflow import writes the scenes storage key
PASS stored scene can be read back
PASS storage events announce cross-tab changes
PASS corrupt cross-tab scene bytes are ignored
PASS unsubscribe removes both event listeners
PASS event name is stable
PASS playback command announces same-tab controls
PASS playback command writes a transient storage value
PASS playback storage events announce cross-tab controls
PASS event name is stable

verify-workflow-scene-asset-sync: all green

PASS 125 Node verification files
```
