### PR TITLE
fix(agent): pick the authoring workspace when several editors are connected (#135)

### DIFF
--- a/bin/agent/agent-tools.mjs
+++ b/bin/agent/agent-tools.mjs
@@ -3,10 +3,25 @@ import { randomUUID } from "node:crypto";
 const objectSchema = (properties = {}, required = []) => ({ type: "object", properties, required, additionalProperties: false });
 export const SYSTEM_PROMPT = "You are CozyClay's previs assistant. Use describe_scene and describe_shot to understand the scene. Capture a blocking frame before rendering; render_from_frame edits that capture. Use place_image_in_scene to add renders to the scene. Keep responses concise and practical.";
 
+/** The Workflow page embeds the Studio as a live preview, so the hub usually
+ * sees at least two editors. Prefer the tab the user is authoring in: any
+ * workspace whose hello meta does not say embed:true. Fall back to the hub's
+ * own single-workspace rule (which throws when the choice is ambiguous). */
+export function pickWorkspace(liveHub, requiredCommands = ["capture_framing_png", "import_asset"]) {
+	const details = typeof liveHub.workspaceHandleDetails === "function" ? liveHub.workspaceHandleDetails() : [];
+	// An editor that does not advertise its commands predates the agent work;
+	// it cannot answer capture_framing_png, so it is never a candidate.
+	const supports = (entry) => Array.isArray(entry.meta?.commands) && requiredCommands.every((name) => entry.meta.commands.includes(name));
+	const authoring = details.filter((entry) => entry.meta?.embed !== true && supports(entry)).map((entry) => entry.handle);
+	if (authoring.length === 1) return authoring[0];
+	if (authoring.length > 1) return authoring[authoring.length - 1];
+	return liveHub.resolveWorkspace("agent turn");
+}
+
 export function createAgentTools({ liveHub, handlers = [], session, emit }) {
 	const registry = new Map(handlers.map((tool) => [tool.name, tool]));
 	const workspace = () => {
-		if (liveHub?.resolveWorkspace && session.workspaceHandle === undefined) session.workspaceHandle = liveHub.resolveWorkspace("agent turn");
+		if (liveHub?.resolveWorkspace && session.workspaceHandle === undefined) session.workspaceHandle = pickWorkspace(liveHub);
 		return session.workspaceHandle;
 	};
 	const live = (name, args = {}) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3858,6 +3858,14 @@ globalThis.playMode = centerTab === "play";
 						project: projectName ?? "Untitled",
 						scene: scenes.find((entry) => entry.id === activeSceneId)?.name ?? "",
 						cast: charactersRef.current.length,
+						// The Workflow page embeds this same Studio as a preview. It is a
+						// live editor too, so an agent choosing a workspace must be able to
+						// tell the preview apart from the tab the user is authoring in.
+						...(embedMode ? { embed: true } : {}),
+						// Which live commands this editor answers. A stale tab from an
+						// older build (or a different app on the same port) answers a
+						// different set; the agent picks a workspace that has what it needs.
+						commands: Object.keys(liveHandlersRef.current ?? {}),
 					},
 					onWorkspace: setLiveWorkspaceHandle,
 					onEvent: (name, payload) => {

--- a/test/verify-agent-routes.mjs
+++ b/test/verify-agent-routes.mjs
@@ -63,9 +63,11 @@ console.log("agent routes verified");
 		workspaceHandleDetails: () => details,
 		resolveWorkspace: () => { throw new Error("requires workspace_handle"); },
 	});
