### PR TITLE
feat: connect scene framing to image generation (#147)

### DIFF
--- a/bin/agent/agent-routes.mjs
+++ b/bin/agent/agent-routes.mjs
@@ -110,6 +110,19 @@ export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHu
 			} catch (error) { json(res, error.status === 401 ? 401 : 502, { error: errorInfo(error) }); }
 			return true;
 		}
+		if (path === "/agent/image" && req.method === "POST") {
+			let value;
+			try {
+				value = await readBody(req);
+				if (typeof value.prompt !== "string" || !value.prompt.trim() || typeof value.imageDataUrl !== "string" || !value.imageDataUrl.startsWith("data:image/") || (value.referenceDataUrl !== undefined && (typeof value.referenceDataUrl !== "string" || !value.referenceDataUrl.startsWith("data:image/"))) || (value.quality !== undefined && !["auto", "low", "medium", "high"].includes(value.quality))) throw new Error("Invalid request.");
+			} catch { json(res, 400, { error: "invalid request" }); return true; }
+			if (!await auth.getAccessToken()) { json(res, 401, { error: { code: "auth", message: "Sign in with ChatGPT in the Agent panel." } }); return true; }
+			try {
+				const result = await codex.editImage(value);
+				json(res, 200, { dataUrl: `data:image/png;base64,${result.pngBase64}`, width: result.width, height: result.height });
+			} catch (error) { json(res, error.status === 401 ? 401 : 502, { error: errorInfo(error) }); }
+			return true;
+		}
 		if (req.method !== "POST" || !["/agent/turn", "/agent/stop"].includes(path)) {
 			json(res, 404, { error: "not found" }); return true;
 		}

--- a/bin/agent/agent-routes.mjs
+++ b/bin/agent/agent-routes.mjs
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as defaultAuth from "../codex-auth.mjs";
 import { createCodexClient } from "./codex-client.mjs";
-import { createAgentTools, agentToolSchemas, SYSTEM_PROMPT } from "./agent-tools.mjs";
+import { createAgentTools, agentToolSchemas, SYSTEM_PROMPT, pickWorkspace } from "./agent-tools.mjs";
 
 // Values the codex backend accepts for reasoning.effort (its own 400 lists them).
 export const REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
@@ -17,11 +17,14 @@ export function allowAgentOrigin(req, port) {
 			&& [`127.0.0.1:${port}`, `localhost:${port}`].includes(req.headers.host));
 }
 
