### PR TITLE
feat(shots): carry shot metadata on captures and warn per target model (#163)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -324,6 +324,8 @@ import {
 	readStoredGuideMode,
 	writeStoredGuideMode,
 } from "./shot-guides.js";
+import { shotCaptureMeta } from "./shot-meta.js";
+import { VIDEO_MODEL_PRESETS } from "./model-presets.js";
 import { serializeOtio } from "./otio.js";
 import {
 	addShotAtFrame,
@@ -569,7 +571,8 @@ export default function App() {
 				const dataUrl = live.captureFramingPng(live.captureCurrentFraming());
 				if (!dataUrl) throw new Error("The shot renderer is not ready");
 				const output = SHOT_ASPECT_PRESETS[live.stage.shotAspect] ?? SHOT_ASPECT_PRESETS["16:9"];
-				window.parent.postMessage({ type: "cozyclay:capture-framing-result", dataUrl, width: output.width, height: output.height }, "*");
+				const meta = live.captureShotMeta(live.timeline.currentFrame);
+				window.parent.postMessage({ type: "cozyclay:capture-framing-result", dataUrl, width: output.width, height: output.height, meta }, "*");
 			} catch (error) { window.parent.postMessage({ type: "cozyclay:capture-framing-result", error: error.message }, "*"); }
 		};
 		const onMessage = (event) => { if (event.data?.type === "cozyclay:capture-framing") capture(); };
@@ -2453,6 +2456,15 @@ globalThis.playMode = centerTab === "play";
 		else recordShotUndo();
 		setShots((current) => updateStableItem(current, shotId, (shot) => ({ ...shot, camera: updateCameraBlock(shot.camera, patch) }), "shots"));
 	}
+	/** Which video model this shot is being cut FOR. A label, never a
+	 * constraint: nothing re-times or re-crops the shot, the timeline simply
+	 * says when the cut breaks the target's limits. One Ctrl+Z entry per pick,
+	 * exactly like a camera-block commit. */
+	function changeShotTargetModel(targetModel, shotId = activeShot?.id) {
+		if (!shots.some((entry) => entry.id === shotId)) return;
+		recordShotUndo();
+		setShots((current) => updateStableItem(current, shotId, (entry) => ({ ...entry, targetModel: targetModel || null }), "shots"));
+	}
 	function addActiveCranePoint(requestedT = null, shotId = activeShot?.id) {
 		const shot = shots.find((entry) => entry.id === shotId);
 		const camera = createCameraBlock(shot?.camera);
@@ -3369,6 +3381,7 @@ globalThis.playMode = centerTab === "play";
 		activeShotId: activeShot?.id ?? null,
 		captureCurrentFraming,
 		captureFramingPng,
+		captureShotMeta,
 	};
 	if (!liveHandlersRef.current) {
 		const finitePatch = (args, fields) => {
@@ -3862,6 +3875,9 @@ globalThis.playMode = centerTab === "play";
 					frame: live.timeline.currentFrame,
 					shotId: live.activeShotId,
 					partColours: live.partColours,
+					// The production notes the PNG cannot carry: lens, delivery
+					// aspect, cast and the video model this shot is aimed at.
+					meta: live.captureShotMeta(live.timeline.currentFrame),
 				};
 			},
 			load_motion: async (args) => {
@@ -4419,6 +4435,28 @@ globalThis.playMode = centerTab === "play";
 		const cam = shotCamRef.current;
 		const pos = cam ? cam.position : cameraPos;
 		return captureFraming({ pos: { x: pos.x, y: pos.y, z: pos.z }, yaw: look.current.yaw, pitch: look.current.pitch, fovDeg });
+	}
+
+	// What a framing capture says about the shot it came from: lens, delivery
+	// aspect, cast, cut range and the video model the shot is aimed at. Both
+	// capture paths (the live command and the embed message) attach this, so a
+	// still handed to a generator arrives with its production notes.
+	// A frame that falls in a gap between shots describes the first shot — a
+	// pull still belongs to the piece even when the playhead sits outside a cut.
+	function captureShotMeta(frame) {
+		const index = shotIndexAtFrame(shots, frame);
+		const resolvedIndex = index >= 0 ? index : shots.length ? 0 : null;
+		return shotCaptureMeta({
+			shot: resolvedIndex == null ? null : shots[resolvedIndex],
+			shotIndex: resolvedIndex,
+			stage: { keyLight },
+			cast: characters,
+			fps: tlFps,
+			aspectKey: shotAspectKey,
+			size: { width: shotOutput.width, height: shotOutput.height },
+			frame,
+			lens: { focalMm: shot.focalMm, fovDeg },
+		});
 	}
 
 	// Key authoring lives in each unified Shot block's lower key strip: clicking
