### PR TITLE
fix(mcp): restore G009 tool coverage and pack the tool handler registry (#127)

### DIFF
--- a/bin/package-signature.mjs
+++ b/bin/package-signature.mjs
@@ -11,6 +11,7 @@ const CONTENT_ROOTS = [
 	"tools",
 	"mcp/runtime",
 	"mcp/server.mjs",
+	"mcp/tool-handlers.mjs",
 	"mcp/live-hub.mjs",
 	"mcp/ardy-prompts.mjs",
 	"mcp/package.json",

--- a/mcp/tool-handlers.mjs
+++ b/mcp/tool-handlers.mjs
@@ -484,8 +484,8 @@ const tool = (name, config, handler) => ({
  * @param {Promise<string>} [deps.projectRootPromise] the resolved directory
  *   `open_project`/`save_project` confine themselves to; the owner resolves it
  *   because doing so chdirs the process.
- * @param {import("./live-hub.mjs").MotionJobRegistry} [deps.motionJobs] job book
- *   `generate_motion` records work in.
+ * @param {object} [deps.motionJobs] the MotionJobRegistry `generate_motion`
+ *   records work in.
  * @param {(job: object) => Promise<void>} [deps.publishMotionJob] delivers a
  *   finished job to its workspace; the owner holds it because the live hub's
  *   reconnect and cancel paths publish jobs too.

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "!tools/ardy/out",
     "!tools/qa-*.mjs",
     "mcp/server.mjs",
+    "mcp/tool-handlers.mjs",
     "mcp/live-hub.mjs",
     "mcp/ardy-prompts.mjs",
     "mcp/runtime",

--- a/test/verify-mcp-invariants.mjs
+++ b/test/verify-mcp-invariants.mjs
@@ -54,12 +54,21 @@ function sourceFailures(sources, pattern, label) {
 	);
 }
 
-function toolBlocks(server) {
-	const registrations = [...server.matchAll(/registerTool\(\s*\n\s*["']([^"']+)["']/g)];
+// The tools are declared in mcp/tool-handlers.mjs as `tool("name", {...})`
+// entries and registered from there by mcp/server.mjs, which may still call
+// `registerTool("name", {...})` directly. Both shapes are scanned, so moving a
+// tool between the two files cannot quietly drop it out of this contract.
+const TOOL_DECLARATION_SITES = [
+	{ path: "mcp/tool-handlers.mjs", keyword: "tool" },
+	{ path: "mcp/server.mjs", keyword: "registerTool" },
+];
+
+function toolBlocks(source, keyword = "registerTool") {
+	const registrations = [...source.matchAll(new RegExp(`(?<![\\w$.])${keyword}\\(\\s*\\n\\s*["']([^"']+)["']`, "g"))];
 	return registrations.map((match, index) => ({
 		name: match[1],
-		body: server.slice(match.index, registrations[index + 1]?.index),
-		line: lineAt(server, match.index),
+		body: source.slice(match.index, registrations[index + 1]?.index),
+		line: lineAt(source, match.index),
 	}));
 }
 
@@ -96,14 +105,20 @@ function rawArgumentFailures(scope, name, body, line, path, pattern) {
 function verifyG009(sources) {
 	const server = sources["mcp/server.mjs"] ?? "";
 	const app = sources["src/App.jsx"] ?? "";
-	const tools = toolBlocks(server);
+	const tools = TOOL_DECLARATION_SITES.flatMap(({ path, keyword }) =>
+		toolBlocks(sources[path] ?? "", keyword).map((tool) => ({ ...tool, path })),
+	);
 	const handlers = liveHandlers(app);
 	const failures = [
-		...tools.flatMap((tool) => rawArgumentFailures("tool", tool.name, schemaBody(tool.body), tool.line, "mcp/server.mjs", /\b([A-Za-z_$][\w$-]*)\s*:/g)),
+		// A rename that stops this parser finding the tools would turn every check
+		// below into a vacuous pass, so an empty scan is itself a failure.
+		...(tools.length === 0 ? [`G009 no MCP tool declarations found in ${TOOL_DECLARATION_SITES.map(({ path }) => path).join(" or ")}`] : []),
+		...tools.flatMap((tool) => rawArgumentFailures("tool", tool.name, schemaBody(tool.body), tool.line, tool.path, /\b([A-Za-z_$][\w$-]*)\s*:/g)),
 		...handlers.flatMap((handler) => rawArgumentFailures("live handler", handler.name, handler.body, handler.line, "src/App.jsx", /\bargs\.([A-Za-z_$][\w$-]*)\b/g)),
 	];
 	const handlerSources = {
 		"mcp/server.mjs": server,
+		"mcp/tool-handlers.mjs": sources["mcp/tool-handlers.mjs"] ?? "",
 		"mcp/live-hub.mjs": sources["mcp/live-hub.mjs"] ?? "",
 		"src/live-control.js": sources["src/live-control.js"] ?? "",
 		"src/App.jsx": app,
@@ -218,6 +233,8 @@ function selfTest(name, checks) {
 
 function runSelfTests() {
 	selfTest("G009", [verifyG009({ "mcp/server.mjs": 'registerTool(\n"run", { inputSchema: { code: z.string() } }, async () => eval("x"));', "src/App.jsx": "" })]);
+	selfTest("G009 registry", [verifyG009({ "mcp/tool-handlers.mjs": 'tool(\n"run", { inputSchema: { command: z.string() } }, async () => 0);', "src/App.jsx": "" })]);
+	selfTest("G009 empty scan", [verifyG009({ "src/App.jsx": "" })]);
 	selfTest("G010", [verifyG010({ "mcp/server.mjs": 'import y from "yjs";', "mcp/live-hub.mjs": 'const frame = { type: "cmd" };', "src/live-control.js": "dispatchLiveFrame", "src/App.jsx": "liveHandlersRef.current = {" })]);
 	selfTest("G012", [verifyG012({ "mcp/server.mjs": 'const method = "tasks/get";' })]);
 	selfTest("G013", [verifyG013({ root: { dependencies: {} }, mcp: { dependencies: { ...MCP_DEPENDENCY_BASELINE, drift: "1.0.0" } } })]);
@@ -230,7 +247,7 @@ const sources = readSources();
 const modes = entrypointModes();
 const [g009, g010, g012, g013, g014, executableEntrypoints] = runChecks(sources, packages(), modes);
 const failures = [g009, g010, g012, g013, g014, executableEntrypoints].flatMap((check) => check.failures);
-console.log(`G009 MCP tools scanned=${g009.tools.length}: ${g009.tools.map((tool) => tool.name).join(", ")}`);
+console.log(`G009 MCP tools scanned=${g009.tools.length} across ${[...new Set(g009.tools.map((tool) => tool.path))].join(", ")}: ${g009.tools.map((tool) => tool.name).join(", ")}`);
 console.log(`G009 live handlers scanned=${g009.handlers.length}: ${g009.handlers.map((handler) => handler.name).join(", ")}`);
 console.log("G010 agent mutation path: MCP tool -> appliedLiveMutation/liveHub.command -> WebSocket cmd frame -> dispatchLiveFrame -> App liveHandlersRef React-state handlers");
 console.log(`G010 source files scanned=${Object.keys(sources).length}; CRDT/OT imports=0`);


### PR DESCRIPTION
Follow-up to #131 (issue #127). Two gaps the tool registry extraction left behind, both found by re-reading what `test/verify-mcp-invariants.mjs` actually greps for.

## 1. G009 had become a vacuous pass

`verifyG009` parses tool declarations out of `mcp/server.mjs` **source text** with a `registerTool(\n"name"` regex. After #131 the tools declare themselves in `mcp/tool-handlers.mjs`, so that scan matched nothing and printed:

```
G009 MCP tools scanned=0:
```

The suite stayed green, but two checks had silently stopped checking anything:

- the **raw execution argument** scan over each tool's `inputSchema:` body (`code`, `script`, `command`, `shell`, `eval`, ...)
- the **forbidden execution primitive** scan (`eval(`, `new Function`, `child_process`, `spawn(`, `import(`), whose handler source set listed `mcp/server.mjs` but not the file the handler bodies moved into

Keeping the tool-name literals or the `TOOL_ANNOTATIONS` map in server.mjs would not have fixed this: G009 reads the **schemas**, and those are what moved. So this scans both declaration sites instead:

```js
const TOOL_DECLARATION_SITES = [
	{ path: "mcp/tool-handlers.mjs", keyword: "tool" },
	{ path: "mcp/server.mjs", keyword: "registerTool" },
];
```

Failures are attributed to the file they came from, `mcp/tool-handlers.mjs` joins the handler source set, and **an empty scan is now itself a failure**, so this cannot regress into a vacuous pass again. Three self-tests cover the new shapes (registry declaration, and the empty scan). The keyword match is anchored with `(?<![\w$.])` so `registerTool(` is not also counted as a `tool(` hit.

Result:

```
SELF-TEST G009 detector rejected fixture: G009 tool run accepts raw execution argument code at mcp/server.mjs:1
SELF-TEST G009 registry detector rejected fixture: G009 tool run accepts raw execution argument command at mcp/tool-handlers.mjs:1
SELF-TEST G009 empty scan detector rejected fixture: G009 no MCP tool declarations found in mcp/tool-handlers.mjs or mcp/server.mjs
G009 MCP tools scanned=25 across mcp/tool-handlers.mjs: describe_scene, live_status, ... save_project
PASS MCP invariants G009, G010, G012, G013, G014 and executable entrypoints
```

**The restored scan immediately earned its keep**: it flagged `G009 forbidden execution primitive mcp/tool-handlers.mjs:487 import(` — an `@param {import("./live-hub.mjs").MotionJobRegistry}` JSDoc type I wrote in #131. It is only a comment, but the detector is deliberately blunt about `import(` and weakening it to accommodate prose is the wrong trade, so the annotation is rewritten instead.

## 2. The registry was not in the published package

`package.json` `"files"` lists mcp sources individually, so a packed tarball shipped `mcp/server.mjs` importing a `mcp/tool-handlers.mjs` that was not there — `cozyclay mcp` would have failed at startup on a published build. Added to `"files"` and to `CONTENT_ROOTS` in `bin/package-signature.mjs` (the signature test builds and signs its own fixture at runtime, so no signing key is involved).

```
$ npm pack --dry-run --json --ignore-scripts   # mcp/ entries
mcp/ardy-prompts.mjs   mcp/live-hub.mjs   mcp/LIVE-PROTOCOL.md   mcp/package.json
mcp/README.md   mcp/runtime/...   mcp/server.mjs   mcp/tool-handlers.mjs
--- tool-handlers packed: true
```

## Verification

```
npm test  (vite build + tools/run-tests.mjs)   EXIT=0
25 tools registered
420 framing combinations checked
all checks passed
PASS 138 Node verification files
```

```
node test/verify-mcp-invariants.mjs   PASS  (G009 scanned=25, was 0)
node test/verify-package-signature.mjs  PASS  all official package signature checks
node test/verify-tool-handlers.mjs    PASS  25 tools, importable without an MCP server
```

## Note on scope

#131 deliberately did not touch `test/verify-mcp-invariants.mjs`, `package.json` or `bin/package-signature.mjs`, and flagged both of these as follow-ups in its body. Editing the invariants test is what the lead subsequently authorised; it is the only way to restore genuine G009 coverage without moving the schemas back into server.mjs and undoing the refactor. No production behaviour changes here — the only non-test edits are one JSDoc line and two packaging manifests.
