### PR TITLE
fix(character): neutral grey head in the part-colour palette (#141)

### DIFF
--- a/src/part-colours.js
+++ b/src/part-colours.js
@@ -3,9 +3,11 @@ import * as THREE from "three";
 // One table travels with the captured frame: the video inbetweener and a
 // downstream colour segmenter must agree on which colour names each limb.
 // Keep these hex values stable; they are the original palette's sRGB colours.
+// The segmenter treats neutral grey as uncoloured and locates the head by its
+// adjacency to the torso, so the head intentionally has no hue.
 export const PART_COLOURS = Object.freeze([
 	{ part: "torso", bones: ["Hips", "Spine", "Spine1", "Spine2", "Neck", "LeftShoulder", "RightShoulder"], hex: "#FFFFFF", hue: null },
-	{ part: "head", bones: ["Head", "HeadTop_End"], hex: "#000000", hue: null },
+	{ part: "head", bones: ["Head", "HeadTop_End"], hex: "#8C8C8C", hue: null },
 	{ part: "leftUpperArm", bones: ["LeftArm"], hex: "#FFD500", hue: 40 },
 	{ part: "rightUpperArm", bones: ["RightArm"], hex: "#00D0FF", hue: 202 },
 	{ part: "leftForeArm", bones: ["LeftForeArm"], hex: "#F1FF00", hue: 67 },

--- a/test/verify-part-colours.mjs
+++ b/test/verify-part-colours.mjs
@@ -9,7 +9,15 @@ import { PART_COLOURS, paletteViolations, partForBone, applyPartColours } from "
 assert.equal(PART_COLOURS.length, 14);
 assert.deepEqual(paletteViolations(PART_COLOURS), []);
 assert.equal(PART_COLOURS.find((entry) => entry.part === "torso").hex, "#FFFFFF");
-assert.equal(PART_COLOURS.find((entry) => entry.part === "head").hex, "#000000");
+const headHex = PART_COLOURS.find((entry) => entry.part === "head").hex;
+assert.equal(headHex, "#8C8C8C");
+const headChannels = headHex.slice(1).match(/../g).map((hex) => parseInt(hex, 16) / 255);
+const headMax = Math.max(...headChannels);
+const headMin = Math.min(...headChannels);
+const headSaturation = headMax === 0 ? 0 : (headMax - headMin) / headMax;
+assert.ok(headSaturation < 0.1, `head saturation ${headSaturation} should be neutral`);
+assert.ok(headMax > 0.3, `head value ${headMax} should not be near-black`);
+assert.ok(headMax < 0.8, `head value ${headMax} should not be near-white`);
 for (const entry of PART_COLOURS.filter((part) => part.hue !== null)) {
 	const channels = entry.hex.slice(1).match(/../g).map((hex) => parseInt(hex, 16));
 	assert.equal(Math.min(...channels), 0, `${entry.part}: full saturation`);


### PR DESCRIPTION
Closes #141

Changed the part-colour palette head from black to neutral grey (`#8C8C8C`) and documented that the segmenter treats grey as neutral and locates the head by torso adjacency. Added assertions for unsaturated, mid-value head colour while keeping torso and limb colours unchanged.

Tests: `npm test` — PASS 142 Node verification files (after `cd mcp && npm install` to provide `ws`).

QA screenshot: `/tmp/qa141/ybot-shaded-front-f0.png`