@@ -5988,6 +6026,13 @@ globalThis.playMode = centerTab === "play";
 				setPartColoursMode(mode === "flat" ? "flat" : "shaded");
 			},
 			setCharacterScale: (scale) => updateCharacterAt(activeCharIndex, { scale }),
+			// QA-only: the production notes a framing capture carries (lens,
+			// delivery aspect, cast, cut range, target video model) for the frame
+			// the playhead is on — the same object both capture paths attach.
+			// Read through liveStateRef, which every render refreshes: this hook's
+			// effect does not depend on the shot list, so a closure over it would
+			// answer with the cut as it stood when the effect last ran.
+			captureMeta: (frame) => liveStateRef.current.captureShotMeta(frame ?? liveStateRef.current.timeline.currentFrame),
 			characterScale: activeChar?.scale ?? 1,
 			characterModel: activeChar?.model ?? null,
 			// QA-only framing: FlyControls rewrites the editor camera's rotation
@@ -10741,6 +10786,29 @@ function resizePromptClip(id, edge, rawFrame) {
 								? ko(`Editing ${activeShot.name} in the timeline camera bar below.`, `아래 타임라인 카메라 바에서 ${activeShot.name}을 편집합니다.`)
 								: ko("Select a Shot block below to edit its camera.", "아래에서 샷 블록을 선택하면 카메라를 편집할 수 있습니다.")}
 						</p>
+
+						{/* Which generator this cut is being made FOR. Nothing here
+						    re-times or re-crops the shot — the timeline simply warns
+						    when the cut runs past the target's clip length or leaves
+						    its delivery aspects. */}
+						<h3 className="move-head">{ko("Target model", "타깃 모델")}</h3>
+						<p className="inspector-hint">
+							{ko("The timeline flags this shot when the cut runs past the model's clip length or leaves its delivery ratios. Nothing is re-timed or re-cropped.", "컷 길이나 화면 비율이 모델 한계를 벗어나면 타임라인이 표시해줘요. 자동으로 재조정하지는 않습니다.")}
+						</p>
+						<Field label={ko("Cut for", "맞출 모델")}>
+							<select
+								data-shot-target-model
+								aria-label={ko("Target video model", "타깃 영상 모델")}
+								disabled={!activeShot}
+								value={activeShot?.targetModel ?? ""}
+								onChange={(event) => changeShotTargetModel(event.target.value)}
+							>
+								<option value="">{ko("None", "없음")}</option>
+								{VIDEO_MODEL_PRESETS.map((entry) => (
+									<option key={entry.id} value={entry.id}>{entry.name}</option>
+								))}
+							</select>
+						</Field>
 					</Foldout>
 
 				<Foldout hidden={!isCharacterSelection} title={ko("Part colours", "부위 색상")}>