-	assert.equal(pickWorkspace(hub([{ handle: "a", meta: { embed: true } }, { handle: "b", meta: { project: "P" } }])), "b", "skips the embedded preview");
-	assert.equal(pickWorkspace(hub([{ handle: "a", meta: null }, { handle: "b", meta: { project: "P" } }])), "b", "prefers the most recent authoring tab");
-	assert.throws(() => pickWorkspace(hub([{ handle: "a", meta: { embed: true } }])), /requires workspace_handle/, "falls back to the hub rule when only previews are connected");
+	const agentCommands = ["capture_framing_png", "import_asset"];
+	assert.equal(pickWorkspace(hub([{ handle: "a", meta: { embed: true, commands: agentCommands } }, { handle: "b", meta: { project: "P", commands: agentCommands } }])), "b", "skips the embedded preview");
+	assert.equal(pickWorkspace(hub([{ handle: "a", meta: { commands: agentCommands } }, { handle: "b", meta: { project: "P", commands: agentCommands } }])), "b", "prefers the most recent authoring tab");
+	assert.throws(() => pickWorkspace(hub([{ handle: "a", meta: { embed: true, commands: agentCommands } }])), /requires workspace_handle/, "falls back to the hub rule when only previews are connected");
+	assert.throws(() => pickWorkspace(hub([{ handle: "old", meta: { project: "P" } }])), /requires workspace_handle/, "an editor that does not advertise commands is not a candidate");
 	console.log("PASS pickWorkspace skips embedded previews");
 }
 

--- a/test/verify-agent-routes.mjs
+++ b/test/verify-agent-routes.mjs
@@ -54,3 +54,25 @@ await new Promise((resolve) => rateServer.close(resolve));
 await new Promise((resolve) => authServer.close(resolve));
 server.close();
 console.log("agent routes verified");
+
+// #135: the embedded Studio preview is a live editor too; the agent must
+// pick the authoring tab, not throw on "several workspaces connected".
+{
+	const { pickWorkspace } = await import("../bin/agent/agent-tools.mjs");
+	const hub = (details) => ({
+		workspaceHandleDetails: () => details,
+		resolveWorkspace: () => { throw new Error("requires workspace_handle"); },
+	});
+	assert.equal(pickWorkspace(hub([{ handle: "a", meta: { embed: true } }, { handle: "b", meta: { project: "P" } }])), "b", "skips the embedded preview");
+	assert.equal(pickWorkspace(hub([{ handle: "a", meta: null }, { handle: "b", meta: { project: "P" } }])), "b", "prefers the most recent authoring tab");
+	assert.throws(() => pickWorkspace(hub([{ handle: "a", meta: { embed: true } }])), /requires workspace_handle/, "falls back to the hub rule when only previews are connected");
+	console.log("PASS pickWorkspace skips embedded previews");
+}
+
+{
+	const { pickWorkspace } = await import("../bin/agent/agent-tools.mjs");
+	const hub = (details) => ({ workspaceHandleDetails: () => details, resolveWorkspace: () => { throw new Error("requires workspace_handle"); } });
+	// A stale tab (or another app on the live port) that lacks the agent commands is skipped.
+	assert.equal(pickWorkspace(hub([{ handle: "old", meta: { commands: ["describe"] } }, { handle: "new", meta: { commands: ["capture_framing_png", "import_asset"] } }])), "new", "skips workspaces without the agent commands");
+	console.log("PASS pickWorkspace skips workspaces lacking agent commands");
+}


### PR DESCRIPTION
Closes #135.

Reproduced on main @04365bb with a CDP probe: every agent turn failed with 'The model or live editor could not complete this turn.' because LiveHub.resolveWorkspace() threw 'requires workspace_handle' - the Workflow page's embedded Studio is a second live editor.

Fix: editor hello meta carries embed:true and commands:[...]; agent-tools.pickWorkspace() chooses the newest non-embedded workspace that answers capture_framing_png/import_asset.

RED->GREEN: mutating the embed filter fails 'skips the embedded preview'; restored -> PASS pickWorkspace skips embedded previews / skips workspaces lacking agent commands.

Real surface (dev 5180, signed in, model gpt-5.3-codex-spark): capture blocking frame 53ms ok -> describe shot -> describe scene -> render from frame (429: account image quota exhausted this window) -> paused card. Screenshot /tmp/agent-v1-qa-135/02-after-turn.png.

node tools/run-tests.mjs EXIT=0.