### PR TITLE
fix(workflow): take an image paste even when a text field has focus

### DIFF
--- a/src/workflow/WorkflowBuilder.jsx
+++ b/src/workflow/WorkflowBuilder.jsx
@@ -22,7 +22,7 @@ import { createLiveControl } from "../live-control.js";
 import { createCanvasCommands } from "./canvas-commands.js";
 import { applyMotionToActiveScene, importImageIntoActiveScene, readStoredSceneDocument } from "./scene-asset-sync.js";
 import { createHttpTransport } from "./agent-client.js";
-import { fileToDataUrl, imageFileFromTransfer, pastedImageNodeData } from "./clipboard-image.js";
+import { canvasTakesPaste, fileToDataUrl, imageFileFromTransfer, pastedImageNodeData } from "./clipboard-image.js";
 
 const NODE_COLORS = { text: "#6c7cff", image: "#44c2a4", video: "#d9955b", audio: "#6bb6dc", api: "#cf8de8", "video-combiner": "#efb064", upload: "#a88cdb", concat: "#d6b55e", "motion-input": "#79b5ed", scene: "#ef759d" };
 
@@ -243,10 +243,8 @@ export default function WorkflowBuilder() {
 	}, [addNode]);
 	useEffect(() => {
 		const onPaste = (event) => {
-			const target = event.target;
-			if (target instanceof HTMLElement && (target.matches("input,textarea,select,[contenteditable=true]") || target.isContentEditable)) return;
+			if (!canvasTakesPaste(event.target, event.clipboardData)) return;
 			const file = imageFileFromTransfer(event.clipboardData);
-			if (!file) return;
 			event.preventDefault();
 			placeImage(file).catch((error) => toast.error(`Could not paste the image (${error.message})`));
 		};

--- a/src/workflow/clipboard-image.js
+++ b/src/workflow/clipboard-image.js
@@ -32,3 +32,13 @@ export function pastedImageNodeData(file, dataUrl) {
 	const name = file.name && file.name !== "image.png" ? file.name : `pasted-${new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-")}.png`;
 	return { fileName: name, mimeType: file.type || "image/png", fileUrl: dataUrl, image_url: dataUrl, localPreview: true, outputs: [{ value: dataUrl }] };
 }
+
+/** Whether a paste aimed at `target` should land on the canvas. The Agent
+ * composer autofocuses, so most real pastes target a textarea; a plain text
+ * field cannot hold an image, so the canvas takes it. Text stays in the field
+ * and a rich editor keeps images it can hold. */
+export function canvasTakesPaste(target, transfer) {
+	if (!imageFileFromTransfer(transfer)) return false;
+	if (!target || typeof target.matches !== "function") return true;
+	return !(target.isContentEditable || target.matches("[contenteditable=true]"));
+}

--- a/test/verify-clipboard-image.mjs
+++ b/test/verify-clipboard-image.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { imageFileFromTransfer, fileToDataUrl, pastedImageNodeData } from "../src/workflow/clipboard-image.js";
+import { imageFileFromTransfer, fileToDataUrl, pastedImageNodeData, canvasTakesPaste } from "../src/workflow/clipboard-image.js";
 
 const png = new File([Buffer.from("89504e470d0a1a0a", "hex")], "image.png", { type: "image/png" });
 const txt = new File(["hi"], "note.txt", { type: "text/plain" });
@@ -17,3 +17,15 @@ assert.equal(data.image_url, dataUrl); assert.equal(data.fileUrl, dataUrl); asse
 assert.match(data.fileName, /^pasted-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.png$/, "clipboard images get a dated name instead of image.png");
 assert.equal(pastedImageNodeData(new File([], "ref.jpg", { type: "image/jpeg" }), "data:image/jpeg;base64,").fileName, "ref.jpg", "dropped files keep their name");
 console.log("PASS clipboard image: transfer extraction, data URL read, node data");
+
+// The Agent composer autofocuses, so a real Cmd+V usually targets a textarea.
+// A plain text field cannot hold an image: the canvas takes it. Text pastes
+// stay in the field, and a rich editor keeps images it can hold.
+const el = (tag, extra = {}) => ({ tagName: tag, matches: (sel) => sel.split(",").some((s) => s.trim().toLowerCase() === tag.toLowerCase()), isContentEditable: false, ...extra });
+assert.equal(canvasTakesPaste(el("TEXTAREA"), { files: [png], items: [] }), true, "an image pasted into a textarea goes to the canvas");
+assert.equal(canvasTakesPaste(el("INPUT"), { files: [png], items: [] }), true, "an image pasted into an input goes to the canvas");
+assert.equal(canvasTakesPaste(el("TEXTAREA"), { files: [], items: [{ kind: "string", type: "text/plain" }] }), false, "text pasted into a textarea stays there");
+assert.equal(canvasTakesPaste(el("DIV", { isContentEditable: true }), { files: [png], items: [] }), false, "a rich editor keeps images it can hold");
+assert.equal(canvasTakesPaste(el("BODY"), { files: [png], items: [] }), true, "a paste with nothing focused goes to the canvas");
+assert.equal(canvasTakesPaste(el("BODY"), { files: [], items: [] }), false, "no image, nothing to place");
+console.log("PASS canvas takes image pastes aimed at plain text fields");


### PR DESCRIPTION
Real-clipboard follow-up to #151 (whose QA used a synthetic ClipboardEvent).

Root cause: the Agent composer autofocuses, so a real Cmd+V targets its textarea and the handler's "skip inputs/textareas" rule dropped the image. New rule (`canvasTakesPaste`): an image pasted into a plain input/textarea goes to the canvas; text stays in the field; contenteditable keeps images.

Evidence (headed Chrome + CDP `Input.dispatchKeyEvent commands:["Paste"]` with a PNG placed on the macOS clipboard via osascript):
- RED on main a187c4f: nodes 3→3, paste target TEXTAREA.agent-input, files=1 image/png.
- C1 on branch: nodes 3→4, new Upload node with thumbnail (data:image/png). /tmp/clip-qa/after.png
- C2: text on clipboard, composer focused → nodes unchanged, text lands in the field.
- C2b: image on clipboard, Text node textarea focused → node added.
Unit: `test/verify-clipboard-image.mjs` canvasTakesPaste cases (RED with the old rule → GREEN).