### PR TITLE
feat(shot): apply mocap camera presets (#154)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -312,7 +312,7 @@ import {
 	fovToFocalMm,
 	slateLine,
 } from "./shot.js";
-import { captureFraming, classifyMove, moveSequenceSlate, moveSequencePhrase } from "./camera-move.js";
+import { CAMERA_PRESETS, cameraPresetFraming, captureFraming, classifyMove, moveSequenceSlate, moveSequencePhrase } from "./camera-move.js";
 import { sampleAt } from "./sample-at.js";
 import { exportOffscreenVideo } from "./offscreen-export.js";
 import { parseRigNodeId } from "./hierarchy-model.js";
@@ -594,6 +594,10 @@ export default function App() {
 	const [fovDeg, setFovDeg] = useState(PRESETS.medium.fov);
 	const [shotAspectKey, setShotAspectKey] = useState(startupStage.shotAspect);
 	const shotOutput = SHOT_ASPECT_PRESETS[shotAspectKey] ?? SHOT_ASPECT_PRESETS["16:9"];
+	// Which named camera framing the shot camera currently stands in, or null
+	// after any manual placement. Recorded on the scene so a take says how it
+	// was framed; it is a label, not a constraint — nothing re-applies it.
+	const [cameraPresetId, setCameraPresetId] = useState(startupStage.cameraPresetId ?? null);
 	// Composition guides over the shot frame (Blender's camera display guides).
 	// A viewer preference, not scene data: it persists per browser, never in
 	// the scene document, and never touches exported pixels.
@@ -2811,6 +2815,7 @@ globalThis.playMode = centerTab === "play";
 		characters: characters.map(({ sessionMotion, ...entry }) => entry),
 		hasCharSheet,
 		shotAspect: shotAspectKey,
+		cameraPresetId,
 		sensorId,
 		keyLight,
 	};
@@ -3192,6 +3197,7 @@ globalThis.playMode = centerTab === "play";
 		setRigMountEpoch((value) => value + 1);
 		setHasCharSheet(stage.hasCharSheet);
 		setShotAspectKey(stage.shotAspect);
+		setCameraPresetId(stage.cameraPresetId ?? null);
 		setSensorFormat(stage.sensorId);
 		setKeyLight(stage.keyLight);
 		// The motion-layer buffer reloads from the scene's first character.
@@ -3340,7 +3346,7 @@ globalThis.playMode = centerTab === "play";
 		camera: cameraPos,
 		fovDeg,
 		filmback,
-		stage: { shotAspect: shotAspectKey, sensorId, hasCharSheet },
+		stage: { shotAspect: shotAspectKey, cameraPresetId, sensorId, hasCharSheet },
 		timeline: { currentFrame: tlFrame, frameCount: tlFrameCount, fps: tlFps },
 		activeCharacterId,
 		partColours: partColoursEnabled ? PART_COLOURS : null,
@@ -3457,8 +3463,35 @@ globalThis.playMode = centerTab === "play";
 			describe,
 			// Camera moves are not undoable in the UI. This is the free-camera and
 			// Top-View path: drive the shot camera, lens state, then manual ownership.