-async function readBody(req) {
+// Two 1920x1080 PNG data URLs (frame + reference) fit comfortably in this.
+const IMAGE_BODY_LIMIT = 24 * 1024 * 1024;
+
+async function readBody(req, limit = 64 * 1024) {
 	let text = "";
 	for await (const chunk of req) {
 		text += chunk;
-		if (Buffer.byteLength(text) > 64 * 1024) throw new Error("Request too large.");
+		if (Buffer.byteLength(text) > limit) throw new Error("Request too large.");
 	}
 	return JSON.parse(text || "{}");
 }
@@ -86,6 +89,18 @@ export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHu
 	const requestContext = new AsyncLocalStorage();
 	codex ||= defaultClient(auth, requestContext);
 	const runtime = handlers !== undefined || liveHub !== undefined ? Promise.resolve({ handlers: handlers ?? [], liveHub }) : liveToolsRuntime();
+	const renderGuidance = async (environment) => {
+		try {
+			const { handlers: tools, liveHub: hub } = await runtime;
+			const tool = tools.find((entry) => entry.name === "render_prompt");
+			if (!tool || !hub?.connected) return "";
+			const workspaceHandle = pickWorkspace(hub);
+			const result = await tool.handler({ mode: "image", environment }, { workspaceHandle });
+			if (result?.isError) return "";
+			const text = typeof result === "string" ? result : (result?.content ?? []).filter((part) => part.type === "text").map((part) => part.text).join("\n");
+			return text ? `\n${text}` : "";
+		} catch { return ""; }
+	};
 	const sessions = new Map();
 	const unsubscribe = auth.onAuthChange?.(() => {
 		for (const session of sessions.values()) session.controller?.abort();
@@ -113,12 +128,15 @@ export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHu
 		if (path === "/agent/image" && req.method === "POST") {
 			let value;
 			try {
-				value = await readBody(req);
+				value = await readBody(req, IMAGE_BODY_LIMIT);
 				if (typeof value.prompt !== "string" || !value.prompt.trim() || typeof value.imageDataUrl !== "string" || !value.imageDataUrl.startsWith("data:image/") || (value.referenceDataUrl !== undefined && (typeof value.referenceDataUrl !== "string" || !value.referenceDataUrl.startsWith("data:image/"))) || (value.quality !== undefined && !["auto", "low", "medium", "high"].includes(value.quality))) throw new Error("Invalid request.");
 			} catch { json(res, 400, { error: "invalid request" }); return true; }
 			if (!await auth.getAccessToken()) { json(res, 401, { error: { code: "auth", message: "Sign in with ChatGPT in the Agent panel." } }); return true; }
 			try {
-				const result = await codex.editImage(value);
+				// Same composition guidance the agent's render_from_frame appends: the
+				// node's prompt is intent only; camera, cast and set come from the scene.
+				const prompt = `${value.prompt}${await renderGuidance(value.prompt)}`;
+				const result = await codex.editImage({ ...value, prompt });
 				json(res, 200, { dataUrl: `data:image/png;base64,${result.pngBase64}`, width: result.width, height: result.height });
 			} catch (error) { json(res, error.status === 401 ? 401 : 502, { error: errorInfo(error) }); }
 			return true;

--- a/bin/agent/codex-client.mjs
+++ b/bin/agent/codex-client.mjs
@@ -231,11 +231,12 @@ export function createCodexClient({
 		return { history: continued, finalText };
 	}
 
-	async function editImage({ prompt, imageDataUrl, quality = "auto", signal }) {
+	async function editImage({ prompt, imageDataUrl, referenceDataUrl, quality = "auto", signal }) {
+		const images = [imageDataUrl, referenceDataUrl].filter((value) => typeof value === "string" && value);
 		const response = await postJson("/images/edits", {
 			model: "gpt-image-2",
 			prompt,
-			images: [{ image_url: imageDataUrl }],
+			images: images.map((image_url) => ({ image_url })),
 			quality,
 		}, signal);
 		const payload = await response.json();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -561,6 +561,21 @@ function poseMemberAtFrame(rig, clip, ikState, frame, blendFrames = 0) {
 
 export default function App() {
 	const embedMode = ["scene", "playview"].includes(new URLSearchParams(globalThis.location?.search || "").get("embed"));
+	useEffect(() => {
+		if (!embedMode) return undefined;
+		const capture = () => {
+			try {
+				const live = liveStateRef.current;
+				const dataUrl = live.captureFramingPng(live.captureCurrentFraming());
+				if (!dataUrl) throw new Error("The shot renderer is not ready");
+				const output = SHOT_ASPECT_PRESETS[live.stage.shotAspect] ?? SHOT_ASPECT_PRESETS["16:9"];
+				window.parent.postMessage({ type: "cozyclay:capture-framing-result", dataUrl, width: output.width, height: output.height }, "*");
+			} catch (error) { window.parent.postMessage({ type: "cozyclay:capture-framing-result", error: error.message }, "*"); }
+		};
+		const onMessage = (event) => { if (event.data?.type === "cozyclay:capture-framing") capture(); };
+		window.addEventListener("message", onMessage);
+		return () => window.removeEventListener("message", onMessage);
+	}, [embedMode]);
 	// QA-only render counter (same spirit as window.__cozyclay): headless perf
 	// probes read renders/second to find re-render storms. Negligible cost.
 	if (typeof window !== "undefined") window.__cozyclayRenders = (window.__cozyclayRenders || 0) + 1;

--- a/src/workflow/CozySceneNode.jsx
+++ b/src/workflow/CozySceneNode.jsx
@@ -84,7 +84,7 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 			</header>
 
 			<section className="cozy-scene-preview" aria-label="3D scene preview">
-				{data.preview === "render" && data.lastOutput?.renderUrl ? <video className="cozy-scene-render" src={data.lastOutput.renderUrl} controls muted /> : <SceneViewport />}
+				{data.preview === "render" && data.lastOutput?.renderUrl ? <img className="cozy-scene-render" src={data.lastOutput.renderUrl} alt="Captured scene frame" /> : <SceneViewport />}
 			{data.preview === "render" && <div className="cozy-scene-preview-copy"><strong>Rendered frame</strong><span>{data.statusMessage || "Open Studio to edit the scene"}</span></div>}
 			</section>
 

--- a/src/workflow/WorkflowBuilder.jsx
+++ b/src/workflow/WorkflowBuilder.jsx
@@ -21,6 +21,7 @@ import { executeLocalWorkflowGraph } from "./local-workflow.js";
 import { createLiveControl } from "../live-control.js";
 import { createCanvasCommands } from "./canvas-commands.js";
 import { applyMotionToActiveScene, importImageIntoActiveScene, readStoredSceneDocument } from "./scene-asset-sync.js";
+import { createHttpTransport } from "./agent-client.js";
 
 const NODE_COLORS = { text: "#6c7cff", image: "#44c2a4", video: "#d9955b", audio: "#6bb6dc", api: "#cf8de8", "video-combiner": "#efb064", upload: "#a88cdb", concat: "#d6b55e", "motion-input": "#79b5ed", scene: "#ef759d" };
 
@@ -54,6 +55,21 @@ function readGraph() {
 	const graph = loadWorkflowGraph();
 	if (!graph.nodes.length) return DEFAULT_GRAPH;
 	return { ...graph, nodes: graph.nodes.map((node) => node.type === "video-combiner" && !node.data?.model ? { ...node, data: { ...node.data, model: "video-combiner" } } : node) };
+}
+
+function captureSceneFrame(id) {
+	return new Promise((resolve, reject) => {
+		const iframe = document.querySelector(`[data-node-id="${CSS.escape(id)}"] iframe`);
+		if (!iframe?.contentWindow) { reject(new Error("Scene preview is unavailable.")); return; }
+		const timer = window.setTimeout(() => { window.removeEventListener("message", onMessage); reject(new Error("Scene capture timed out.")); }, 10000);
+		const onMessage = (event) => {
+			if (event.source !== iframe.contentWindow || event.data?.type !== "cozyclay:capture-framing-result") return;
+			window.clearTimeout(timer); window.removeEventListener("message", onMessage);
+			if (event.data.error) reject(new Error(event.data.error)); else resolve(event.data);
+		};
+		window.addEventListener("message", onMessage);
+		iframe.contentWindow.postMessage({ type: "cozyclay:capture-framing" }, "*");
+	});
 }
 
 function stripFunctions(value) {
@@ -121,7 +137,8 @@ function TextNode({ id, data }) {
 }
 
 function ImageNode({ id, data }) {
-	return <NodeShell id={id} type="image" title="Image" icon={FiImage}><label>Model</label><ModelSelect id={id} data={data} category="image" fallback={["image-passthrough", "image-generation"]} /><div className="workflow-dropzone"><FiImage size={18} /><span>Connect an image or prompt</span></div><SchemaFields id={id} data={data} category="image" /><div className="workflow-node-foot"><span>Image output <NodeCost data={data} /></span><button className="workflow-mini-button" type="button" onClick={() => data.onRun?.(id)}><FiPlay size={12} /></button></div></NodeShell>;
+	const generated = data.model === "image-generation";
+	return <NodeShell id={id} type="image" title="Image" icon={FiImage}><label>Model</label><ModelSelect id={id} data={data} category="image" fallback={["image-passthrough", "image-generation"]} />{generated && data.resultUrl ? <img className="workflow-image-preview" src={data.resultUrl} alt="Generated workflow output" /> : <div className="workflow-dropzone"><FiImage size={18} /><span>{generated ? "Connect a Scene frame" : "Connect an image or prompt"}</span></div>}{generated && data.isLoading && <div className="workflow-hint">Generating image…</div>}{generated && data.errorMsg && <div className="workflow-error">{data.errorMsg}</div>}<SchemaFields id={id} data={data} category="image" /><div className="workflow-node-foot"><span>Image output <NodeCost data={data} /></span><button className="workflow-mini-button" type="button" onClick={() => data.onRun?.(id)} disabled={data.isLoading}><FiPlay size={12} /></button></div></NodeShell>;
 }
 
 function VideoNode({ id, data }) {
@@ -298,6 +315,25 @@ export default function WorkflowBuilder() {
 		setRunState("running");
 		const result = executeLocalWorkflowGraph(graph, { runId: `local-${Date.now()}` });
 		setNodes(result.nodes);
+		const runId = `local-${Date.now()}`;
+		const values = new Map();
+		for (const id of result.order) {
+			const current = result.nodes.find((node) => node.id === id);
+			if (!current) continue;
+			if (current.type === "scene") {
+				try {
+					const frame = await captureSceneFrame(id);
+					values.set(id, frame.dataUrl);
+					updateNode(id, { status: "complete", statusMessage: "Captured framing PNG", preview: "render", lastOutput: { renderUrl: frame.dataUrl, sceneUrl: "/app/", jobId: null }, outputs: [{ value: frame.dataUrl }], resultUrl: frame.dataUrl });
+				} catch (error) { updateNode(id, { status: "error", errorMsg: error.message, statusMessage: error.message }); }
+			} else if (current.type === "image" && current.data?.model === "image-generation") {
+				const source = (graph.edges || []).filter((edge) => edge.target === id).map((edge) => values.get(edge.source)).find(Boolean) || current.data.image_url;
+				if (!source) { updateNode(id, { status: "error", errorMsg: "Connect a Scene frame before generating." }); continue; }
+				updateNode(id, { isLoading: true, errorMsg: null });
+				try { const output = await createHttpTransport().image({ prompt: current.data.prompt || "", imageDataUrl: source, referenceDataUrl: current.data.image_url, quality: "auto" }); values.set(id, output.dataUrl); updateNode(id, { isLoading: false, status: "complete", resultUrl: output.dataUrl, outputs: [{ value: output.dataUrl }], errorMsg: null }); }
+				catch (error) { updateNode(id, { isLoading: false, status: "error", errorMsg: error.message }); }
+			} else values.set(id, current.data?.outputs?.[0]?.value);
+		}
 		const resultById = new Map(result.nodes.map((node) => [node.id, node]));
 		for (const scene of result.nodes.filter((node) => node.type === "scene")) {
 			for (const assignment of Array.isArray(scene.data?.characterInputs) ? scene.data.characterInputs : []) {
@@ -325,9 +361,9 @@ export default function WorkflowBuilder() {
 		return () => { window.removeEventListener("keydown", onKeyDown); control.close(); commandsRef.current = null; };
 	}, [nodeSchemas, setEdges, setNodes]);
 	const runScene = useCallback(async ({ id, data }) => {
-		const payload = toCozySceneRunRequest({ id, data }, { workflow: graphRef.current });
-		updateScene({ id, patch: { status: "complete", statusMessage: `Local scene ready at frame ${payload.frame}`, preview: "scene", lastOutput: { renderUrl: null, sceneUrl: "/app/", jobId: null } } });
-		toast.success("CozyClay Scene updated locally");
+		updateScene({ id, patch: { status: "running", statusMessage: "Capturing framing PNG" } });
+		try { const frame = await captureSceneFrame(id); updateScene({ id, patch: { status: "complete", statusMessage: "Captured framing PNG", preview: "render", lastOutput: { renderUrl: frame.dataUrl, sceneUrl: "/app/", jobId: null }, outputs: [{ value: frame.dataUrl }], resultUrl: frame.dataUrl } }); toast.success("Scene frame captured"); }
+		catch (error) { updateScene({ id, patch: { status: "error", errorMsg: error.message, statusMessage: error.message } }); }
 	}, [updateScene]);
 
 	const decoratedNodes = useMemo(() => nodes.map((node) => ({

--- a/src/workflow/agent-client.js
+++ b/src/workflow/agent-client.js
@@ -184,6 +184,9 @@ export function createHttpTransport({ fetchImpl = globalThis.fetch?.bind(globalT
 		async stop(sessionId) {
 			return request("/agent/stop", { method: "POST", body: JSON.stringify({ sessionId }) });
 		},
+		async image({ prompt, imageDataUrl, referenceDataUrl, quality = "auto" }, signal) {
+			return request("/agent/image", { method: "POST", body: JSON.stringify({ prompt, imageDataUrl, ...(referenceDataUrl ? { referenceDataUrl } : {}), quality }), signal });
+		},
 		/** Streams sidecar events to `onEvent`. Resolves when the turn ends. */
 		async turn({ sessionId, text, attachFrame, model, effort }, onEvent, signal) {
 			const response = await fetchImpl(sidecarUrl("/agent/turn"), {

--- a/test/verify-agent-routes.mjs
+++ b/test/verify-agent-routes.mjs
@@ -34,6 +34,34 @@ const text = await response.text();
 const events = [...text.matchAll(/^data: (.+)$/gm)].map((match) => JSON.parse(match[1]));
 assert.deepEqual(events.map((event) => event.type), ["quota", "text.delta", "tool.start", "tool.done", "tool.start", "image", "tool.done", "text.delta", "done"]);
 assert.equal(calls[0][0].content[0].text.includes(png), false);
+{
+	const post = (body, p = port) => fetch(`http://127.0.0.1:${p}/agent/image`, { method: "POST", headers: { "content-type": "application/json", origin: `http://127.0.0.1:${p}` }, body: JSON.stringify(body) });
+	// A real 1920x1080 shot PNG is a few MB as a data URL; the route must not
+	// fall under the 64 KB limit that protects the chat routes.
+	const bigFrame = "data:image/png;base64," + "A".repeat(3 * 1024 * 1024);
+	const ok = await post({ prompt: "golden hour", imageDataUrl: bigFrame, referenceDataUrl: png, quality: "auto" });
+	assert.equal(ok.status, 200, "a full-size frame is accepted");
+	const image = await ok.json();
+	assert.ok(image.dataUrl.startsWith("data:image/png;base64,") && image.width === 1 && image.height === 1);
+	assert.equal((await post({ prompt: "", imageDataUrl: png })).status, 400, "empty prompt is rejected");
+	assert.equal((await post({ prompt: "x", imageDataUrl: "https://example.com/a.png" })).status, 400, "only data URLs are accepted");
+	assert.equal((await post({ prompt: "x", imageDataUrl: png, quality: "ultra" })).status, 400, "unknown quality is rejected");
+	const seen = [];
+	const refHandler = createAgentHandler({ auth: { getAccessToken: async () => "token" }, codex: { ...fakeCodex, editImage: async (args) => { seen.push(args); return fakeCodex.editImage(args); } }, liveHub: fakeLive, port: () => refServer.address().port });
+	const refServer = createServer((req, res) => refHandler(req, res).catch(() => {})); refServer.listen(0, "127.0.0.1"); await once(refServer, "listening");
+	await post({ prompt: "x", imageDataUrl: png, referenceDataUrl: png }, refServer.address().port);
+	assert.equal(seen[0].referenceDataUrl, png, "the reference image reaches codex");
+	assert.equal(seen[0].prompt, "x", "without a scene to describe, the prompt is sent as written");
+	refServer.close();
+	const guided = [];
+	const guideLive = { ...fakeLive, connected: true, workspaceHandleDetails: () => [{ handle: "w", meta: { commands: ["capture_framing_png", "import_asset"] } }], resolveWorkspace: () => "w" };
+	const guideHandler = createAgentHandler({ auth: { getAccessToken: async () => "token" }, codex: { ...fakeCodex, editImage: async (args) => { guided.push(args.prompt); return fakeCodex.editImage(args); } }, liveHub: guideLive, handlers: [{ name: "render_prompt", handler: async ({ mode, environment }) => ({ content: [{ type: "text", text: `[${mode}] medium shot, 24mm, subject faces camera (${environment})` }] }) }], port: () => guideServer.address().port });
+	const guideServer = createServer((req, res) => guideHandler(req, res).catch(() => {})); guideServer.listen(0, "127.0.0.1"); await once(guideServer, "listening");
+	await post({ prompt: "golden hour", imageDataUrl: png }, guideServer.address().port);
+	assert.equal(guided[0], "golden hour\n[image] medium shot, 24mm, subject faces camera (golden hour)", "scene guidance is appended to the node prompt like render_from_frame does");
+	guideServer.close();
+	console.log("PASS /agent/image: full-size frame accepted, validation, reference forwarded");
+}
 const forbidden = await fetch(`http://127.0.0.1:${port}/agent/models`, { headers: { origin: "http://evil.example" } });
 assert.equal(forbidden.status, 403);
 assert.equal((await fetch(`http://127.0.0.1:${port}/agent/models`)).status, 200);

--- a/test/verify-codex-client.mjs
+++ b/test/verify-codex-client.mjs
@@ -219,6 +219,16 @@ const USER_ITEM = { type: "message", role: "user", content: [{ type: "input_text
 	pass("editImage body shape + IHDR dims");
 }
 
+// --- 4b. editImage with a reference image sends both, frame first ----------
+{
+	const fetch = mockFetch([() => new Response(JSON.stringify({ data: [{ b64_json: PNG_1X1_BASE64 }] }), { status: 200, headers: { "content-type": "application/json" } })]);
+	const client = createCodexClient({ getAccessToken: async () => "tok-123", getAccountId: async () => "acct-9", fetch });
+	const frame = "data:image/png;base64," + PNG_1X1_BASE64, reference = "data:image/jpeg;base64,/9j/4AAQ";
+	await client.editImage({ prompt: "match the framing", imageDataUrl: frame, referenceDataUrl: reference });
+	assert.deepEqual(fetch.calls[0].body.images, [{ image_url: frame }, { image_url: reference }]);
+	pass("editImage sends frame + reference as two images");
+}
+
 // --- 5. generateImage: /images/generations body ------------------------------
 {
 	const fetch = mockFetch([


### PR DESCRIPTION
## Summary
- Capture embedded Scene framing PNGs through a direct `window.postMessage` bridge and show them in the Scene node.
- Add authenticated `POST /agent/image` and multi-image Codex edits.
- Run Scene and image-generation nodes asynchronously in graph order with isolated node errors and loading/error UI.

## Design choice
(a) Direct window.postMessage was chosen because the canvas already owns the iframe, requires no server state or hub forwarding, and works offline for capture.

## Verification
- RED: initial `node tools/run-tests.mjs` failed before build artifacts existed (`dist/demo/index.html is missing`); this is the expected pre-build test harness state.
- GREEN: `npm test` passed (build plus 142 Node verification files).
- Targeted: `node test/verify-codex-client.mjs`, `node test/verify-agent-routes.mjs`, `node test/verify-cozy-scene-node.mjs`, `node test/verify-local-workflow.mjs`.

## QA evidence
Browser QA and real image generation were not run in this worker session; no generated PNG or screenshot evidence is available.

## Commands
`npm test`
`node tools/run-tests.mjs`
`node test/verify-codex-client.mjs`
`node test/verify-agent-routes.mjs`
`node test/verify-cozy-scene-node.mjs`
`node test/verify-local-workflow.mjs`


## Lead review + browser QA (run on this branch, real generation x2)

Defect found by running the real page: **/agent/image returned 400 for every real frame** — `readBody` capped requests at 64 KB, and a 1920x1080 PNG data URL is ~900 KB. Fixed (24 MB limit on the image route only), RED→GREEN in `test/verify-agent-routes.mjs`. The worker's PR had no tests for the new route or the two-image edit body; both added. Also added the `render_prompt` scene guidance suffix so the node prompt is intent only (as the issue asked).

Browser QA (CDP, dev on 5190, signed in): default canvas rewired to `Scene.render → Image.input`, model `image-generation`, prompt "photoreal cinematic still, golden hour, keep the exact pose and camera framing", Run:
- Scene node: "Captured framing PNG", preview shows the frame.
- /agent/image → 200; Image node shows the generated PNG (1.7 MB).
- Composition preserved: same figure position, pose, camera and horizon; environment changed per prompt.
Evidence: /tmp/scene-image-qa/{01-wired,02-scene-captured,03-image-result}.png, captured-frame.png, generated.png.