### PR TITLE
feat(shot): 12:7 aspect and mocap camera presets (#149)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2811,7 +2811,6 @@ globalThis.playMode = centerTab === "play";
 		characters: characters.map(({ sessionMotion, ...entry }) => entry),
 		hasCharSheet,
 		shotAspect: shotAspectKey,
-		cameraPresetId: preset.startsWith("mocap") ? preset : null,
 		sensorId,
 		keyLight,
 	};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2811,6 +2811,7 @@ globalThis.playMode = centerTab === "play";
 		characters: characters.map(({ sessionMotion, ...entry }) => entry),
 		hasCharSheet,
 		shotAspect: shotAspectKey,
+		cameraPresetId: preset.startsWith("mocap") ? preset : null,
 		sensorId,
 		keyLight,
 	};

--- a/src/app-stage.jsx
+++ b/src/app-stage.jsx
@@ -441,6 +441,7 @@ export const SHOT_ASPECT_PRESETS = Object.freeze({
 	"9:16": Object.freeze({ label: "9:16", aspect: SHOT_ASPECT_RATIOS["9:16"], width: 1080, height: 1920 }),
 	"1:1": Object.freeze({ label: "1:1", aspect: SHOT_ASPECT_RATIOS["1:1"], width: 1080, height: 1080 }),
 	"4:3": Object.freeze({ label: "4:3", aspect: SHOT_ASPECT_RATIOS["4:3"], width: 1440, height: 1080 }),
+	"12:7": Object.freeze({ label: "12:7", aspect: SHOT_ASPECT_RATIOS["12:7"], width: 1536, height: 896, title: "12:7 video-inbetweener ratio" }),
 });
 // Pre-generated clip shipped with the build so a bridge-less session (a hosted
 // static demo, or `npm run dev:ui`) still shows real generated motion.
@@ -956,7 +957,7 @@ export function ShotRig({ preset, nonce, fovDeg, charA, charB, showB, probeX, pr
 		const horizontal = p.distance * Math.cos(el);
 		cam.position.set(
 			aim.x + horizontal * Math.sin(az),
-			Math.max(p.targetY + p.distance * Math.sin(el), 0.15),
+			p.height ?? Math.max(p.targetY + p.distance * Math.sin(el), 0.15),
 			aim.z + horizontal * Math.cos(az),
 		);
 		const angles = aimAt(cam.position, { x: aim.x, y: p.targetY, z: aim.z });

--- a/src/camera-move.js
+++ b/src/camera-move.js
@@ -7,6 +7,29 @@
 
 import { FRAMING_PIVOT_Y, SUBJECT_HEIGHT_M, deriveShot, focalMmToFov, fovToFocalMm, usedSensorHeightMm } from "./shot.js";
 
+export const CAMERA_PRESETS = Object.freeze({
+	"mocapLocomotion": Object.freeze({ id: "mocapLocomotion", label: "Mocap: locomotion", azimuthDeg: 45, height: 2.4, focalMm: 80, subjectFraction: 0.55 }),
+	"mocapInteraction": Object.freeze({ id: "mocapInteraction", label: "Mocap: interaction", azimuthDeg: 45, height: 2.4, focalMm: 38, subjectFraction: 0.35 }),
+});
+
+/** Build a repeatable camera framing around the current subject. */
+export function cameraPresetFraming(id, subject = {}, filmback = {}) {
+	const preset = CAMERA_PRESETS[id];
+	if (!preset) return null;
+	const x = Number.isFinite(subject.x) ? subject.x : 0;
+	const z = Number.isFinite(subject.z) ? subject.z : 0;
+	const height = Number.isFinite(subject.height) ? subject.height : SUBJECT_HEIGHT_M;
+	const sensorId = filmback.sensorId;
+	const aspectRatio = filmback.aspectRatio;
+	const fovDeg = (focalMmToFov(preset.focalMm, sensorId, aspectRatio) * 180) / Math.PI;
+	const distance = height / (2 * preset.subjectFraction * Math.tan((fovDeg * Math.PI) / 360));
+	const az = (preset.azimuthDeg * Math.PI) / 180;
+	const pos = { x: x + distance * Math.sin(az), y: preset.height, z: z + distance * Math.cos(az) };
+	const target = { x, y: height * 0.52, z };
+	const { yaw, pitch } = aimAngles(pos, target);
+	return { id, pos, yaw, pitch, fovDeg, focalMm: preset.focalMm };
+}
+
 /* ------------------------------------------------------------ framing --- */
 
 /**

--- a/src/scenes.js
+++ b/src/scenes.js
@@ -42,6 +42,7 @@ export const DEFAULT_SCENE_STAGE = Object.freeze({
 	]),
 	hasCharSheet: false,
 	shotAspect: "16:9",
+	cameraPresetId: null,
 	sensorId: DEFAULT_SENSOR_FORMAT,
 	// The key light the user can grab: position of the sun puck, the rig's
 	// master brightness, and a warm/cool colour offset. Values mirror the
@@ -272,7 +273,7 @@ export function createSceneStage(stage = null) {
 		...extras,
 		characters,
 		hasCharSheet: source.hasCharSheet === true,
-		shotAspect: ["16:9", "2.39:1", "9:16", "1:1", "4:3"].includes(source.shotAspect)
+		shotAspect: ["16:9", "2.39:1", "9:16", "1:1", "4:3", "12:7"].includes(source.shotAspect)
 			? source.shotAspect
 			: DEFAULT_SCENE_STAGE.shotAspect,
 		// `sensorFormat` was this field's name for one unreleased day; read it so

--- a/src/shot.js
+++ b/src/shot.js
@@ -30,6 +30,7 @@ export const SHOT_ASPECT_RATIOS = Object.freeze({
 	"9:16": 9 / 16,
 	"1:1": 1,
 	"4:3": 4 / 3,
+	"12:7": 12 / 7,
 });
 
 export function shotAspectRatio(value) {


### PR DESCRIPTION
Closes #149

Implemented:
- Added 12:7 shot aspect at 1536x896 (12/7 exact ratio).
- Added Mocap: locomotion and Mocap: interaction camera presets with persisted stage preset id.
- Added reusable cameraPresetFraming geometry helper.

Tests:
- `npm test` — PASS (142 Node verification files; initial ws dependency fixed with `cd mcp && npm install`).

Capture size:
- `capture_framing_png` under 12:7 resolves to 1536x896 and returns width=1536, height=896.

QA screenshots:
- Blocked: `qa:browser` launched Chrome on CDP_PORT=9249 but `test/qa-screenshot-browser.mjs` did not complete or emit files before timeout/interruption; no screenshot paths were produced.
