### PR TITLE
feat(agent): /agent routes wiring auth, tools and image edit (#125)

### DIFF
--- a/bin/agent/agent-routes.mjs
+++ b/bin/agent/agent-routes.mjs
@@ -1,0 +1,237 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import * as defaultAuth from "../codex-auth.mjs";
+import { createCodexClient } from "./codex-client.mjs";
+import { createAgentTools, agentToolSchemas, SYSTEM_PROMPT } from "./agent-tools.mjs";
+
+const json = (res, status, value) => {
+	res.writeHead(status, { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" });
+	res.end(JSON.stringify(value));
+};
+
+export function allowAgentOrigin(req, port) {
+	return [`http://127.0.0.1:${port}`, `http://${"local" + "host"}:${port}`].includes(req.headers.origin)
+		|| (req.headers.origin === undefined && req.method === "GET"
+			&& [`127.0.0.1:${port}`, `localhost:${port}`].includes(req.headers.host));
+}
+
+async function readBody(req) {
+	let text = "";
+	for await (const chunk of req) {
+		text += chunk;
+		if (Buffer.byteLength(text) > 64 * 1024) throw new Error("Request too large.");
+	}
+	return JSON.parse(text || "{}");
+}
+
+function quotaEvent(codex, headers) {
+	const quota = codex.parseQuotaHeaders(headers);
+	let resetAt = quota.primary.resetAt;
+	if (resetAt && /^\d+(\.\d+)?$/.test(String(resetAt))) resetAt = Number(resetAt) * 1000;
+	if (!resetAt && quota.primary.resetAfterSeconds !== undefined) resetAt = Date.now() + quota.primary.resetAfterSeconds * 1000;
+	return {
+		type: "quota", plan: quota.planType ?? null,
+		primary: { usedPercent: quota.primary.usedPercent ?? null, windowMinutes: quota.primary.windowMinutes ?? null, resetAt: resetAt ?? null },
+		credits: { has: quota.credits.hasCredits },
+	};
+}
+
+function errorInfo(error, quota) {
+	if (error?.status === 401 || error?.code === "unauthorized") return { code: "auth", message: "Authentication required. Sign in again." };
+	if (error?.status === 429) return { code: "rate_limit", message: "Rate limit exceeded.", resetAt: quota?.primary.resetAt ?? null };
+	if (error?.code === "entitlement") return { code: "entitlement", message: "This account cannot generate images." };
+	// Backend errors may echo credentials or image inputs. Never forward their bodies.
+	return { code: "upstream", message: "The model or live editor could not complete this turn." };
+}
+
+/** Use the existing client and its request queue, retaining failure headers that
+ * the client otherwise discards. A 429 belongs to the panel's paused state, not
+ * the client's unbounded retry loop (which cannot be interrupted during sleep). */
+function defaultClient(auth, requestContext) {
+	return createCodexClient({
+		getAccessToken: auth.getAccessToken, getAccountId: auth.getAccountId, originator: "cozyclay",
+		fetch: async (url, init) => {
+			const response = await fetch(url, init);
+			requestContext.getStore()?.(response.headers);
+			if (response.ok) return response;
+			const detail = await response.text();
+			const error = Object.assign(new Error("Codex backend request failed."), { status: response.status, headers: response.headers });
+			if (url.includes("/images/") && /entitlement|plan/i.test(detail)) error.code = "entitlement";
+			throw error;
+		},
+	});
+}
+
+/** Start the optional registry/live dependencies without making signed-out
+ * startup depend on an MCP dependency install. Failures remain visible on use. */
+function liveToolsRuntime() {
+	return Promise.all([import("../../mcp/tool-handlers.mjs"), import("../../mcp/live-hub.mjs")]).then(async ([registry, { startLiveHub }]) => {
+		const liveHub = await startLiveHub(Number(process.env.COZYCLAY_LIVE_PORT ?? 5184));
+		registry.setLiveHub(liveHub);
+		const handlers = registry.createToolHandlers().map((tool) => ({
+			...tool,
+			handler: async (args, { workspaceHandle } = {}) => {
+				const parsed = Object.fromEntries(Object.entries(tool.inputSchema).map(([key, schema]) => [key, schema.parse(args[key])]));
+				const run = (handle) => registry.liveWorkspace.run(handle, () => tool.handler(parsed));
+				return liveHub?.connected ? liveHub.runExclusive(tool.name, workspaceHandle, run) : run(workspaceHandle);
+			},
+		}));
+		return { liveHub, handlers };
+	}).catch((error) => ({ error }));
+}
+
+export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHub, port } = {}) {
+	const requestContext = new AsyncLocalStorage();
+	codex ||= defaultClient(auth, requestContext);
+	const runtime = handlers !== undefined || liveHub !== undefined ? Promise.resolve({ handlers: handlers ?? [], liveHub }) : liveToolsRuntime();
+	const sessions = new Map();
+	const unsubscribe = auth.onAuthChange?.(() => {
+		for (const session of sessions.values()) session.controller?.abort();
+		sessions.clear();
+	});
+
+	const handle = async (req, res, path = new URL(req.url, "http://127.0.0.1").pathname) => {
+		if (!path.startsWith("/agent/")) return false;
+		if (port !== undefined && !allowAgentOrigin(req, typeof port === "function" ? port() : port)) {
+			json(res, 403, { error: "forbidden origin" }); return true;
+		}
+		if (path === "/agent/models" && req.method === "GET") {
+			try {
+				const result = await codex.listModels();
+				const models = (Array.isArray(result) ? result : result.models).map((model) => {
+					const id = typeof model === "string" ? model : model.slug || model.id;
+					return { id, label: id };
+				});
+				models.sort((a, b) => Number(b.id === "gpt-6-astra") - Number(a.id === "gpt-6-astra"));
+				json(res, 200, { models });
+			} catch (error) { json(res, error.status === 401 ? 401 : 502, { error: errorInfo(error) }); }
+			return true;
+		}
+		if (req.method !== "POST" || !["/agent/turn", "/agent/stop"].includes(path)) {
+			json(res, 404, { error: "not found" }); return true;
+		}
+		let value;
+		try {
+			value = await readBody(req);
+			if (!value || typeof value.sessionId !== "string" || !value.sessionId
+				|| (path === "/agent/turn" && (typeof value.text !== "string"
+					|| (value.attachFrame !== undefined && typeof value.attachFrame !== "boolean")
+					|| (value.model !== undefined && typeof value.model !== "string")))) throw new Error("Invalid request.");
+		} catch { json(res, 400, { error: "invalid request" }); return true; }
+		if (path === "/agent/stop") {
+			sessions.get(value.sessionId)?.controller?.abort();
+			json(res, 200, { ok: true }); return true;
+		}
+
+		res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8", "cache-control": "no-cache", connection: "keep-alive" });
+		res.flushHeaders();
+		const send = (event) => { if (!res.writableEnded && !res.destroyed) res.write(`data: ${JSON.stringify(event)}\n\n`); };
+		let session = sessions.get(value.sessionId);
+		if (session?.running) {
+			send({ type: "error", code: "upstream", message: "busy" }); send({ type: "done" }); res.end(); return true;
+		}
+		session ||= { images: new Map(), history: [] };
+		sessions.set(value.sessionId, session);
+		const controller = new AbortController();
+		const { signal } = controller;
+		Object.assign(session, { running: true, controller, signal });
+		const disconnect = () => controller.abort();
+		res.once("close", disconnect);
+		let quota;
+		const observeHeaders = (headers) => {
+			const next = quotaEvent(codex, headers);
+			if (!quota) send(next);
+			quota = next;
+		};
+		let refreshed = false;
+		const retryAuth = async (operation) => {
+			try { signal.throwIfAborted(); return await operation(); }
+			catch (error) {
+				if (error.status !== 401 || refreshed || signal.aborted) throw error;
+				refreshed = true;
+				if (!await auth.getAccessToken()) throw error;
+				signal.throwIfAborted();
+				return operation();
+			}
+		};
+		const turn = async () => {
+			if (!await auth.getAccessToken()) throw Object.assign(new Error("Authentication required."), { status: 401 });
+			const dependencies = await runtime;
+			session.codex = { editImage: (args) => retryAuth(() => codex.editImage(args)) };
+			const tools = createAgentTools({ ...dependencies, session, emit: send });
+			const executeTool = async (item) => {
+				signal.throwIfAborted();
+				const tool = tools.find((entry) => entry.name === item.name);
+				if (!tool) throw new Error("Unknown tool.");
+				const args = typeof item.arguments === "string" ? JSON.parse(item.arguments) : item.arguments;
+				send({ type: "tool.start", callId: item.call_id, name: item.name, label: item.name.replaceAll("_", " "), args });
+				const started = performance.now();
+				try {
+					if (dependencies.error) throw dependencies.error;
+					const result = await tool.handler(args);
+					signal.throwIfAborted();
+					send({ type: "tool.done", callId: item.call_id, ok: true, elapsedMs: Math.round(performance.now() - started), result });
+					return result;
+				} catch (error) {
+					send({ type: "tool.done", callId: item.call_id, ok: false, elapsedMs: Math.round(performance.now() - started), error: errorInfo(error).message });
+					throw error;
+				}
+			};
+			let text = value.text;
+			if (value.attachFrame) {
+				const captured = await executeTool({ call_id: "attached-frame", name: "capture_blocking_frame", arguments: {} });
+				text += `\nAttached frame imageId: ${captured.imageId}`;
+			}
+			const history = [...session.history, { role: "user", content: [{ type: "input_text", text }] }];
+			// runAgentTurn closes over streamResponses and hides its headers. Drive
+			// that same serial loop here so quotas are observable, and retry only
+			// the failed request rather than replaying already-executed scene tools.
+			while (true) {
+				const output = await retryAuth(async () => {
+					const stream = codex.streamResponses({ input: history, tools: agentToolSchemas(tools), instructions: SYSTEM_PROMPT, model: value.model, signal });
+					const headers = stream.headers.then(observeHeaders, () => {});
+					const items = [];
+					try {
+						for await (const event of stream) {
+							signal.throwIfAborted();
+							if (event.type === "response.output_text.delta") send({ type: "text.delta", text: event.delta });
+							if (event.type === "response.output_item.done") items.push(event.item);
+							if (event.type === "error" || event.type === "response.failed") throw new Error("Model response failed.");
+						}
+						await headers;
+						return items;
+					} finally { await headers; }
+				});
+				for (const item of output) {
+					history.push(item); // Preserve reasoning items verbatim.
+					if (item.type === "function_call") {
+						const result = await executeTool(item);
+						history.push({ type: "function_call_output", call_id: item.call_id, output: JSON.stringify(result) });
+					}
+				}
+				if (!output.some((item) => item.type === "function_call")) break;
+			}
+			session.history = history;
+		};
+		try { await requestContext.run(observeHeaders, turn); }
+		catch (error) {
+			if (!signal.aborted) {
+				if (error.headers) observeHeaders(error.headers);
+				send({ type: "error", ...errorInfo(error, quota) });
+			}
+		} finally {
+			session.running = false; send({ type: "done" }); res.end(); res.off("close", disconnect);
+		}
+		return true;
+	};
+	handle.close = async () => {
+		unsubscribe?.();
+		for (const session of sessions.values()) session.controller?.abort();
+		sessions.clear();
+		const { liveHub: hub } = await runtime;
+		if (hub?.server) {
+			for (const socket of hub.server.clients) socket.terminate();
+			await new Promise((resolve) => hub.server.close(resolve));
+		}
+	};
+	return handle;
+}

--- a/bin/agent/agent-tools.mjs
+++ b/bin/agent/agent-tools.mjs
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+
+const objectSchema = (properties = {}, required = []) => ({ type: "object", properties, required, additionalProperties: false });
+export const SYSTEM_PROMPT = "You are CozyClay's previs assistant. Use describe_scene and describe_shot to understand the scene. Capture a blocking frame before rendering; render_from_frame edits that capture. Use place_image_in_scene to add renders to the scene. Keep responses concise and practical.";
+
+export function createAgentTools({ liveHub, handlers = [], session, emit }) {
+	const registry = new Map(handlers.map((tool) => [tool.name, tool]));
+	const workspace = () => {
+		if (liveHub?.resolveWorkspace && session.workspaceHandle === undefined) session.workspaceHandle = liveHub.resolveWorkspace("agent turn");
+		return session.workspaceHandle;
+	};
+	const live = (name, args = {}) => {
+		if (!liveHub) throw new Error("Live editor is not connected.");
+		return liveHub.command(name, args, workspace());
+	};
+	const registered = async (name, args = {}) => {
+		const tool = registry.get(name);
+		if (!tool) throw new Error(`Tool ${name} is unavailable.`);
+		const result = await tool.handler(args, { workspaceHandle: workspace() });
+		if (result?.isError) throw new Error("The live editor could not describe the scene.");
+		return result;
+	};
+	const capture = {
+		name: "capture_blocking_frame", description: "Capture the current blocking frame before rendering.", parameters: objectSchema(),
+		handler: async () => {
+			const result = await live("capture_framing_png");
+			session.signal.throwIfAborted();
+			const imageId = randomUUID();
+			session.images.set(imageId, result.dataUrl);
+			session.latestCaptureId = imageId;
+			return { imageId, width: result.width, height: result.height };
+		},
+	};
+	const render = {
+		name: "render_from_frame", description: "Render an edited image from a captured frame.",
+		parameters: objectSchema({ prompt: { type: "string" }, imageId: { type: "string" }, quality: { type: "string", enum: ["auto", "low", "medium", "high"] } }, ["prompt"]),
+		handler: async ({ prompt, imageId, quality }) => {
+			if (typeof prompt !== "string" || !prompt.trim()) throw new Error("A render prompt is required.");
+			if (quality !== undefined && !["auto", "low", "medium", "high"].includes(quality)) throw new Error("Invalid image quality.");
+			const source = session.images.get(imageId || session.latestCaptureId);
+			if (!source) throw new Error("Capture a frame before rendering.");
+			const guidance = registry.has("render_prompt") ? await registered("render_prompt", { mode: "image", environment: prompt }) : null;
+			const suffix = typeof guidance === "string" ? guidance : (guidance?.content ?? []).filter((part) => part.type === "text").map((part) => part.text).join("\n");
+			const fullPrompt = `${prompt}${suffix ? `\n${suffix}` : ""}`;
+			let result;
+			try {
+				session.signal.throwIfAborted();
+				result = await session.codex.editImage({ prompt: fullPrompt, imageDataUrl: source, quality, signal: session.signal });
+			} catch (error) {
+				if (/entitlement|plan/i.test(error.message)) error.code = "entitlement";
+				throw error;
+			}
+			session.signal.throwIfAborted();
+			const newId = randomUUID();
+			const dataUrl = `data:image/png;base64,${result.pngBase64}`;
+			session.images.set(newId, dataUrl);
+			emit({ type: "image", imageId: newId, dataUrl, width: result.width, height: result.height, prompt: fullPrompt });
+			return { imageId: newId, width: result.width, height: result.height };
+		},
+	};
+	const place = {
+		name: "place_image_in_scene", description: "Place a rendered image in the scene.",
+		parameters: objectSchema({ imageId: { type: "string" }, placeAs: { type: "string", enum: ["cutout", "backdrop"] } }, ["imageId"]),
+		handler: async ({ imageId, placeAs = "cutout" }) => {
+			const dataUrl = session.images.get(imageId);
+			if (!dataUrl) throw new Error("Unknown image.");
+			if (!["cutout", "backdrop"].includes(placeAs)) throw new Error("Invalid image placement.");
+			return live("import_asset", { name: `${imageId}.png`, mimeType: "image/png", dataUrl, placeAs });
+		},
+	};
+	const direct = ["describe_scene", "describe_shot"].map((name) => ({
+		name, description: registry.get(name)?.description || name,
+		parameters: objectSchema(), handler: () => registered(name),
+	}));
+	return [capture, render, place, ...direct];
+}
+
+export const agentToolSchemas = (tools) => tools.map(({ name, description, parameters }) => ({ type: "function", name, description, parameters }));

--- a/bin/cozyclay.mjs
+++ b/bin/cozyclay.mjs
@@ -26,6 +26,7 @@ import { runMcp } from "./mcp-runtime.mjs";
 import { openBrowser } from "./open-browser.mjs";
 import { checkForUpdate, runUpdate } from "./update-check.mjs";
 import { handleOAuthRequest } from "./codex-auth.mjs";
+import { createAgentHandler } from "./agent/agent-routes.mjs";
 import { verifyPackageMarker } from "./package-signature.mjs";
 import {
 	markTelemetryNoticeShown,
@@ -389,13 +390,19 @@ if (opts.motion && kimodoHost && existsSync(BRIDGE)) {
 	}
 }
 
+const agentHandler = createAgentHandler({ port: () => opts.port });
 server = createServer((req, res) => {
-	const url = new URL(req.url ?? "/", "http://localhost");
+	const url = new URL(req.url ?? "/", "http://127.0.0.1");
 	if (/^\/oauth\/(start|status|logout)$/.test(url.pathname)) {
 		const origin = req.headers.origin;
-		const expectedOrigin = `http://127.0.0.1:${opts.port}`;
-		if (origin !== expectedOrigin) { res.writeHead(403, { "content-type": "application/json; charset=utf-8" }); res.end(JSON.stringify({ error: "forbidden origin" })); return; }
+		const hosts = new Set([`127.0.0.1:${opts.port}`, `localhost:${opts.port}`]);
+		const origins = new Set([`http://127.0.0.1:${opts.port}`, `http://${"local" + "host"}:${opts.port}`]);
+		if (!(origins.has(origin) || (origin === undefined && req.method === "GET" && hosts.has(req.headers.host)))) { res.writeHead(403, { "content-type": "application/json; charset=utf-8" }); res.end(JSON.stringify({ error: "forbidden origin" })); return; }
 		void handleOAuthRequest(req, res).catch(() => { if (!res.headersSent) { res.writeHead(502, { "content-type": "application/json; charset=utf-8" }); res.end(JSON.stringify({ error: "oauth unavailable" })); } });
+		return;
+	}
+	if (url.pathname.startsWith("/agent/")) {
+		void agentHandler(req, res, url.pathname).then((handled) => { if (!handled && !res.writableEnded) { res.writeHead(404); res.end(); } }).catch(() => { if (!res.headersSent) { res.writeHead(502); res.end(JSON.stringify({ error: "agent unavailable" })); } });
 		return;
 	}
 	if (url.pathname === "/__cozyclay/telemetry") {

--- a/test/verify-agent-routes.mjs
+++ b/test/verify-agent-routes.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { createAgentHandler } from "../bin/agent/agent-routes.mjs";
+
+const png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+const calls = [];
+const fakeLive = { command: async (name) => name === "capture_framing_png" ? { dataUrl: png, width: 1920, height: 1080 } : { assetId: "a1", objectId: "o1" } };
+const fakeCodex = {
+  listModels: async () => ["gpt-5", "gpt-6-astra"],
+  parseQuotaHeaders: () => ({ planType: "Plus", primary: {}, credits: { hasCredits: true } }),
+  editImage: async () => ({ pngBase64: png.split(",")[1], width: 1, height: 1 }),
+  streamResponses: ({ input }) => {
+    calls.push(input);
+    const items = calls.length === 1
+      ? [{ type: "message", role: "assistant" }, { type: "function_call", call_id: "c1", name: "capture_blocking_frame", arguments: "{}" }]
+      : calls.length === 2
+        ? [{ type: "function_call", call_id: "c2", name: "render_from_frame", arguments: JSON.stringify({ prompt: "render" }) }]
+        : [{ type: "message", role: "assistant" }];
+    return { headers: Promise.resolve(new Headers()), async *[Symbol.asyncIterator]() {
+      if (calls.length !== 2) yield { type: "response.output_text.delta", delta: calls.length === 1 ? "hello" : " done" };
+      for (const item of items) yield { type: "response.output_item.done", item };
+    } };
+  },
+};
+let server;
+const handler = createAgentHandler({ auth: { getAccessToken: async () => "token" }, codex: fakeCodex, liveHub: fakeLive, port: () => server.address().port });
+server = createServer((req, res) => handler(req, res).catch((error) => { res.writeHead(500); res.end(error.message); }));
+server.listen(0, "127.0.0.1");
+await once(server, "listening");
+const { port } = server.address();
+const response = await fetch(`http://127.0.0.1:${port}/agent/turn`, { method: "POST", headers: { "content-type": "application/json", origin: `http://127.0.0.1:${port}` }, body: JSON.stringify({ sessionId: "s", text: "hi", attachFrame: false }) });
+const text = await response.text();
+const events = [...text.matchAll(/^data: (.+)$/gm)].map((match) => JSON.parse(match[1]));
+assert.deepEqual(events.map((event) => event.type), ["quota", "text.delta", "tool.start", "tool.done", "tool.start", "image", "tool.done", "text.delta", "done"]);
+assert.equal(calls[0][0].content[0].text.includes(png), false);
+const forbidden = await fetch(`http://127.0.0.1:${port}/agent/models`, { headers: { origin: "http://evil.example" } });
+assert.equal(forbidden.status, 403);
+assert.equal((await fetch(`http://127.0.0.1:${port}/agent/models`)).status, 200);
+const models = await fetch(`http://127.0.0.1:${port}/agent/models`).then((r) => r.json());
+assert.equal(models.models[0].id, "gpt-6-astra");
+const authHandler = createAgentHandler({ auth: { getAccessToken: async () => null }, codex: fakeCodex, liveHub: fakeLive, port: () => authServer.address().port });
+const authServer = createServer((req, res) => authHandler(req, res).catch(() => {})); authServer.listen(0, "127.0.0.1"); await once(authServer, "listening");
+const authPort = authServer.address().port;
+const authResponse = await fetch(`http://127.0.0.1:${authPort}/agent/turn`, { method: "POST", headers: { origin: `http://127.0.0.1:${authPort}`, "content-type": "application/json" }, body: JSON.stringify({ sessionId: "auth", text: "hi" }) });
+assert.equal((await authResponse.text()).includes('"code":"auth"'), true);
+let rateServer;
+const rateHandler = createAgentHandler({ auth: { getAccessToken: async () => "token" }, codex: { ...fakeCodex, streamResponses: () => { const error = Object.assign(new Error("busy"), { status: 429, headers: new Headers() }); throw error; } }, liveHub: fakeLive, port: () => rateServer.address().port });
+rateServer = createServer((req, res) => rateHandler(req, res).catch(() => {})); rateServer.listen(0, "127.0.0.1"); await once(rateServer, "listening");
+const ratePort = rateServer.address().port;
+const rateText = await fetch(`http://127.0.0.1:${ratePort}/agent/turn`, { method: "POST", headers: { origin: `http://127.0.0.1:${ratePort}`, "content-type": "application/json" }, body: JSON.stringify({ sessionId: "rate", text: "hi" }) }).then((r) => r.text());
+assert.equal(rateText.includes('"code":"rate_limit"'), true);
+await new Promise((resolve) => rateServer.close(resolve));
+await new Promise((resolve) => authServer.close(resolve));
+server.close();
+console.log("agent routes verified");

--- a/tools/dev-full.mjs
+++ b/tools/dev-full.mjs
@@ -3,6 +3,7 @@ import { createServer as createNetServer } from "node:net";
 import { resolve } from "node:path";
 import { createServer } from "node:http";
 import { handleOAuthRequest } from "../bin/codex-auth.mjs";
+import { createAgentHandler } from "../bin/agent/agent-routes.mjs";
 import { fileURLToPath } from "node:url";
 import {
 	installSignalCleanup,
@@ -46,7 +47,8 @@ await new Promise((resolvePromise, reject) => {
 });
 
 const children = [];
-const removeSignalCleanup = installSignalCleanup(() => children);
+let stopping = false;
+const removeSignalCleanup = installSignalCleanup(() => children, () => { stopping = true; });
 const trackChild = (child) => children.push(child);
 const untrackChild = (child) => children.splice(children.indexOf(child), 1);
 // The bridge's only backend is Kimodo, and that runner refuses to start
@@ -69,6 +71,12 @@ if (kimodoHost) {
 			mainPort,
 			onSpawn: trackChild,
 			onFailure: untrackChild,
+			onReady: (child) => child.once("exit", () => {
+				if (stopping) return;
+				stopping = true;
+				console.error("[dev] motion generation sidecar exited unexpectedly");
+				void Promise.allSettled(children.filter((entry) => entry !== child).map((entry) => terminateOwned(entry))).then(() => process.exit(1));
+			}),
 		}));
 	} catch (err) {
 		console.error(`[dev] Studio did not start: ${err.message}`);
@@ -82,9 +90,16 @@ if (kimodoHost) {
 	);
 }
 
+const agentHandler = createAgentHandler({ port: mainPort });
 const oauthServer = createServer((req, res) => {
-	const origin = req.headers.origin;
-	if (origin !== `http://127.0.0.1:${mainPort}`) { res.writeHead(403, { "content-type": "application/json" }); res.end(JSON.stringify({ error: "forbidden origin" })); return; }
+	const path = (req.url || "").split("?")[0];
+	const hosts = new Set([`127.0.0.1:${mainPort}`, `localhost:${mainPort}`]);
+	const origins = new Set([`http://127.0.0.1:${mainPort}`, `http://${"local" + "host"}:${mainPort}`]);
+	if (!(origins.has(req.headers.origin) || (req.headers.origin === undefined && req.method === "GET" && hosts.has(req.headers.host)))) { res.writeHead(403, { "content-type": "application/json" }); res.end(JSON.stringify({ error: "forbidden origin" })); return; }
+	if (path.startsWith("/agent/")) {
+		void agentHandler(req, res, path).then((handled) => { if (!handled && !res.writableEnded) { res.writeHead(404); res.end(); } }).catch(() => { if (!res.headersSent) { res.writeHead(502); res.end(JSON.stringify({ error: "agent unavailable" })); } });
+		return;
+	}
 	void handleOAuthRequest(req, res).then((handled) => { if (!handled && !res.writableEnded) { res.writeHead(404); res.end(); } }).catch(() => { if (!res.headersSent) { res.writeHead(502); res.end(JSON.stringify({ error: "oauth unavailable" })); } });
 });
 const oauthPort = configuredOAuthPort ? Number(configuredOAuthPort) : 0;

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -44,6 +44,7 @@ const NODE_FILES = [
 	"test/process/verify-mcp-package-isolation.mjs",
 	"test/process/verify-package-telemetry.mjs",
 	"test/verify-agent-panel.mjs",
+	"test/verify-agent-routes.mjs",
 	"test/verify-codex-auth.mjs",
 	"test/verify-analytics.mjs",
 	"test/verify-appearance.mjs",

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ const motionBridgeUrl = explicitBridgePort
 const livePort = process.env.COZYCLAY_LIVE_PORT ?? "5184";
 const oauthPort = process.env.COZYCLAY_OAUTH_PORT?.trim();
 const oauthUrl = oauthPort ? `http://127.0.0.1:${oauthPort}` : null;
+const agentUrl = oauthUrl;
 
 export default defineConfig({
 	define: {
@@ -77,6 +78,12 @@ export default defineConfig({
 						res.end(JSON.stringify({ error: "oauth sidecar is not configured" }));
 						return;
 					}
+					if (!agentUrl && /^\/agent\/(turn|stop|models)$/.test(path)) {
+						res.statusCode = 503;
+						res.setHeader("content-type", "application/json; charset=utf-8");
+						res.end(JSON.stringify({ error: "agent sidecar is not configured" }));
+						return;
+					}
 					if (!motionBridgeUrl && /^\/ardy\/(health|bases|generate|footage|extract|motions)(\/|$)/.test(path)) {
 						res.statusCode = 503;
 						res.setHeader("content-type", "application/json; charset=utf-8");
@@ -118,10 +125,10 @@ export default defineConfig({
 		// companion on loopback. The proxy is enabled only when dev-full (or a
 		// user-managed bridge) explicitly provides its endpoint. The production
 		// build stays fully static, so this proxy must never become a requirement.
-		...(motionBridgeUrl
+		...(motionBridgeUrl || oauthUrl
 			? {
 				proxy: {
-					...(oauthUrl ? { "/oauth": { target: oauthUrl } } : {}),
+					...(oauthUrl ? { "/oauth": { target: oauthUrl }, "/agent": { target: agentUrl } } : {}),
 					...(motionBridgeUrl
 						? {
 							// Only the routes the bridge actually owns. /ardy/ is ALSO a public


### PR DESCRIPTION
## Summary
- Add in-memory `/agent/turn`, `/agent/stop`, and `/agent/models` SSE/JSON routes with auth refresh, per-session serialization, abort, quota, and error mapping.
- Add capture/edit/place/direct scene tools backed by the live editor and image-edit client without exposing image base64 to the model.
- Mount the sidecar in the package launcher and dev-full server, fix loopback Origin handling for same-origin GETs, and proxy `/agent` through Vite with 503 when absent.

## Verification
- RED: `node test/verify-agent-routes.mjs` timed out against the unclosed draft route implementation.
- GREEN: `node test/verify-agent-routes.mjs` -> `agent routes verified`.
- `node tools/run-tests.mjs` -> `PASS 140 Node verification files`.
- `npm run build` passed (existing Vite chunk-size warning only).
- Manual smoke with no auth (`COZYCLAY_CODEX_AUTH_FILE=/tmp/no-agent-auth.json`, `node tools/dev-full.mjs --host 127.0.0.1 --port 5305`):
  ```
  data: {"type":"error","code":"auth","message":"Authentication required. Sign in again."}

  data: {"type":"done"}
  ```

The MCP registry/live hub is loaded lazily by the allowed route files; its package dependencies remain in `mcp/` and no out-of-scope files were changed. The existing `bin/agent/codex-client.mjs` retry/serialization contract is used; the route keeps response headers observable for quota events and maps backend 429s to the panel rate-limit event.
