### PR TITLE
fix(workflow): Scene node preview looks through the shot camera

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -650,15 +650,17 @@ globalThis.playMode = centerTab === "play";
 	// records; the shot camera keeps the framing. Look-through hands the fly
 	// controls the shot camera itself — the pre-split single-view behaviour —
 	// for framing by flying.
-	const [lookThroughShot, setLookThroughShot] = useState(false);
+	// The Workflow page embeds this Studio as the Scene node's preview; that
+	// preview must show what the node captures on Run: the shot camera's view.
+	const [lookThroughShot, setLookThroughShot] = useState(embedMode);
 	useEffect(() => {
-		if (!lookThroughShot) return undefined;
+		if (!lookThroughShot || embedMode) return undefined;
 		const onKey = (event) => {
 			if (event.key === "Escape") setLookThroughShot(false);
 		};
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
-	}, [lookThroughShot]);
+	}, [lookThroughShot, embedMode]);
 	useEffect(() => {
 		// The player always starts the finished piece from frame 0; auto-play
 		// only exists once there is a motion to play.

--- a/test/verify-cozy-scene-node.mjs
+++ b/test/verify-cozy-scene-node.mjs
@@ -72,3 +72,13 @@ assert.equal(failed.status, "error");
 assert.equal(failed.statusMessage, "bridge unavailable");
 
 console.log("cozy scene node adapter checks passed");
+
+// The embedded Studio is the Scene node's preview: it must look through the
+// shot camera (what capture_framing_png renders), not the editor camera.
+{
+	const { readFileSync } = await import("node:fs");
+	const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+	assert.match(app, /useState\(embedMode\)/, "lookThroughShot defaults to the embed mode");
+	assert.match(app, /if \(!lookThroughShot \|\| embedMode\) return undefined;/, "Escape does not leave the shot view inside the embed");
+	console.log("PASS embedded Studio previews through the shot camera");
+}


### PR DESCRIPTION
Closes #157.

In embed mode (`/app/?embed=playview`, the Scene node's iframe) the Studio now defaults to `lookThroughShot` and Escape does not drop out of it, so the node preview is the same shot-camera view that `capture_framing_png` renders on Run.

QA (CDP, vite 5190): node preview crop vs the captured frame after Run — same view (subject centred, same horizon and floor grid). /tmp/preview-qa/preview.png, captured.png.