### PR TITLE
feat(ardy): --bone-scale override for gvhmr-to-cskel27 (#143)

### DIFF
--- a/test/smpl-cskel27.test.mjs
+++ b/test/smpl-cskel27.test.mjs
@@ -125,6 +125,11 @@ test("posed limb lengths equal the SMPL rest limb lengths and boneScale says so"
 	let low = Infinity; for (const j of ["LeftFoot", "RightFoot", "LeftToeBase", "RightToeBase"]) low = Math.min(low, at(0, J(j))[1]);
 	assert.ok(Math.abs(low) < 1e-3);
 });
+test("bone-scale override uses one uniform factor without changing timing", () => {
+	const input = fixture(3), derived = smplToCskel27Motion(input), uniform = smplToCskel27Motion(input, { boneScale: 1 });
+	assert.equal(uniform.frames, derived.frames); assert.equal(uniform.fps, derived.fps);
+	assert.ok([...uniform.boneScale].every((value) => value === 1)); assert.ok([...derived.boneScale].some((value) => value !== 1));
+});
 
 // Retarget POSE rotations, not the anatomical shape of SMPL's J-regressor.
 // Its zero-pose spine is an S curve and its head joint sits ~43 degrees in

--- a/tools/ardy/GVHMR-NPZ.md
+++ b/tools/ardy/GVHMR-NPZ.md
@@ -49,6 +49,7 @@ sampled frames from the front and side on both shipped bodies:
 
 ```bash
 node tools/ardy/gvhmr-to-cskel27.mjs /path/to/gvhmr.npz public/demo/qa-gvhmr.npz
+# For takes extracted from CozyClay-rendered clips, use --bone-scale 1.
 node --test test/smpl-cskel27.test.mjs
 
 # Keep `npm run dev:ui -- --host 127.0.0.1 --port 5180` running separately.

--- a/tools/ardy/gvhmr-to-cskel27.mjs
+++ b/tools/ardy/gvhmr-to-cskel27.mjs
@@ -3,12 +3,19 @@ import { readNpz } from "../kimodo/read-npz.mjs";
 import { motionArraysToNpzMembers, writeNpz } from "./npz.mjs";
 import { smplToCskel27Motion } from "./smpl-cskel27.mjs";
 
-const [input, output] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const input = args[0], output = args[1];
+let boneScale = "derive";
+for (let i = 2; i < args.length; i += 1) {
+	if (args[i] !== "--bone-scale" || i + 1 >= args.length) { console.error("usage: node tools/ardy/gvhmr-to-cskel27.mjs <gvhmr.npz> <motion.npz> [--bone-scale derive|number]"); process.exit(2); }
+	const value = args[++i];
+	if (value !== "derive") { boneScale = Number(value); if (!(Number.isFinite(boneScale) && boneScale > 0)) { console.error("--bone-scale must be derive or a positive number"); process.exit(2); } }
+}
 if (!input || !output) {
-	console.error("usage: node tools/ardy/gvhmr-to-cskel27.mjs <gvhmr.npz> <motion.npz>");
+	console.error("usage: node tools/ardy/gvhmr-to-cskel27.mjs <gvhmr.npz> <motion.npz> [--bone-scale derive|number]");
 	process.exit(2);
 }
 
-const motion = smplToCskel27Motion(readNpz(input));
+const motion = smplToCskel27Motion(readNpz(input), { boneScale });
 writeNpz(output, motionArraysToNpzMembers(motion));
-console.log(JSON.stringify({ output, frames: motion.frames, fps: motion.fps, boneScale: Boolean(motion.boneScale) }));
+console.log(JSON.stringify({ output, frames: motion.frames, fps: motion.fps, boneScale }));

--- a/tools/ardy/smpl-cskel27.mjs
+++ b/tools/ardy/smpl-cskel27.mjs
@@ -112,7 +112,8 @@ function sourceGlobals(go, pose, frames) {
 function writeMat(out, offset, m) { out[offset] = m[0][0]; out[offset + 1] = m[0][1]; out[offset + 2] = m[0][2]; out[offset + 3] = m[1][0]; out[offset + 4] = m[1][1]; out[offset + 5] = m[1][2]; out[offset + 6] = m[2][0]; out[offset + 7] = m[2][1]; out[offset + 8] = m[2][2]; }
 function percentile(values, p) { const a = [...values].sort((x, y) => x - y); const x = (a.length - 1) * p, i = Math.floor(x), t = x - i; return a[i] * (1 - t) + (a[i + 1] ?? a[i]) * t; }
 
-export function smplToCskel27Motion(members) {
+export function smplToCskel27Motion(members, { boneScale: boneScaleOption = "derive" } = {}) {
+	if (boneScaleOption !== "derive" && !(typeof boneScaleOption === "number" && Number.isFinite(boneScaleOption) && boneScaleOption > 0)) throw new Error('smplToCskel27Motion: boneScale must be "derive" or a positive number');
 	const go = data(members.smpl_global_orient), poseMember = members.smpl_body_pose;
 	const goShape = poseMember?.shape?.[0] ?? members.smpl_global_orient?.shape?.[0];
 	const frames = Number.isInteger(goShape) ? goShape : go.length / 3;
@@ -127,8 +128,8 @@ export function smplToCskel27Motion(members) {
 	const cpos = skeleton.posed_joints;
 	const restVec = (j) => [rest[j * 3], rest[j * 3 + 1], rest[j * 3 + 2]];
 	const dist = (a, b) => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
-	const boneScale = new Float32Array(27).fill(1);
-	for (let j = 1; j < 27; j += 1) {
+	const boneScale = new Float32Array(27).fill(typeof boneScaleOption === "number" ? boneScaleOption : 1);
+	for (let j = 1; j < 27 && boneScaleOption === "derive"; j += 1) {
 		const name = CSKEL27_JOINTS[j];
 		if (!LENGTH_SOURCE[name]) continue;
 		const [s0, s1] = LENGTH_SOURCE[name];


### PR DESCRIPTION
Adds a `boneScale` option to `smplToCskel27Motion` and exposes it through `gvhmr-to-cskel27` as `--bone-scale derive|<number>`. The default remains derived scaling; CozyClay-rendered takes can use `--bone-scale 1` to preserve canonical rig proportions.

Closes #143

Validation:
- `node --test test/smpl-cskel27.test.mjs` — 6 passed.
- Manual sample conversion (241 frames at 24 fps): default summary `{"boneScale":"derive"}`; override summary `{"boneScale":1}`.
- `npm test` builds successfully and runs the suite, but the existing `test/process/verify-lifecycle.mjs` fails in this environment with `EMFILE: too many open files, watch`; no test assertion failures were reported before that environment error.