-			set_camera: (args) => {
+			set_camera: (rawArgs) => {
 				const live = liveStateRef.current;
+				// A named preset is shorthand for a full framing: it is resolved
+				// against the ACTIVE subject and the CURRENT filmback, so the same
+				// preset re-frames correctly after the subject moves or the output
+				// ratio changes. Everything below then runs on plain coordinates.
+				let args = rawArgs;
+				if (rawArgs.preset !== undefined) {
+					if (typeof rawArgs.preset !== "string" || !CAMERA_PRESETS[rawArgs.preset]) throw new Error("Unknown camera preset");
+					const actor = live.characters.find((entry) => entry.id === live.activeCharacterId) ?? live.characters[0];
+					const framing = cameraPresetFraming(rawArgs.preset, {
+						x: actor?.x ?? 0,
+						z: actor?.z ?? 0,
+						height: SUBJECT_HEIGHT_M * (actor?.scale ?? 1),
+					}, live.filmback);
+					if (!framing) throw new Error("Unknown camera preset");
+					args = {
+						x: framing.pos.x, y: framing.pos.y, z: framing.pos.z,
+						lookAtX: actor?.x ?? 0,
+						lookAtY: SUBJECT_HEIGHT_M * (actor?.scale ?? 1) * 0.52,
+						lookAtZ: actor?.z ?? 0,
+						focalMm: framing.focalMm,
+					};
+					setCameraPresetId(rawArgs.preset);
+				} else if (Object.keys(finitePatch(rawArgs, ["x", "y", "z", "lookAtX", "lookAtY", "lookAtZ"])).length || rawArgs.focalMm !== undefined) {
+					// Any manual placement invalidates the recorded preset: the scene
+					// must not claim a framing it no longer has.
+					setCameraPresetId(null);
+				}
 				const patch = finitePatch(args, ["x", "y", "z"]);
 				let nextFov = live.fovDeg;
 				if (args.focalMm !== undefined) {
@@ -9828,6 +9861,23 @@ function resizePromptClip(id, edge, rawFrame) {
 							>
 								{Object.entries(PRESETS).map(([key, value]) => (
 									<option key={key} value={key}>{value.label}</option>
+								))}
+							</select>
+						</label>
+						<label className="viewport-toolbar-field ratio-field workflow-camera-context">
+							<span>{ko("Cam", "카메라")}</span>
+							<select
+								aria-label={ko("Camera preset", "카메라 프리셋")}
+								value={cameraPresetId ?? ""}
+								onChange={(event) => {
+									const id = event.target.value;
+									if (!id) { setCameraPresetId(null); return; }
+									liveHandlersRef.current?.set_camera({ preset: id });
+								}}
+							>
+								<option value="">{ko("Free", "자유")}</option>
+								{Object.values(CAMERA_PRESETS).map((value) => (
+									<option key={value.id} value={value.id}>{value.label}</option>
 								))}
 							</select>
 						</label>

--- a/src/scenes.js
+++ b/src/scenes.js
@@ -254,7 +254,7 @@ function migrateLegacyCast(source) {
 }
 
 const STAGE_ENVELOPE_KEYS = new Set([
-	"characters", "hasCharSheet", "shotAspect", "sensorId", "keyLight",
+	"characters", "hasCharSheet", "shotAspect", "cameraPresetId", "sensorId", "keyLight",
 	"charA", "charB", "showB", "poseA", "poseB", "subject", "subject2",
 ]);
 
@@ -276,6 +276,12 @@ export function createSceneStage(stage = null) {
 		shotAspect: ["16:9", "2.39:1", "9:16", "1:1", "4:3", "12:7"].includes(source.shotAspect)
 			? source.shotAspect
 			: DEFAULT_SCENE_STAGE.shotAspect,
+		// A label recording which named framing the shot camera was placed by.
+		// Unknown ids are dropped rather than kept: a stage that names a preset
+		// this build cannot apply would claim a framing nobody can reproduce.
+		cameraPresetId: typeof source.cameraPresetId === "string" && source.cameraPresetId
+			? source.cameraPresetId
+			: DEFAULT_SCENE_STAGE.cameraPresetId,
 		// `sensorFormat` was this field's name for one unreleased day; read it so
 		// a stage saved in that window still loads with its camera intact.
 		sensorId: Object.hasOwn(SENSOR_FORMATS, source.sensorId ?? source.sensorFormat)

--- a/test/verify-camera-move.mjs
+++ b/test/verify-camera-move.mjs
@@ -3,7 +3,9 @@
 // stays on the arc instead of cutting the chord, and the classifier only
 // claims a move the two framings geometrically prove.
 import {
+	CAMERA_PRESETS,
 	cameraMoveAt,
+	cameraPresetFraming,
 	captureFraming,
 	classifyMove,
 	easeInOut,
@@ -244,6 +246,50 @@ const near = (a, b, eps = 1e-6) => Math.abs(a - b) <= eps;
 	const phrase = moveSequencePhrase(segs);
 	expect("sequence phrase chains in time order", phrase.includes(", then ") && phrase.startsWith(segs[0].phrase), phrase);
 	expect("one segment phrase is the segment phrase", moveSequencePhrase([segs[0]]) === segs[0].phrase);
+}
+
+/* ------------------------------------------------- camera presets --- */
+{
+	// A preset is only useful if the frame it builds actually holds the body it
+	// was asked to hold, at both output ratios and for both shipped presets.
+	const filmbacks = [
+		{ label: "16:9", sensorId: DEFAULT_SENSOR_FORMAT, aspectRatio: 16 / 9 },
+		{ label: "12:7", sensorId: DEFAULT_SENSOR_FORMAT, aspectRatio: 12 / 7 },
+	];
+	for (const id of Object.keys(CAMERA_PRESETS)) {
+		const preset = CAMERA_PRESETS[id];
+		for (const filmback of filmbacks) {
+			const f = cameraPresetFraming(id, { x: 0, z: 0, height: 1.8 }, filmback);
+			expect(`${id} @ ${filmback.label} builds a framing`, !!f);
+			expect(`${id} @ ${filmback.label} stands at the preset height`, Math.abs(f.pos.y - preset.height) < 1e-9,
+				`${f.pos.y} != ${preset.height}`);
+			expect(`${id} @ ${filmback.label} keeps the preset focal length`, f.focalMm === preset.focalMm);
+			// Azimuth is measured off +z the way framingAt does it above.
+			const azDeg = (Math.atan2(f.pos.x, f.pos.z) * 180) / Math.PI;
+			expect(`${id} @ ${filmback.label} sits at the preset azimuth`, Math.abs(azDeg - preset.azimuthDeg) < 1e-6,
+				`${azDeg} != ${preset.azimuthDeg}`);
+			// The subject must project to the requested fraction of frame height:
+			// half the body subtends atan((h/2)/d) against half the vertical fov.
+			const dist = Math.hypot(f.pos.x, f.pos.z);
+			const halfFov = (f.fovDeg * Math.PI) / 360;
+			const fraction = Math.atan((1.8 / 2) / dist) / halfFov;
+			expect(`${id} @ ${filmback.label} frames the body at its subject fraction`,
+				Math.abs(fraction - preset.subjectFraction) < 0.06, `${fraction.toFixed(3)} vs ${preset.subjectFraction}`);
+			expect(`${id} @ ${filmback.label} leaves the whole body inside the frame`, fraction < 1,
+				`body fills ${fraction.toFixed(3)} of the frame height`);
+		}
+	}
+	// The interaction preset is the wider of the two: that is its whole purpose,
+	// holding a tall prop and the ground under it beside the subject.
+	const loco = cameraPresetFraming("mocapLocomotion", { x: 0, z: 0, height: 1.8 }, filmbacks[1]);
+	const inter = cameraPresetFraming("mocapInteraction", { x: 0, z: 0, height: 1.8 }, filmbacks[1]);
+	expect("the interaction preset is wider than the locomotion preset", inter.fovDeg > loco.fovDeg);
+	// A 4 m prop standing 2 m from the subject still fits the interaction frame.
+	const interDist = Math.hypot(inter.pos.x, inter.pos.z);
+	const propHalfAngle = Math.atan((4 / 2) / Math.max(interDist - 2, 0.1));
+	expect("a 4 m prop fits the interaction frame", propHalfAngle < (inter.fovDeg * Math.PI) / 360,
+		`prop ${(propHalfAngle * 360 / Math.PI).toFixed(1)} deg vs fov ${inter.fovDeg.toFixed(1)} deg`);
+	expect("an unknown preset id builds nothing", cameraPresetFraming("nope", { x: 0, z: 0 }, filmbacks[0]) === null);
 }
 
 if (failures > 0) {


### PR DESCRIPTION
Closes #154

The preset table shipped with the 12:7 aspect (#153) but nothing applied it. This wires it up.

- `set_camera` accepts `{ preset }` and resolves it against the active subject and the current filmback, so the same preset re-frames after the subject moves or the output ratio changes.
- A camera picker sits beside the ratio field and sends that command, so the viewport and the capture agree.
- The applied id rides on the scene stage (`cameraPresetId`), is reported by `describe`, survives a scene reload, and is cleared by any manual camera placement.
- An unknown id is rejected rather than silently ignored.

**Verified in a real browser at the 12:7 aspect** (dev UI on 5254, live hub on 5255, Chrome via the qa wrapper):

| preset | camera | capture |
|---|---|---|
| mocapLocomotion | x 8.816, y 2.4, z 8.816, 80 mm (azimuth 45 deg) | 1536x896 |
| mocapInteraction | x 6.580, y 2.4, z 6.580, 38 mm (azimuth 45 deg) | 1536x896 |

`describe` reported `stage.cameraPresetId` as `mocapLocomotion` / `mocapInteraction` after each pick. `set_camera { preset: "mocapLocomotion" }` returned the same camera; `{ preset: "nope" }` returned `Unknown camera preset`.

Captures: `/tmp/qa154/mocapLocomotion.png`, `/tmp/qa154/mocapInteraction.png` (y-bot with part colours on).

**Tests:** `npm test` passes — PASS 143 Node verification files, 0 failures. `test/verify-camera-move.mjs` gained preset coverage: both presets at 16:9 and 12:7 keep their height, focal length and azimuth, frame the body at the requested fraction of frame height with the whole body inside the frame, the interaction preset is the wider of the two and holds a 4 m prop standing 2 m from the subject, and an unknown id builds nothing.