### PR TITLE
feat(character): part-colour render mode (#137)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -244,6 +244,7 @@ import {
 import LocaleToggle from "./locale-toggle.jsx";
 import { bucketCount, bucketMs, bucketProjectAge, motionBackendState, track, trackActivation, trackFeature } from "./analytics.js";
 import { ko, isKo } from "./locale.js";
+import { PART_COLOURS } from "./part-colours.js";
 import {
 	DEFAULT_POSE,
 	applyHipsOffset,
@@ -1033,6 +1034,8 @@ globalThis.playMode = centerTab === "play";
 	// every drag tick and must not re-render the scene; ikTick re-renders
 	// only the timeline markers.
 	const [ikMode, setIkMode] = useState(false);
+	const [partColoursEnabled, setPartColoursEnabled] = useState(false);
+	const [partColoursMode, setPartColoursMode] = useState("shaded");
 	const [ikChains, setIkChains] = useState(null);
 	const [ikFkJoints, setIkFkJoints] = useState(null);
 	const [ikFocus, setIkFocus] = useState(null);
@@ -3325,6 +3328,7 @@ globalThis.playMode = centerTab === "play";
 		stage: { shotAspect: shotAspectKey, sensorId, hasCharSheet },
 		timeline: { currentFrame: tlFrame, frameCount: tlFrameCount, fps: tlFps },
 		activeCharacterId,
+		partColours: partColoursEnabled ? PART_COLOURS : null,
 		waypoints,
 		characters,
 		objects: sceneObjects,
@@ -3772,6 +3776,7 @@ globalThis.playMode = centerTab === "play";
 			capture_frame: async () => {
 				const live = liveStateRef.current;
 				return captureMcpFrame({
+					partColours: live.partColours,
 					capture: mcpCaptureRef.current,
 					camera: shotCamRef.current,
 					characters: live.characters,
@@ -3806,6 +3811,7 @@ globalThis.playMode = centerTab === "play";
 					height: output.height,
 					frame: live.timeline.currentFrame,
 					shotId: live.activeShotId,
+					partColours: live.partColours,
 				};
 			},
 			load_motion: async (args) => {
@@ -3991,6 +3997,8 @@ globalThis.playMode = centerTab === "play";
 			position: clip ? [clip.anchorX, entry.y ?? 0, clip.anchorZ] : [entry.x, entry.y ?? 0, entry.z],
 			rot: clip ? clip.rotationDeg : entry.rot,
 			tint: entry.tint ?? defaultCharacterTint(entry, index),
+			partColoursEnabled,
+			partColoursMode,
 			pose: clip ? null : (entry.pose ?? DEFAULT_POSE),
 			// The stature the entry's take was extracted at. It rides with the
 			// clip, never separately — see Character for why.
@@ -3998,7 +4006,7 @@ globalThis.playMode = centerTab === "play";
 			onRig: reportRig(entry.id),
 			pickId: index === 0 ? "A" : index === 1 ? "B" : entry.id,
 		}];
-	}), [characters, activeChar.id, motion]);
+	}), [characters, activeChar.id, motion, partColoursEnabled, partColoursMode]);
 	// Where the selection gizmo stands: same driving rules as the render,
 	// for the active (selected) cast member only. Gated on the HIERARCHY
 	// selection, not the sticky active layer — the layer stays on the last
@@ -5925,6 +5933,10 @@ globalThis.playMode = centerTab === "play";
 			// QA-only: swap the active character's body ("x-bot-tpose" / "y-bot-tpose")
 			// or stature, so a browser QA run can check every shipped rig.
 			setCharacterModel: (id) => updateCharacterAt(activeCharIndex, { model: id }),
+			setPartColours: (enabled, mode = "shaded") => {
+				setPartColoursEnabled(!!enabled);
+				setPartColoursMode(mode === "flat" ? "flat" : "shaded");
+			},
 			setCharacterScale: (scale) => updateCharacterAt(activeCharIndex, { scale }),
 			characterScale: activeChar?.scale ?? 1,
 			characterModel: activeChar?.model ?? null,
@@ -6505,6 +6517,7 @@ globalThis.playMode = centerTab === "play";
 			prompt,
 			frame,
 			frameB,
