### PR TITLE
feat(agent): reasoning effort picker in the Agent panel

### DIFF
--- a/bin/agent/agent-routes.mjs
+++ b/bin/agent/agent-routes.mjs
@@ -3,6 +3,9 @@ import * as defaultAuth from "../codex-auth.mjs";
 import { createCodexClient } from "./codex-client.mjs";
 import { createAgentTools, agentToolSchemas, SYSTEM_PROMPT } from "./agent-tools.mjs";
 
+// Values the codex backend accepts for reasoning.effort (its own 400 lists them).
+export const REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+
 const json = (res, status, value) => {
 	res.writeHead(status, { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" });
 	res.end(JSON.stringify(value));
@@ -99,7 +102,8 @@ export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHu
 				const result = await codex.listModels();
 				const models = (Array.isArray(result) ? result : result.models).map((model) => {
 					const id = typeof model === "string" ? model : model.slug || model.id;
-					return { id, label: id };
+					const efforts = Array.isArray(model.supported_reasoning_levels) ? model.supported_reasoning_levels.map((level) => (typeof level === "string" ? level : level.effort)).filter(Boolean) : [];
+					return { id, label: id, efforts, defaultEffort: typeof model.default_reasoning_level === "string" ? model.default_reasoning_level : efforts[0] ?? null };
 				});
 				models.sort((a, b) => Number(b.id === "gpt-6-astra") - Number(a.id === "gpt-6-astra"));
 				json(res, 200, { models });
@@ -115,7 +119,8 @@ export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHu
 			if (!value || typeof value.sessionId !== "string" || !value.sessionId
 				|| (path === "/agent/turn" && (typeof value.text !== "string"
 					|| (value.attachFrame !== undefined && typeof value.attachFrame !== "boolean")
-					|| (value.model !== undefined && typeof value.model !== "string")))) throw new Error("Invalid request.");
+					|| (value.model !== undefined && typeof value.model !== "string")
+					|| (value.effort !== undefined && !REASONING_EFFORTS.includes(value.effort))))) throw new Error("Invalid request.");
 		} catch { json(res, 400, { error: "invalid request" }); return true; }
 		if (path === "/agent/stop") {
 			sessions.get(value.sessionId)?.controller?.abort();
@@ -187,7 +192,7 @@ export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHu
 			// the failed request rather than replaying already-executed scene tools.
 			while (true) {
 				const output = await retryAuth(async () => {
-					const stream = codex.streamResponses({ input: history, tools: agentToolSchemas(tools), instructions: SYSTEM_PROMPT, model: value.model, signal });
+					const stream = codex.streamResponses({ input: history, tools: agentToolSchemas(tools), instructions: SYSTEM_PROMPT, model: value.model, effort: value.effort, signal });
 					const headers = stream.headers.then(observeHeaders, () => {});
 					const items = [];
 					try {

--- a/bin/agent/codex-client.mjs
+++ b/bin/agent/codex-client.mjs
@@ -144,6 +144,7 @@ export function createCodexClient({
 			store: false,
 			stream: true,
 			...(request.model ? { model: request.model } : {}),
+			...(request.effort ? { reasoning: { effort: request.effort } } : {}),
 		};
 	}
 
@@ -185,11 +186,11 @@ export function createCodexClient({
 	 * item and re-POSTs until the model produces a final assistant message.
 	 * Reasoning items are replayed verbatim exactly as the backend emitted them.
 	 */
-	async function runAgentTurn({ history, tools = [], executeTool, onEvent, signal, instructions, model }) {
+	async function runAgentTurn({ history, tools = [], executeTool, onEvent, signal, instructions, model, effort }) {
 		const continued = [...history];
 		let finalText = "";
 		while (true) {
-			const stream = streamResponses({ input: continued, tools, instructions, model, signal });
+			const stream = streamResponses({ input: continued, tools, instructions, model, effort, signal });
 			const outputItems = [];
 			for await (const event of stream) {
 				if (onEvent) onEvent(event);

--- a/src/workflow/AgentPanel.jsx
+++ b/src/workflow/AgentPanel.jsx
@@ -7,6 +7,7 @@ import {
 	AGENT_PANEL_WIDTH_MIN,
 	AGENT_STATES,
 	DEFAULT_MODELS,
+	effortOptions,
 	ERROR_COPY,
 	IMAGE_COST_HINT,
 	SUGGESTION_CHIPS,
@@ -97,6 +98,10 @@ export default function AgentPanel({ transport: injectedTransport = null, sceneN
 	const [authState, setAuthState] = useState("loading");
 	const [models, setModels] = useState(DEFAULT_MODELS);
 	const [model, setModel] = useState(DEFAULT_MODELS[0].id);
+	// null = the model's backend default; picking a model resets it.
+	const [effort, setEffort] = useState(null);
+	const efforts = useMemo(() => effortOptions(models.find((entry) => entry.id === model)), [models, model]);
+	const chooseModel = useCallback((id) => { setModel(id); setEffort(null); }, []);
 	const [draft, setDraft] = useState("");
 	const [attachFrame, setAttachFrame] = useState(false);
 	const [items, setItems] = useState([]);
@@ -264,14 +269,14 @@ export default function AgentPanel({ transport: injectedTransport = null, sceneN
 		const controller = new AbortController();
 		abortRef.current = controller;
 		try {
-			await transport.turn({ sessionId: sessionRef.current, text: trimmed, attachFrame, model }, applyEvent, controller.signal);
+			await transport.turn({ sessionId: sessionRef.current, text: trimmed, attachFrame, model, effort: effort ?? undefined }, applyEvent, controller.signal);
 		} catch (error) {
 			if (!controller.signal.aborted) applyEvent({ type: "error", code: "upstream", message: String(error?.message || error) });
 		} finally {
 			abortRef.current = null;
 			setStreaming(false);
 		}
-	}, [applyEvent, attachFrame, model, streaming, transport]);
+	}, [applyEvent, attachFrame, effort, model, streaming, transport]);
 	runTurnRef.current = runTurn;
 
 	const stopTurn = useCallback(() => {
@@ -323,9 +328,9 @@ export default function AgentPanel({ transport: injectedTransport = null, sceneN
 	const switchModel = useCallback(() => {
 		const index = models.findIndex((entry) => entry.id === model);
 		const next = models[(index + 1) % models.length];
-		if (next) setModel(next.id);
+		if (next) chooseModel(next.id);
 		setRateLimit(null);
-	}, [model, models]);
+	}, [chooseModel, model, models]);
 
 	const onComposerKeyDown = useCallback((event) => {
 		if (event.key === "Escape" && streaming) {
@@ -453,14 +458,22 @@ export default function AgentPanel({ transport: injectedTransport = null, sceneN
 				onChange={(event) => setDraft(event.target.value)}
 				onKeyDown={onComposerKeyDown}
 			/>
+			<div className="agent-composer-controls agent-composer-picks">
+				<select className="agent-model-select" aria-label="Model" value={model} onChange={(event) => chooseModel(event.target.value)}>
+					{models.map((entry) => <option key={entry.id} value={entry.id}>{entry.label}</option>)}
+				</select>
+				{efforts.length > 0 && (
+					<select className="agent-model-select agent-effort-select" aria-label="Reasoning effort" title="Reasoning effort" value={effort ?? efforts[0]} onChange={(event) => setEffort(event.target.value)}>
+						{efforts.map((value, index) => <option key={value} value={value}>{index === 0 ? `${value} · default` : value}</option>)}
+					</select>
+				)}
+			</div>
 			<div className="agent-composer-controls">
 				<button type="button" className="agent-attach-chip" aria-pressed={attachFrame} onClick={() => setAttachFrame((value) => !value)}>
 					{attachFrame ? <span className="agent-attach-thumb" aria-hidden="true" /> : <FiPaperclip size={11} aria-hidden="true" />}
 					Attach current frame
 				</button>
-				<select className="agent-model-select" aria-label="Model" value={model} onChange={(event) => setModel(event.target.value)}>
-					{models.map((entry) => <option key={entry.id} value={entry.id}>{entry.label}</option>)}
-				</select>
+				<span className="agent-composer-spacer" aria-hidden="true" />
 				{streaming
 					? <button type="button" className="agent-send stop agent-stop" onClick={stopTurn}>Stop</button>
 					: <button type="button" className="agent-send" disabled={composerDisabled || !draft.trim()} onClick={() => runTurn(draft)}>Send</button>}

--- a/src/workflow/agent-client.js
+++ b/src/workflow/agent-client.js
@@ -34,6 +34,14 @@ export const AGENT_STATES = [
 	"error",
 ];
 
+/** Effort options for a model entry from /agent/models; the backend default comes first. */
+export function effortOptions(entry) {
+	const efforts = Array.isArray(entry?.efforts) ? entry.efforts : [];
+	if (!efforts.length) return [];
+	const fallback = entry.defaultEffort && efforts.includes(entry.defaultEffort) ? entry.defaultEffort : efforts[0];
+	return [fallback, ...efforts.filter((effort) => effort !== fallback)];
+}
+
 export const DEFAULT_MODELS = [
 	{ id: "gpt-5.1-codex", label: "Codex (default)" },
 	{ id: "gpt-5.1", label: "GPT-5.1" },
@@ -177,11 +185,11 @@ export function createHttpTransport({ fetchImpl = globalThis.fetch?.bind(globalT
 			return request("/agent/stop", { method: "POST", body: JSON.stringify({ sessionId }) });
 		},
 		/** Streams sidecar events to `onEvent`. Resolves when the turn ends. */
-		async turn({ sessionId, text, attachFrame, model }, onEvent, signal) {
+		async turn({ sessionId, text, attachFrame, model, effort }, onEvent, signal) {
 			const response = await fetchImpl(sidecarUrl("/agent/turn"), {
 				method: "POST",
 				headers: { "content-type": "application/json", accept: "text/event-stream" },
-				body: JSON.stringify({ sessionId, text, attachFrame, model }),
+				body: JSON.stringify({ sessionId, text, attachFrame, model, ...(effort ? { effort } : {}) }),
 				signal,
 			});
 			if (!response.ok || !response.body) {

--- a/src/workflow/agent-panel.css
+++ b/src/workflow/agent-panel.css
@@ -638,6 +638,9 @@
 }
 
 .agent-model-select:focus { border-color: var(--agent-border-focus); }
+.agent-composer-picks { margin-bottom: var(--agent-space-2); }
+.agent-effort-select { flex: 0 0 auto; width: auto; max-width: 42%; }
+.agent-composer-spacer { flex: 1; }
 
 .agent-send {
 	flex: none;

--- a/test/verify-agent-routes.mjs
+++ b/test/verify-agent-routes.mjs
@@ -7,7 +7,7 @@ const png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCA
 const calls = [];
 const fakeLive = { command: async (name) => name === "capture_framing_png" ? { dataUrl: png, width: 1920, height: 1080 } : { assetId: "a1", objectId: "o1" } };
 const fakeCodex = {
-  listModels: async () => ["gpt-5", "gpt-6-astra"],
+  listModels: async () => ["gpt-5", { slug: "gpt-6-astra", supported_reasoning_levels: [{ effort: "low" }, { effort: "medium" }, { effort: "xhigh" }], default_reasoning_level: "medium" }],
   parseQuotaHeaders: () => ({ planType: "Plus", primary: {}, credits: { hasCredits: true } }),
   editImage: async () => ({ pngBase64: png.split(",")[1], width: 1, height: 1 }),
   streamResponses: ({ input }) => {
@@ -39,6 +39,20 @@ assert.equal(forbidden.status, 403);
 assert.equal((await fetch(`http://127.0.0.1:${port}/agent/models`)).status, 200);
 const models = await fetch(`http://127.0.0.1:${port}/agent/models`).then((r) => r.json());
 assert.equal(models.models[0].id, "gpt-6-astra");
+assert.deepEqual(models.models[0].efforts, ["low", "medium", "xhigh"]); assert.equal(models.models[0].defaultEffort, "medium");
+assert.deepEqual(models.models[1].efforts, []); assert.equal(models.models[1].defaultEffort, null);
+{
+	const bad = await fetch(`http://127.0.0.1:${port}/agent/turn`, { method: "POST", headers: { "content-type": "application/json", origin: `http://127.0.0.1:${port}` }, body: JSON.stringify({ sessionId: "e", text: "hi", effort: "bogus" }) });
+	assert.equal(bad.status, 400, "an effort the backend would reject never leaves the sidecar");
+	const seen = [];
+	const effortHandler = createAgentHandler({ auth: { getAccessToken: async () => "token" }, codex: { ...fakeCodex, streamResponses: (request) => { seen.push(request.effort); return fakeCodex.streamResponses(request); } }, liveHub: fakeLive, port: () => effortServer.address().port });
+	const effortServer = createServer((req, res) => effortHandler(req, res).catch(() => {})); effortServer.listen(0, "127.0.0.1"); await once(effortServer, "listening");
+	const effortPort = effortServer.address().port;
+	await fetch(`http://127.0.0.1:${effortPort}/agent/turn`, { method: "POST", headers: { "content-type": "application/json", origin: `http://127.0.0.1:${effortPort}` }, body: JSON.stringify({ sessionId: "e2", text: "hi", effort: "xhigh" }) }).then((r) => r.text());
+	assert.ok(seen.length > 0 && seen.every((effort) => effort === "xhigh"), "the chosen effort reaches every codex request of the turn");
+	effortServer.close();
+	console.log("PASS reasoning effort: models expose efforts/default, invalid effort is 400, chosen effort reaches codex");
+}
 const authHandler = createAgentHandler({ auth: { getAccessToken: async () => null }, codex: fakeCodex, liveHub: fakeLive, port: () => authServer.address().port });
 const authServer = createServer((req, res) => authHandler(req, res).catch(() => {})); authServer.listen(0, "127.0.0.1"); await once(authServer, "listening");
 const authPort = authServer.address().port;

--- a/test/verify-codex-client.mjs
+++ b/test/verify-codex-client.mjs
@@ -85,7 +85,17 @@ const USER_ITEM = { type: "message", role: "user", content: [{ type: "input_text
 	for (const forbidden of ["max_output_tokens", "previous_response_id", "background"]) {
 		assert.ok(!(forbidden in call.body), `must never send ${forbidden}`);
 	}
+	assert.ok(!("reasoning" in call.body), "no effort chosen → let the backend pick its default");
 	pass("streamResponses sends codex /responses shape + headers");
+}
+
+// --- 1b. reasoning effort is forwarded only when chosen ----------------------
+{
+	const fetch = mockFetch([() => sseResponse([COMPLETED])]);
+	const client = createCodexClient({ getAccessToken: async () => "tok-123", getAccountId: async () => "acct-9", fetch });
+	for await (const _ of await client.streamResponses({ input: [USER_ITEM], effort: "xhigh" })) { /* drain */ }
+	assert.deepEqual(fetch.calls[0].body.reasoning, { effort: "xhigh" });
+	pass("streamResponses sends reasoning.effort when the user picked one");
 }
 
 // --- 2. SSE parsing of function_call items ----------------------------------


### PR DESCRIPTION
Closes #145.

- `GET /agent/models` → `{ id, label, efforts[], defaultEffort }` (from codex `supported_reasoning_levels` / `default_reasoning_level`).
- Panel: effort select next to the model select (own row above attach/send). Default option is the model's backend default; switching model resets it.
- `POST /agent/turn` accepts `effort`, 400 on values the backend would reject; codex client adds `reasoning: { effort }` only when chosen.

Tests: `verify-codex-client` (no effort → no `reasoning` key; chosen → `{ effort }`), `verify-agent-routes` (models payload, invalid effort 400, effort reaches every codex request of the turn), `verify-agent-panel` unchanged green.

Real-surface QA (branch dev on 5190, CDP): effort options render (`medium · default, low, high, xhigh, max, ultra` for astra; `high · default …` for spark); picked spark + `low`; request body `{"model":"gpt-5.3-codex-spark","effort":"low"}`; reply "ok". Backend probe: codex `/responses` echoes `"effort":"low"`/`"xhigh"`, 400 on bogus. Screenshots /tmp/agent-effort-qa/01-effort-select.png, 02-after-turn.png.