@@ -12505,6 +12573,7 @@ function resizePromptClip(id, edge, rawFrame) {
 				footSnap={footSnap}
 				bodyContact={bodyContact}
 					shots={shots}
+					shotAspect={shotAspectKey}
 					activeShotIdx={activeShotIdx}
 					railDraw={railDraw}
 					pathDraw={pathDraw}

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -7,6 +7,7 @@ import { ko, isKo } from "../locale.js";
 import { buildRail, craneHeightAt } from "../camera-follow.js";
 import { pathMetrics } from "../object-path.js";
 import { flatTiming, timingIsFlat, envelopeDrag, insertCut, removeCut, CUT_MIN_GAP } from "../speed-envelope.js";
+import { checkShotAgainstPreset, presetById } from "../model-presets.js";
 
 /**
  * ARDY Viser-style animation timeline — the live motion workspace.
@@ -968,6 +969,10 @@ export default function Timeline({
 	footSnap = true, // feet stay planted while the body moves
 	bodyContact = true, // body markers stay above the floor
 	shots = [],
+	// The stage's delivery aspect label ("16:9", "9:16", …). A shot aimed at a
+	// video model is checked against it, so the badge can say when the cut
+	// leaves the target's supported ratios.
+	shotAspect = null,
 	activeShotIdx = 0,
 	selectedCameraBlockIdx,
 	shotCutDisabled = false,
@@ -2036,6 +2041,13 @@ export default function Timeline({
 											: null;
 										const railOff = storedRail?.mode === "off" || mode !== "rail";
 										const localProgress = frame - shot.startFrame;
+										// A shot aimed at a video model is measured against that
+										// model's clip lengths and delivery aspects. The badge is
+										// advisory: nothing here trims or re-crops the cut.
+										const targetPreset = shot.targetModel ? presetById(shot.targetModel) : null;
+										const modelWarnings = targetPreset
+											? checkShotAgainstPreset({ frames: durationFrames, fps, aspect: shotAspect }, targetPreset).warnings
+											: [];
 										return (
 											<div
 												key={shot.id}
@@ -2087,6 +2099,15 @@ export default function Timeline({
 													<span className="tl-shot-label">
 														<b>{shot.name}</b>
 														<small>{shot.startFrame}–{lastFrame} · {durationS.toFixed(1)}{ko("s", "초")}</small>
+													</span>
+												)}
+												{modelWarnings.length > 0 && (
+													<span
+														className="tl-shot-warn"
+														role="status"
+														title={modelWarnings.join("; ")}
+													>
+														⚠ {targetPreset.name}
 													</span>
 												)}
 											<span className="tl-shot-actions">

--- a/src/shot-authoring.js
+++ b/src/shot-authoring.js
@@ -7,6 +7,9 @@
 import { createTiming, timingIsFlat } from "./speed-envelope.js";
 import { createShot } from "./cuts.js";
 import { normalizeStableItems } from "./stable-items.js";
+import { VIDEO_MODEL_PRESETS } from "./model-presets.js";
+
+const VIDEO_MODEL_IDS = new Set(VIDEO_MODEL_PRESETS.map((preset) => preset.id));
 
 export const SHOT_AUTHORING_VERSION = 4;
 export const SHOT_AUTHORING_KEY = "cozyclay.shot-authoring.v4";
@@ -135,6 +138,11 @@ function repairShots(entries, frameCount, inheritedCamera = null, ids = new Set(
 	);
 	return ordered.map((entry, index) => {
 		const startFrame = entry.startFrame;
+		// Which video model this cut is aimed at. Absent unless the shot names
+		// one, so an untargeted body round-trips byte-identical; an unknown id
+		// from a newer build is dropped rather than kept, because the badge must
+		// never cite a preset this build cannot describe.
+		const targetModel = VIDEO_MODEL_IDS.has(entry.targetModel) ? { targetModel: entry.targetModel } : null;
 		const nextStart = ordered[index + 1]?.startFrame ?? frameCount;
 		// Pre-overlay v3 bodies had no endFrame and were gapless by definition.
 		// Infer their old boundary exactly; new bodies persist an explicit end.
@@ -147,6 +155,7 @@ function repairShots(entries, frameCount, inheritedCamera = null, ids = new Set(
 			endFrame,
 			cameraKeys: repairKeys(entry.cameraKeys, startFrame, endFrame, ids),
 			camera: repairCamera(inheritedCamera ?? entry.camera),
+			...targetModel,
 		};
 	});
 }

--- a/src/shot-meta.js
+++ b/src/shot-meta.js
@@ -1,0 +1,66 @@
+/**
+ * What a framing capture SAYS about the shot it came from.
+ *
+ * A PNG on its own is just pixels: an agent handing it to a video model still
+ * has to know the lens, the delivery aspect, who is in frame and which model
+ * the shot is aimed at. This module answers that in one pure object, so both
+ * capture paths (the live `capture_framing_png` command and the embed-mode
+ * message handler) describe a pull the same way.
+ *
+ * Pure data: no DOM, no React, no three.js — it runs in node tests and in the
+ * browser unchanged. Everything is read defensively because callers pass live
+ * editor state, where a shot can be missing entirely (no shots authored yet).
+ */
+
+const finite = (value) => (Number.isFinite(value) ? value : null);
+
+/**
+ * @param {object} input
+ * @param {object|null} input.shot         the shot the captured frame lands in
+ * @param {object|null} input.stage        { keyLight } — the stage envelope
+ * @param {Array}       input.cast         characters array ({ name, model })
+ * @param {number}      input.fps          timeline frames per second
+ * @param {string}      input.aspectKey    delivery aspect label, e.g. "16:9"
+ * @param {object}      input.size         { width, height } of the capture
+ * @param {number}      input.frame        the captured frame number
+ * @param {number}      [input.shotIndex]  the shot's index in the shot list
+ * @param {object}      [input.lens]       { focalMm, fovDeg } of the live shot
+ *   camera, used when the shot's own camera block carries no lens — the block
+ *   stores the MOVE (rail, crane, follow), while the lens lives on the stage.
+ */
+export function shotCaptureMeta({ shot = null, stage = null, cast = [], fps = null, aspectKey = null, size = null, frame = null, shotIndex = null, lens = null } = {}) {
+	const camera = shot?.camera ?? null;
+	return {
+		focalMm: finite(camera?.focalMm) ?? finite(lens?.focalMm),
+		fovDeg: finite(camera?.fovDeg) ?? finite(lens?.fovDeg),
+		aspect: typeof aspectKey === "string" && aspectKey ? aspectKey : null,
+		size: {
+			width: finite(size?.width),
+			height: finite(size?.height),
+		},
+		// Which instruments the move actually uses, not which ones were once
+		// switched on: a stored-but-empty envelope is no dolly move.
+		cameraMove: {
+			dolly: Boolean(camera?.dollyTiming),
+			crane: Boolean(camera?.craneHeight),
+			rail: Boolean(camera?.railFollow) && camera.railFollow.mode !== "off",
+		},
+		keyLight: stage?.keyLight ?? null,
+		// A cast member's name is what the operator typed for it: the studio
+		// stores that as the subject description, which is exactly the line a
+		// generator wants beside the still.
+		cast: (Array.isArray(cast) ? cast : []).map((entry) => ({
+			name: entry?.name ?? entry?.subject ?? null,
+			model: entry?.model ?? null,
+		})),
+		frameRange: {
+			start: finite(shot?.startFrame),
+			end: finite(shot?.endFrame),
+		},
+		fps: finite(fps),
+		shotIndex: Number.isInteger(shotIndex) && shotIndex >= 0 ? shotIndex : null,
+		shotTitle: typeof shot?.name === "string" && shot.name ? shot.name : null,
+		targetModel: shot?.targetModel ?? null,
+		frame: finite(frame),
+	};
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4903,6 +4903,23 @@ input[type=range]::-moz-range-thumb {
 	cursor: default;
 }
 
+/* The shot outruns (or out-crops) the video model it is aimed at. Advisory
+   only — same amber the timeline already uses for an over-speed path, sized
+   like the state chip beside it so the strip keeps one type scale. */
+.tl-shot-warn {
+	flex: 0 0 auto;
+	padding: 1px 3px;
+	border: 1px solid rgba(245, 180, 83, .5);
+	border-radius: 2px;
+	background: rgba(245, 180, 83, .16);
+	color: var(--warn, #f5b453);
+	font-size: 7.5px;
+	font-weight: 700;
+	letter-spacing: .06em;
+	white-space: nowrap;
+	cursor: help;
+}
+
 .tl-camera-block-state {
 	padding: 1px 3px;
 	border: 1px solid rgba(255, 255, 255, .22);

--- a/test/qa-shot-meta-browser.mjs
+++ b/test/qa-shot-meta-browser.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Browser QA for shot metadata (#163), driven over CDP through the QA browser
+// wrapper: aim a shot at a video model through the inspector select, stretch
+// the cut past that model's clip length, and read the warning badge and the
+// capture metadata out of the real DOM. Evidence script; not in the manifest.
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const out = process.env.QA_OUT || "/tmp/shot-meta-qa";
+mkdirSync(out, { recursive: true });
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+// React state lands on a later commit than the call that requested it, so
+// every assertion waits for the DOM to actually say so instead of sleeping.
+const waitFor = async (expression, timeoutMs = 20000) => {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		if (Date.now() >= deadline) return false;
+		await new Promise((resolve) => setTimeout(resolve, 60));
+	}
+};
+const screenshot = async (name) => {
+	const { data } = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: false });
+	const path = `${out}/${name}.png`;
+	writeFileSync(path, Buffer.from(data, "base64"));
+	return path;
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+expect("app becomes ready", await waitFor("!!document.querySelector('.add-object-trigger')", 60000));
+expect("the QA capture-meta hook is exposed", await waitFor("typeof window.__cozyclay?.captureMeta === 'function'", 30000));
+
+// --- a shot to aim -------------------------------------------------------
+// The lane's own "+ Add shot" is the shipped way to create one, so QA uses it
+// rather than reaching into state.
+await evaluate(`(() => {
+	const add = [...document.querySelectorAll('.tl-track-add.cut')][0];
+	if (add && !add.disabled) add.click();
+})()`);
+expect("a shot block exists on the timeline", await waitFor("!!document.querySelector('.tl-shot-block')", 20000));
+await evaluate("document.querySelector('.tl-shot-block').click()");
+
+// --- aim it at Seedance 2.5 through the inspector select -----------------
+const select = "document.querySelector('[data-shot-target-model]')";
+expect("the shot inspector offers a Target model select", await waitFor(`!!${select} && !${select}.disabled`, 20000));
+expect("the select lists every shipped preset plus None", await evaluate(`(() => {
+	const values = [...${select}.options].map((option) => option.value);
+	return values[0] === "" && ["seedance-2.5", "kling-2", "veo-3", "minimax-h3-selfhosted"].every((id) => values.includes(id));
+})()`));
+// A React-controlled select only sees a change dispatched through its own
+// value setter, the way a user's pick reaches it.
+await evaluate(`(() => {
+	const element = ${select};
+	const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set;
+	setter.call(element, "seedance-2.5");
+	element.dispatchEvent(new Event("change", { bubbles: true }));
+})()`);
+expect("the pick lands on the shot", await waitFor(`${select}.value === "seedance-2.5"`, 20000));
+
+// --- stretch the cut past the 10 s limit ---------------------------------
+// Seedance takes exactly 5 s or 10 s clips, so a shot longer than 10 s is out
+// of grid. The end handle is the shipped control; QA drags it to the far right
+// of the lane the way an editor trims.
+await evaluate(`(() => {
+	const block = document.querySelector('.tl-shot-block');
+	const handle = block.querySelector('.tl-shot-edge.end');
+	const lane = block.closest('.tl-lane');
+	const laneBox = lane.getBoundingClientRect();
+	const handleBox = handle.getBoundingClientRect();
+	const options = { bubbles: true, cancelable: true, pointerId: 1, button: 0, buttons: 1 };
+	handle.setPointerCapture = () => {};
+	handle.releasePointerCapture = () => {};
+	handle.dispatchEvent(new PointerEvent("pointerdown", { ...options, clientX: handleBox.left + 2, clientY: handleBox.top + 4 }));
+	handle.dispatchEvent(new PointerEvent("pointermove", { ...options, clientX: laneBox.right - 2, clientY: handleBox.top + 4 }));
+	handle.dispatchEvent(new PointerEvent("pointerup", { ...options, buttons: 0, clientX: laneBox.right - 2, clientY: handleBox.top + 4 }));
+})()`);
+const longEnough = "(() => { const m = window.__cozyclay.captureMeta(); return (m.frameRange.end - m.frameRange.start + 1) / m.fps > 10; })()";
+expect("the shot now runs past 10 s", await waitFor(longEnough, 20000), await evaluate("JSON.stringify(window.__cozyclay.captureMeta().frameRange)"));
+
+// --- the badge ------------------------------------------------------------
+expect("the shot box shows the model warning badge", await waitFor("!!document.querySelector('.tl-shot-warn')", 20000));
+const badgeTitle = await evaluate("document.querySelector('.tl-shot-warn')?.title ?? ''");
+expect("the badge names the limit it broke", /Seedance/.test(badgeTitle) && /too long/.test(badgeTitle), badgeTitle);
+console.log(`badge title: ${badgeTitle}`);
+console.log(`badge screenshot: ${await screenshot("badge")}`);
+
+// --- capture metadata -----------------------------------------------------
+const meta = await evaluate("window.__cozyclay.captureMeta()");
+expect("capture meta carries the lens", Number.isFinite(meta.focalMm) && Number.isFinite(meta.fovDeg), JSON.stringify({ focalMm: meta.focalMm, fovDeg: meta.fovDeg }));
+expect("capture meta carries the delivery aspect", typeof meta.aspect === "string" && meta.aspect.includes(":"), String(meta.aspect));
+expect("capture meta carries the cast", Array.isArray(meta.cast) && meta.cast.length > 0 && typeof meta.cast[0].model === "string" && typeof meta.cast[0].name === "string", JSON.stringify(meta.cast));
+expect("capture meta names the target model", meta.targetModel === "seedance-2.5", String(meta.targetModel));
+expect("capture meta carries the cut range and fps", Number.isInteger(meta.frameRange.start) && Number.isInteger(meta.frameRange.end) && meta.fps > 0, JSON.stringify(meta));
+writeFileSync(`${out}/capture-meta.json`, JSON.stringify(meta, null, 2));
+console.log(`capture meta: ${out}/capture-meta.json`);
+
+// --- clearing the target clears the badge --------------------------------
+await evaluate(`(() => {
+	const element = ${select};
+	const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set;
+	setter.call(element, "");
+	element.dispatchEvent(new Event("change", { bubbles: true }));
+})()`);
+expect("clearing the target drops the badge", await waitFor("!document.querySelector('.tl-shot-warn')", 20000));
+
+if (failures > 0) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log("qa-shot-meta-browser: all checks passed");
+process.exit(0);

--- a/test/verify-shot-meta.mjs
+++ b/test/verify-shot-meta.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { shotCaptureMeta } from "../src/shot-meta.js";
+import { VIDEO_MODEL_PRESETS, presetById, checkShotAgainstPreset } from "../src/model-presets.js";
+
+const shot = {
+	name: "Shot 2",
+	startFrame: 48,
+	endFrame: 95,
+	targetModel: "seedance-2.5",
+	camera: {
+		mode: "rail",
+		dollyTiming: { cuts: [] },
+		craneHeight: { points: [{ t: 0, height: 1.6 }, { t: 1, height: 2.4 }] },
+		railFollow: { mode: "range", startFrame: 0, endFrame: 47 },
+	},
+};
+const stage = { keyLight: { x: 2, y: 3, z: 1, intensity: 1.1 } };
+const cast = [{ name: "Ari", model: "y-bot-tpose" }, { name: "Bo", model: "x-bot-tpose" }];
+
+const meta = shotCaptureMeta({
+	shot,
+	shotIndex: 1,
+	stage,
+	cast,
+	fps: 24,
+	aspectKey: "16:9",
+	size: { width: 1920, height: 1080 },
+	frame: 60,
+	lens: { focalMm: 35, fovDeg: 42 },
+});
+
+assert.equal(meta.aspect, "16:9");
+assert.deepEqual(meta.size, { width: 1920, height: 1080 });
+assert.deepEqual(meta.frameRange, { start: 48, end: 95 });
+assert.equal(meta.fps, 24);
+assert.equal(meta.frame, 60);
+assert.equal(meta.shotIndex, 1);
+assert.equal(meta.shotTitle, "Shot 2");
+assert.equal(meta.targetModel, "seedance-2.5");
+assert.deepEqual(meta.keyLight, stage.keyLight);
+assert.deepEqual(meta.cast, [{ name: "Ari", model: "y-bot-tpose" }, { name: "Bo", model: "x-bot-tpose" }]);
+// The lens lives on the stage, not in the camera block: the capture still
+// reports it, because a still without a focal length cannot be re-shot.
+assert.equal(meta.focalMm, 35);
+assert.equal(meta.fovDeg, 42);
+console.log("PASS shot meta: lens, aspect, size, cut range, cast and target model");
+
+// cameraMove is derived from what the block actually carries.
+assert.deepEqual(meta.cameraMove, { dolly: true, crane: true, rail: true });
+const still = shotCaptureMeta({ shot: { ...shot, camera: { mode: "keys" } }, aspectKey: "9:16" });
+assert.deepEqual(still.cameraMove, { dolly: false, crane: false, rail: false }, "a keys-only block moves on none of the three axes");
+const railedOff = shotCaptureMeta({ shot: { ...shot, camera: { ...shot.camera, railFollow: { mode: "off" }, dollyTiming: null, craneHeight: null } } });
+assert.deepEqual(railedOff.cameraMove, { dolly: false, crane: false, rail: false }, "a switched-off rail is not a dolly move");
+console.log("PASS shot meta: cameraMove flags follow dollyTiming, craneHeight and railFollow");
+
+// A capture taken with nothing authored still describes itself honestly:
+// nulls, never undefined or a thrown read of a missing shot.
+const empty = shotCaptureMeta();
+assert.deepEqual(empty, {
+	focalMm: null,
+	fovDeg: null,
+	aspect: null,
+	size: { width: null, height: null },
+	cameraMove: { dolly: false, crane: false, rail: false },
+	keyLight: null,
+	cast: [],
+	frameRange: { start: null, end: null },
+	fps: null,
+	shotIndex: null,
+	shotTitle: null,
+	targetModel: null,
+	frame: null,
+});
+const named = shotCaptureMeta({ cast: [{ subject: "a young woman in a red coat", model: "y-bot-tpose" }] });
+assert.deepEqual(named.cast, [{ name: "a young woman in a red coat", model: "y-bot-tpose" }], "the studio's subject line is the cast member's name");
+const untargeted = shotCaptureMeta({ shot: { name: "Shot 1", startFrame: 0, endFrame: 47 }, cast: null, fps: Number.NaN });
+assert.equal(untargeted.targetModel, null, "a shot with no target model reports null, not undefined");
+assert.equal(untargeted.fps, null, "a non-finite fps falls back to null");
+assert.deepEqual(untargeted.cast, [], "a missing cast is an empty cast");
+console.log("PASS shot meta: missing shot, cast and fps fall back to nulls");
+
+// The target model is the id of a shipped preset, so the timeline can measure
+// the cut against it without a second lookup table.
+assert.ok(presetById(meta.targetModel), "the stored target model names a shipped preset");
+assert.deepEqual(
+	VIDEO_MODEL_PRESETS.map((preset) => preset.id).includes(meta.targetModel),
+	true,
+);
+const frames = meta.frameRange.end - meta.frameRange.start + 1;
+const check = checkShotAgainstPreset({ frames, fps: meta.fps, aspect: meta.aspect }, presetById(meta.targetModel));
+assert.equal(check.ok, false, "48 frames @ 24 fps is 2s, off Seedance's 5s/10s grid");
+assert.match(check.warnings.join("; "), /too long/);
+console.log("PASS shot meta: targetModel feeds checkShotAgainstPreset directly");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -132,6 +132,7 @@ const NODE_FILES = [
 	"test/verify-stable-ids.mjs",
 	"test/verify-storyboard.mjs",
 	"test/verify-shot-authoring.mjs",
+	"test/verify-shot-meta.mjs",
 	"test/verify-shot-prompt.mjs",
 	"test/verify-take-recipe.mjs",
 	"test/verify-theme.mjs",


### PR DESCRIPTION
## What changed

A framing capture now carries the production notes the PNG itself cannot, and a shot can name the video model it is being cut for.

**`src/shot-meta.js` (new, pure)** — `shotCaptureMeta({ shot, stage, cast, fps, aspectKey, size, frame, shotIndex, lens })` returns `{ focalMm, fovDeg, aspect, size, cameraMove: { dolly, crane, rail }, keyLight, cast: [{ name, model }], frameRange, fps, shotIndex, shotTitle, targetModel, frame }`. `cameraMove` is derived from what the camera block actually carries (`dollyTiming`, `craneHeight`, a `railFollow` that is not `"off"`), and every missing input falls back to `null` rather than `undefined` or a throw. The lens lives on the stage rather than in the camera block, so the helper takes it as a `lens` fallback; a cast member's `name` falls back to the studio's `subject` line.

**`src/App.jsx`** — `captureShotMeta(frame)` resolves the shot containing the frame (falling back to the first shot) and builds the meta. Both capture paths attach it: the live `capture_framing_png` command returns `meta`, and the embed-mode `cozyclay:capture-framing-result` message posts it alongside `dataUrl/width/height`. A "Target model" select in the Camera inspector lists every `VIDEO_MODEL_PRESETS` entry plus "None", stored as `shot.targetModel` through `changeShotTargetModel`, which pushes one `recordShotUndo` entry per pick — the same history a camera-block commit uses. QA hook `window.__cozyclay.captureMeta(frame?)` reads through `liveStateRef`, so it answers with the current cut rather than the one the hook's effect last saw.

**`src/ardy/timeline.jsx` + `src/styles.css`** — the shot box shows a `.tl-shot-warn` badge when `checkShotAgainstPreset({ frames, fps, aspect }, preset)` returns warnings, with `title` set to the warnings joined by `"; "`. The stage aspect arrives as a new `shotAspect` prop. The badge reuses the timeline's existing amber warn tone and the same chip metrics as `.tl-camera-block-state` beside it, so the strip keeps one type scale. (The timeline lives in `src/ardy/timeline.jsx`, not `src/App.jsx` — this is the file that already holds the `.tl-shot` markup the badge belongs to.)

**`src/shot-authoring.js`** — `repairShots` keeps `targetModel` so the pick survives a reload, dropping ids this build does not ship. The key is emitted only when a shot names one, so untargeted bodies round-trip byte-identical.

## How it was verified

`node test/verify-shot-meta.mjs` (registered in `tools/run-tests.mjs`):

```
PASS shot meta: lens, aspect, size, cut range, cast and target model
PASS shot meta: cameraMove flags follow dollyTiming, craneHeight and railFollow
PASS shot meta: missing shot, cast and fps fall back to nulls
PASS shot meta: targetModel feeds checkShotAgainstPreset directly
```

Browser QA against a real studio — `COZYCLAY_LIVE_PORT=5294 npm run dev -- --port 5290`, then `QA_URL=http://127.0.0.1:5290/app/ CDP_PORT=9463 node tools/qa-browser.mjs -- node test/qa-shot-meta-browser.mjs`. It adds a shot through the lane's own "+ Add shot", picks Seedance 2.5 in the inspector select, drags the shot's end handle out to 15 s and reads the DOM:

```
PASS app becomes ready
PASS the QA capture-meta hook is exposed
PASS a shot block exists on the timeline
PASS the shot inspector offers a Target model select
PASS the select lists every shipped preset plus None
PASS the pick lands on the shot
PASS the shot now runs past 10 s
PASS the shot box shows the model warning badge
PASS the badge names the limit it broke
badge title: too long: 15s is not an allowed clip length for Seedance 2.5 (allowed: 5s or 10s)
badge screenshot: /tmp/shot-meta-qa/badge.png
PASS capture meta carries the lens
PASS capture meta carries the delivery aspect
PASS capture meta carries the cast
PASS capture meta names the target model
PASS capture meta carries the cut range and fps
capture meta: /tmp/shot-meta-qa/capture-meta.json
PASS clearing the target drops the badge
qa-shot-meta-browser: all checks passed
```

Screenshot: `/tmp/shot-meta-qa/badge.png` (the `⚠ Seedance 2.5` badge on the Shot 1 box, with the Target model field in the inspector). Captured meta: `/tmp/shot-meta-qa/capture-meta.json` —

```json
{ "focalMm": 24, "fovDeg": 45, "aspect": "16:9", "size": { "width": 1920, "height": 1080 },
  "cameraMove": { "dolly": false, "crane": false, "rail": false },
  "frameRange": { "start": 0, "end": 359 }, "fps": 24, "shotIndex": 0,
  "shotTitle": "Shot 1", "targetModel": "seedance-2.5", "frame": 0 }
```

`NO_COLOR=1 npm test` — EXIT 0. Last 15 lines:

```
switch_scene | false | true | true | false | Make a different scene active.
open_project | false | true | true | true | Load a project authored in the CozyClay studio (or saved here).
save_project | false | true | true | true | Write the current state as a .cclayproject file.
PASS place_character versus add_character: "Unlike add_character, place_character changes an existing cast member instead of adding one." / "Unlike place_character, add_character adds a new cast member instead of changing an existing one."
PASS place_object versus update_object: "Unlike update_object, place_object adds a new prop instead of changing an existing one." / "Unlike place_object, update_object changes an existing prop instead of adding one."
PASS frame_shot versus set_camera: "Unlike set_camera, frame_shot derives camera position and lens from shot intent rather than applying explicit coordinates." / "Unlike frame_shot, set_camera applies explicit camera coordinates or focal length rather than deriving a shot."
PASS G005 tools/list safety contract (25 tools; deterministic order)

RUNNING mcp/verify.mjs
25 tools registered
420 framing combinations checked

all checks passed

PASS 152 Node verification files
```

Closes #163