+			partColours: partColoursEnabled ? PART_COLOURS : null,
 			move: movePlan,
 			mode,
 			modelLabel: model?.label,
@@ -6542,6 +6555,13 @@ globalThis.playMode = centerTab === "play";
 			a.click();
 			a.remove();
 		};
+		// A small sidecar keeps downloaded key frames tied to their palette.
+		if (result.partColours) {
+			const blob = new Blob([JSON.stringify({ partColours: result.partColours }, null, 2)], { type: "application/json" });
+			const url = URL.createObjectURL(blob);
+			save(url, "blocking-frame-palette.json");
+			setTimeout(() => URL.revokeObjectURL(url), 1000);
+		}
 		if (result.frameB) {
 			// named for the seat they take in a first/last-frame video request
 			save(result.frame, "blocking-frame-A-start.png");
@@ -9998,6 +10018,8 @@ function resizePromptClip(id, edge, rawFrame) {
 									position={view.position}
 									rot={view.rot}
 									tint={view.tint}
+									partColoursEnabled={view.partColoursEnabled}
+									partColoursMode={view.partColoursMode}
 									pose={view.pose}
 									scale={view.scale}
 									onRig={view.onRig}
@@ -10654,6 +10676,10 @@ function resizePromptClip(id, edge, rawFrame) {
 						</p>
 					</Foldout>
 
+				<Foldout hidden={!isCharacterSelection} title={ko("Part colours", "부위 색상")}>
+					<label className="check snap-toggle"><input type="checkbox" checked={partColoursEnabled} onChange={(e) => setPartColoursEnabled(e.target.checked)} /> {ko("Render body parts by colour", "신체 부위를 색상으로 렌더링")}</label>
+					{partColoursEnabled && <div className="move-ab"><button type="button" className={"btn ghost" + (partColoursMode === "shaded" ? " primary" : "")} onClick={() => setPartColoursMode("shaded")}>{ko("Shaded", "음영")}</button><button type="button" className={"btn ghost" + (partColoursMode === "flat" ? " primary" : "")} onClick={() => setPartColoursMode("flat")}>{ko("Flat", "평면")}</button></div>}
+				</Foldout>
 				<Foldout hidden={!isCharacterSelection} title={showB ? ko("Subjects", "인물들") : ko("Subject", "인물")}>
 						<div className={"subjects-row" + (showB ? "" : " single")}>
 							{characters.map((entry, index) => entry.hidden ? null : (

--- a/src/app-stage.jsx
+++ b/src/app-stage.jsx
@@ -876,32 +876,13 @@ export const Character = memo(function Character({ url, position, rot, tint, pos
 				child.receiveShadow = true;
 			}
 		});
+		if (partColoursEnabled) applyPartColours(clone, partColoursMode);
 		addFacingMarks(clone, jointTint);
 		// Stamp the bind pose while the rig is still untouched: the pose effect
 		// below runs immediately after and would otherwise be baked into "rest".
 		primeBindPose(clone);
 		return clone;
-	}, [fbx, tint]);
-
-	// Swap only the display surfaces. Keeping the same rig lets playback and
-	// authored poses continue across a mode change without rebuilding bones.
-	useEffect(() => {
-		if (!partColoursEnabled) return;
-		const originals = [];
-		model.traverse((mesh) => {
-			if (!mesh.isSkinnedMesh || !mesh.geometry?.attributes.skinIndex) return;
-			originals.push({ mesh, geometry: mesh.geometry, material: mesh.material });
-		});
-		applyPartColours(model, partColoursMode);
-		return () => {
-			for (const { mesh, geometry, material } of originals) {
-				mesh.geometry.dispose();
-				mesh.material.dispose();
-				mesh.geometry = geometry;
-				mesh.material = material;
-			}
-		};
-	}, [model, partColoursEnabled, partColoursMode]);
+	}, [fbx, tint, partColoursEnabled, partColoursMode]);
 
 	// A new stature (a fresh extraction on this character) must not rebuild the
 	// clone — that would drop the rig the playback effects hold. Only the world

--- a/src/app-stage.jsx
+++ b/src/app-stage.jsx
@@ -47,6 +47,7 @@ import ObjectGizmo from "./object-gizmo.jsx";
 import { MAX_PATH_POINTS } from "./object-path.js";
 import { track } from "./analytics.js";
 import { ko, isKo } from "./locale.js";
+import { applyPartColours } from "./part-colours.js";
 import { POSE_BONES, applyHipsOffset, applyPose, primeBindPose, normalizeBoneName } from "./poses.js";
 import { FK_TRACKS, IK_TRACKS, MID_TRACKS } from "./ardy/ik.js";
 import { RENDER_ACTIVITY_EVENT } from "./use-render-activity.js";
@@ -837,7 +838,7 @@ export function addFacingMarks(clone, markTint) {
 	mark(new THREE.ConeGeometry(1.7, 3.6, 4), [0, 2.8, 6.4], [Math.PI / 2, Math.PI / 4, 0]);
 }
 
-export const Character = memo(function Character({ url, position, rot, tint, pose, scale = 1, onRig, pickId }) {
+export const Character = memo(function Character({ url, position, rot, tint, pose, scale = 1, onRig, pickId, partColoursEnabled = false, partColoursMode = "shaded" }) {
 	const fbx = useFBX(url);
 	const model = useMemo(() => {
 		const clone = SkeletonUtils.clone(fbx);
@@ -881,6 +882,26 @@ export const Character = memo(function Character({ url, position, rot, tint, pos
 		primeBindPose(clone);
 		return clone;
 	}, [fbx, tint]);
+
+	// Swap only the display surfaces. Keeping the same rig lets playback and
+	// authored poses continue across a mode change without rebuilding bones.
+	useEffect(() => {
+		if (!partColoursEnabled) return;
+		const originals = [];
+		model.traverse((mesh) => {
+			if (!mesh.isSkinnedMesh || !mesh.geometry?.attributes.skinIndex) return;
+			originals.push({ mesh, geometry: mesh.geometry, material: mesh.material });
+		});
+		applyPartColours(model, partColoursMode);
+		return () => {
+			for (const { mesh, geometry, material } of originals) {
+				mesh.geometry.dispose();
+				mesh.material.dispose();
+				mesh.geometry = geometry;
+				mesh.material = material;
+			}
+		};
+	}, [model, partColoursEnabled, partColoursMode]);
 
 	// A new stature (a fresh extraction on this character) must not rebuild the
 	// clone — that would drop the rig the playback effects hold. Only the world
@@ -2406,7 +2427,7 @@ export function CaptureRig({ apiRef, camRef, width = CAPTURE_W, height = CAPTURE
 	return null;
 }
 
-export async function captureMcpFrame({ capture, camera, characters, activeCharacterId, objects, rigs, readAuthoredState }) {
+export async function captureMcpFrame({ capture, camera, characters, activeCharacterId, objects, rigs, readAuthoredState, partColours = null }) {
 	if (!capture || !camera) throw new Error("No renderable shot camera is available for capture_frame.");
 	const authoredStateBefore = JSON.stringify(readAuthoredState());
 	const buffer = capture.render();
@@ -2496,6 +2517,7 @@ export async function captureMcpFrame({ capture, camera, characters, activeChara
 		encoding: "base64",
 		byteSize: bytes.length,
 		data: btoa(binary),
+		partColours,
 		authoredStateBefore,
 		authoredStateAfter,
 		assertions: {

--- a/src/part-colours.js
+++ b/src/part-colours.js
@@ -1,0 +1,103 @@
+import * as THREE from "three";
+
+// One table travels with the captured frame: the video inbetweener and a
+// downstream colour segmenter must agree on which colour names each limb.
+// Keep these hex values stable; they are the original palette's sRGB colours.
+export const PART_COLOURS = Object.freeze([
+	{ part: "torso", bones: ["Hips", "Spine", "Spine1", "Spine2", "Neck", "LeftShoulder", "RightShoulder"], hex: "#FFFFFF", hue: null },
+	{ part: "head", bones: ["Head", "HeadTop_End"], hex: "#000000", hue: null },
+	{ part: "leftUpperArm", bones: ["LeftArm"], hex: "#FFD500", hue: 40 },
+	{ part: "rightUpperArm", bones: ["RightArm"], hex: "#00D0FF", hue: 202 },
+	{ part: "leftForeArm", bones: ["LeftForeArm"], hex: "#F1FF00", hue: 67 },
+	{ part: "rightForeArm", bones: ["RightForeArm"], hex: "#8D00FF", hue: 256 },
+	{ part: "leftHand", bones: ["LeftHand"], hex: "#B0FF00", hue: 94 },
+	{ part: "rightHand", bones: ["RightHand"], hex: "#DC00FF", hue: 283 },
+	{ part: "leftThigh", bones: ["LeftUpLeg"], hex: "#00FF23", hue: 121 },
+	{ part: "rightThigh", bones: ["RightUpLeg"], hex: "#FF00EB", hue: 310 },
+	{ part: "leftShin", bones: ["LeftLeg"], hex: "#FF00A6", hue: 337 },
+	{ part: "rightShin", bones: ["RightLeg"], hex: "#00FFF5", hue: 175 },
+	{ part: "leftFoot", bones: ["LeftFoot", "LeftToeBase", "LeftToe_End"], hex: "#00FFB6", hue: 148 },
+	{ part: "rightFoot", bones: ["RightFoot", "RightToeBase", "RightToe_End"], hex: "#0077FF", hue: 229 },
+]);
+
+function hueDistance(a, b) {
+	const difference = Math.abs(a - b) % 360;
+	return Math.min(difference, 360 - difference);
+}
+
+// Return useful diagnostics instead of throwing, so tests and palette editors
+// can report all three constraints together. Head and torso have no hue.
+export function paletteViolations(palette) {
+	const limbs = palette.filter((entry) => entry.hue !== null);
+	const violations = [];
+	for (const [index, limb] of limbs.entries()) {
+		if (limb.hue >= 10 && limb.hue <= 35) {
+			violations.push(`${limb.part}: hue is inside 10-35 degrees`);
+		}
+		for (const other of limbs.slice(index + 1)) {
+			if (hueDistance(limb.hue, other.hue) < 25) {
+				violations.push(`${limb.part}/${other.part}: hues are less than 25 degrees apart`);
+			}
+		}
+		if (!limb.part.startsWith("left")) continue;
+		const right = limbs.find((entry) => entry.part === limb.part.replace(/^left/, "right"));
+		if (right && hueDistance(limb.hue, right.hue) < 60) {
+			violations.push(`${limb.part}/${right.part}: pair is less than 60 degrees apart`);
+		}
+	}
+	return violations;
+}
+
+function normalizeBone(name) {
+	// FBXLoader removes the colon in Mixamo namespaces. Accept both the file's
+	// spelling and the loaded rig's spelling, as well as unprefixed bone names.
+	return String(name ?? "").replace(/^mixamorig:?/i, "").toLowerCase();
+}
+
+export function partForBone(name) {
+	const bone = normalizeBone(name);
+	return PART_COLOURS.find((entry) => entry.bones.some((candidate) => {
+		const canonical = normalizeBone(candidate);
+		return bone === canonical || bone.startsWith(canonical);
+	}))?.part ?? null;
+}
+
+export function applyPartColours(root, mode = "shaded") {
+	const palette = new Map(PART_COLOURS.map((entry) => [entry.part, new THREE.Color(entry.hex)]));
+	const fallback = palette.get("torso");
+	const unassigned = new Set();
+	root.traverse((mesh) => {
+		if (!mesh.isSkinnedMesh || !mesh.geometry?.attributes.skinIndex) return;
+		// SkeletonUtils clones bones but shares geometry with the cached FBX.
+		// Colour only this instance, so another character and the grey mode keep
+		// their original attributes. The caller restores/disposes this copy.
+		const geometry = mesh.geometry.clone();
+		const indices = geometry.attributes.skinIndex;
+		const weights = geometry.attributes.skinWeight;
+		const colours = new Float32Array(indices.count * 3);
+		for (let vertex = 0; vertex < indices.count; vertex += 1) {
+			let dominantBone = 0;
+			let largestWeight = -1;
+			for (let component = 0; component < 4; component += 1) {
+				const weight = weights?.getComponent(vertex, component) ?? 0;
+				if (weight > largestWeight) {
+					largestWeight = weight;
+					dominantBone = indices.getComponent(vertex, component);
+				}
+			}
+			const bone = mesh.skeleton?.bones[dominantBone]?.name;
+			const part = partForBone(bone);
+			if (!part) unassigned.add(bone);
+			const colour = palette.get(part) ?? fallback;
+			colour.toArray(colours, vertex * 3);
+		}
+		geometry.setAttribute("color", new THREE.BufferAttribute(colours, 3));
+		mesh.geometry = geometry;
+		// Unlit colours bypass tone mapping as well as lights, so an interior
+		// flat pixel encodes the palette hex exactly after sRGB output conversion.
+		mesh.material = mode === "flat"
+			? new THREE.MeshBasicMaterial({ vertexColors: true, toneMapped: false, fog: false })
+			: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.66, metalness: 0, envMapIntensity: 0.35 });
+	});
+	return [...unassigned];
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -6912,6 +6912,16 @@ input[type=range]::-moz-range-thumb {
 	font-size: 11px;
 }
 
+/* Keep the selected part-colour mode visible even though these controls use
+   the compact ghost-button treatment. */
+.move-ab .btn.ghost.primary,
+.move-ab .btn.ghost.primary:hover {
+	background: var(--grad);
+	border-color: transparent;
+	color: var(--on-accent);
+	box-shadow: var(--glow);
+}
+
 .move-ab .btn:disabled {
 	opacity: .45;
 	cursor: default;

--- a/test/qa-screenshot-browser.mjs
+++ b/test/qa-screenshot-browser.mjs
@@ -2,6 +2,13 @@ const port=Number(process.env.CDP_PORT||9222);const targets=await (await fetch(`
 if(process.env.QA_URL) await send("Page.navigate",{url:process.env.QA_URL});
 const t0=Date.now();while(Date.now()-t0<60000){if(await ev("!!(window.__cozyclay&&window.__cozyclay.motion&&window.__cozyclay.rigA&&window.__cozyclay.editorCam)").catch(()=>false))break;await new Promise(r=>setTimeout(r,250))}
 await new Promise(r=>setTimeout(r,1500)); if(process.env.HIDE_PROJECT_MODAL){ await ev(`(()=>{for(const el of document.querySelectorAll("body *")){const text=el.textContent||"";const style=getComputedStyle(el);if(style.position==="fixed"&&/Choose a project to begin|Project name|시작할 프로젝트/i.test(text))el.style.display="none";}return true;})()`); } if(process.env.CHAR_SCALE){ await ev(`window.__cozyclay.setCharacterScale(${process.env.CHAR_SCALE})`); await new Promise(r=>setTimeout(r,800)); } if(process.env.MODEL){ await ev(`window.__cozyclay.setCharacterModel("${process.env.MODEL}")`); const t1=Date.now(); await new Promise(r=>setTimeout(r,2500)); while(Date.now()-t1<30000){ if(await ev("!!(window.__cozyclay&&window.__cozyclay.rigA&&window.__cozyclay.motion)").catch(()=>false)) break; await new Promise(r=>setTimeout(r,250)); } } if(process.env.AUTO_PHYSICS){ await ev("window.__cozyclay.apRun()"); await new Promise(r=>setTimeout(r,500)); } const fs=await import("node:fs"); const frames=(process.env.FRAMES||"0,60,120,240").split(",").map(Number); const view=process.env.VIEW||"front";
+// Display-only mode: use the same React state transition as the Studio toggle.
+if (process.env.PART_COLOURS) {
+  const mode = process.env.PART_COLOURS;
+  if (!["off", "flat", "shaded"].includes(mode)) throw new Error("PART_COLOURS must be off, flat or shaded");
+  await ev(`window.__cozyclay.setPartColours(${mode !== "off"}, ${JSON.stringify(mode)})`);
+  await new Promise(r => setTimeout(r, 500));
+}
 for (const f of frames){
   const info=await ev(`(()=>{const c=window.__cozyclay; c.scrub(${f}); return new Promise(res=>{ let n=0; const tick=()=>{ const rig=c.rigA; rig.updateMatrixWorld(true); let hips=null; rig.traverse(o=>{if(!hips&&o.isBone&&/Hips$/.test(o.name))hips=o;}); const V=hips.position.constructor; const h=hips.getWorldPosition(new V()); const yaw = "${view}"==="front" ? 0 : "${view}"==="side" ? Math.PI/2 : "${view}"==="user" ? -Math.PI*0.75 : Math.PI*0.7; const dist = ("${view}"==="close"||"${view}"==="user") ? 1.9 : 3.0; const off=new V(Math.sin(yaw)*dist,0.35,Math.cos(yaw)*dist); const p=h.clone().add(off); c.frameEditorCam({x:p.x,y:p.y,z:p.z},{x:h.x,y:h.y*0.9,z:h.z}); n+=1; if(n<6) requestAnimationFrame(tick); else res({h:[h.x,h.y,h.z],cam:[p.x,p.y,p.z]}); }; requestAnimationFrame(tick); });})()`);
   await new Promise(r=>setTimeout(r,150));

--- a/test/verify-part-colours.mjs
+++ b/test/verify-part-colours.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import * as THREE from "three";
+import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader.js";
+import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils.js";
+import { PART_COLOURS, paletteViolations, partForBone, applyPartColours } from "../src/part-colours.js";
+
+assert.equal(PART_COLOURS.length, 14);
+assert.deepEqual(paletteViolations(PART_COLOURS), []);
+assert.equal(PART_COLOURS.find((entry) => entry.part === "torso").hex, "#FFFFFF");
+assert.equal(PART_COLOURS.find((entry) => entry.part === "head").hex, "#000000");
+for (const entry of PART_COLOURS.filter((part) => part.hue !== null)) {
+	const channels = entry.hex.slice(1).match(/../g).map((hex) => parseInt(hex, 16));
+	assert.equal(Math.min(...channels), 0, `${entry.part}: full saturation`);
+	assert.equal(Math.max(...channels), 255, `${entry.part}: full value`);
+}
+// Exercise circular distance and each rejection, so an empty stub cannot pass.
+assert.ok(paletteViolations([{ part: "leftHand", hue: 359 }, { part: "rightHand", hue: 1 }]).some((message) => message.includes("60 degrees")));
+assert.ok(paletteViolations([{ part: "leftHand", hue: 359 }, { part: "leftFoot", hue: 1 }]).some((message) => message.includes("25 degrees")));
+assert.ok(paletteViolations([{ part: "leftHand", hue: 20 }]).some((message) => message.includes("10-35")));
+console.log("PASS palette constraints and fully saturated, full-value limb hexes");
+
+// Same Node FBXLoader shim as test/ardy/verify-rest.mjs; read the shipped
+// assets themselves so a replacement rig cannot silently outgrow a fixture.
+globalThis.window ??= {
+	innerWidth: 1920,
+	innerHeight: 1080,
+	URL: { createObjectURL() { throw new Error("no embedded FBX textures under Node"); } },
+};
+for (const model of ["x-bot-tpose", "y-bot-tpose"]) {
+	const buffer = readFileSync(new URL(`../public/models/${model}.fbx`, import.meta.url));
+	const root = new FBXLoader().parse(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength), "");
+	const names = [];
+	root.traverse((bone) => {
+		if (bone.isBone) names.push(bone.name);
+	});
+	assert.ok(names.length > 0);
+	for (const name of names) {
+		const bare = name.replace(/^mixamorig:?/i, "");
+		for (const spelling of [name, bare, `mixamorig:${bare}`]) {
+			assert.ok(partForBone(spelling), `${model}: unassigned ${spelling}`);
+		}
+		if (/Hand/.test(name)) assert.equal(partForBone(name), /Left/.test(name) ? "leftHand" : "rightHand");
+		if (/Toe/.test(name)) assert.equal(partForBone(name), /Left/.test(name) ? "leftFoot" : "rightFoot");
+	}
+	const parts = new Set(names.map(partForBone));
+	assert.equal(parts.size, 14, `${model}: all fourteen parts`);
+	for (const mode of ["flat", "shaded"]) {
+		const clone = SkeletonUtils.clone(root);
+		const originals = new Map();
+		clone.traverse((mesh) => {
+			if (mesh.isSkinnedMesh) originals.set(mesh, mesh.geometry);
+		});
+		assert.deepEqual(applyPartColours(clone, mode), []);
+		for (const [mesh, original] of originals) {
+			assert.notEqual(mesh.geometry, original, "cached FBX geometry stays shared only by grey instances");
+			const colours = mesh.geometry.attributes.color;
+			const { skinIndex, skinWeight } = original.attributes;
+			assert.equal(colours.count, skinIndex.count);
+			for (let vertex = 0; vertex < skinIndex.count; vertex += 1) {
+				const weights = [skinWeight.getX(vertex), skinWeight.getY(vertex), skinWeight.getZ(vertex), skinWeight.getW(vertex)];
+				const indices = [skinIndex.getX(vertex), skinIndex.getY(vertex), skinIndex.getZ(vertex), skinIndex.getW(vertex)];
+				const bone = mesh.skeleton.bones[indices[weights.indexOf(Math.max(...weights))]];
+				const expected = new THREE.Color(PART_COLOURS.find((entry) => entry.part === partForBone(bone.name)).hex);
+				assert.ok(Math.abs(colours.getX(vertex) - expected.r) < 1e-6);
+				assert.ok(Math.abs(colours.getY(vertex) - expected.g) < 1e-6);
+				assert.ok(Math.abs(colours.getZ(vertex) - expected.b) < 1e-6);
+			}
+			assert.equal(!!mesh.material.isMeshBasicMaterial, mode === "flat");
+			if (mode === "flat") assert.equal(mesh.material.toneMapped, false);
+		}
+	}
+	console.log(`PASS ${model}: ${names.length} bones assigned; both modes match dominant weights at every vertex`);
+}
+assert.equal(partForBone("UnknownBone"), null);
+console.log("all part-colour checks PASS");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -49,6 +49,7 @@ const NODE_FILES = [
 	"test/verify-analytics.mjs",
 	"test/verify-appearance.mjs",
 	"test/verify-auto-color.mjs",
+	"test/verify-part-colours.mjs",
 	"test/verify-asset-shelf.mjs",
 	"test/verify-blocking-depth.mjs",
 	"test/verify-burn-in.mjs",


### PR DESCRIPTION
Closes #137

Adds the optional 14-part character colour display mode with shaded and flat rendering, stable palette metadata in frame captures/downloads, and a browser QA hook. The default mode remains off and keeps the existing grey materials.

Tests:
- `npm test` builds and runs the suite; all preceding checks passed, then the pre-existing `test/process/verify-lifecycle.mjs` failed on clean `origin/main` with `EMFILE: too many open files, watch`.
- `node test/verify-part-colours.mjs` passed for both shipped rigs (129 and 117 bones), palette constraints, saturation, and dominant-weight assignment.

Browser QA was blocked: the mandated `npm run qa:browser` Chrome wrapper exits before CDP startup in this environment (Chrome status 134), so no valid rendered screenshots were produced. The dev server was stopped afterward.

The requested screenshot output directory is `/Users/yun/CozyClay-wt/qa-137/`; it is empty because the browser could not start.


## Round 3

- Deterministic construction: `applyPartColours` now runs inside the `Character` model memo before facing marks/bind priming; the post-hoc swap/restore effect was removed. Grey mode keeps the original material path.
- Fresh-page x-bot shaded flow: 5/5 runs rendered coloured; CDP state reported `Beta_Surface` and `Beta_Joints` as `MeshStandardMaterial` with vertex colours on every run.
- Repeated screenshots: `/tmp/qa137/shots/rep-shaded-1.png` through `/tmp/qa137/shots/rep-shaded-5.png` (new run outputs are `/tmp/qa137/shots/rep-shaded-<n>.png`).
- Front-view references: `/tmp/qa137/shots/y-bot-tpose-shaded-front-f0.png`, `/tmp/qa137/shots/y-bot-tpose-flat-front-f0.png`, `/tmp/qa137/shots/y-bot-tpose-off-front-f0.png`, `/tmp/qa137/shots/x-bot-tpose-shaded-front-f0.png`, `/tmp/qa137/shots/x-bot-tpose-flat-front-f0.png`, `/tmp/qa137/shots/x-bot-tpose-off-front-f0.png`.
- `npm test`: PASS 141 Node verification files, 0 failures.
