### PR TITLE
feat(export): keyframe pack zip, depth/normal passes and storyboard sheet (#165)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -325,6 +325,11 @@ import {
 	writeStoredGuideMode,
 } from "./shot-guides.js";
 import { shotCaptureMeta } from "./shot-meta.js";
+import { buildShotPrompt } from "./shot-prompt.js";
+import { keyframePackEntries, keyframePackName } from "./keyframe-pack.js";
+import { buildZip } from "./zip-store.js";
+import { composeStoryboard } from "./storyboard.js";
+import { passFileName, renderPass } from "./render-passes.js";
 import { VIDEO_MODEL_PRESETS } from "./model-presets.js";
 import { serializeOtio } from "./otio.js";
 import {
@@ -468,6 +473,28 @@ function ShotGuideOverlay({ mode, aspect, className = "" }) {
 // scaled on (0..1 visibility), so it reads as "less than half seen".
 const PHOTO_POSE_LOW_CONFIDENCE = 0.5;
 
+// The storyboard contact sheet is drawn on a bare 2d canvas, which has no
+// stylesheet to inherit from: it gets the studio's own type stack explicitly
+// so the sheet reads like the app it came out of.
+const STORYBOARD_FONT = '12px Inter, "Pretendard", "Noto Sans KR", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif';
+// One unwrapped caption line at 12px inside a 480px cell holds about 64
+// characters before it runs into the next column.
+const STORYBOARD_CAPTION_CHARS = 64;
+
+/** Cut a caption to what one unwrapped cell line holds. */
+function storyboardLine(text) {
+	return text.length > STORYBOARD_CAPTION_CHARS ? `${text.slice(0, STORYBOARD_CAPTION_CHARS - 1)}\u2026` : text;
+}
+
+/** Fold a labelled shot prompt into the one line a board cell can hold. */
+function storyboardCaption(prompt) {
+	return storyboardLine(prompt
+		.split("\n")
+		.filter((line) => line.startsWith("SHOT:") || line.startsWith("LENS:"))
+		.map((line) => line.slice(line.indexOf(":") + 1).trim())
+		.join(" · "));
+}
+
 // cskel27 joint names are rig vocabulary — "RightForeArm" means nothing to
 // someone holding a photograph. Every joint collapses into one of six groups a
 // viewer can check against their own picture, ordered so the sentence always
@@ -575,7 +602,29 @@ export default function App() {
 				window.parent.postMessage({ type: "cozyclay:capture-framing-result", dataUrl, width: output.width, height: output.height, meta }, "*");
 			} catch (error) { window.parent.postMessage({ type: "cozyclay:capture-framing-result", error: error.message }, "*"); }
 		};
-		const onMessage = (event) => { if (event.data?.type === "cozyclay:capture-framing") capture(); };
+		// The Workflow page's Scene node asks the embed for a whole reference
+		// pack (#165). The zip is transferred rather than copied: a pack carries a
+		// clip, and structured-cloning tens of megabytes across the frame boundary
+		// is the one part of this that would actually be felt.
+		const exportPack = async (shotId) => {
+			try {
+				const live = liveStateRef.current;
+				const index = live.shotIndexForPack(shotId ?? null);
+				const pack = await live.buildShotKeyframePack(live.shots[index], index);
+				const bytes = pack.bytes.buffer.slice(pack.bytes.byteOffset, pack.bytes.byteOffset + pack.bytes.byteLength);
+				window.parent.postMessage(
+					{ type: "cozyclay:export-keyframe-pack-result", name: pack.name, bytes, entries: pack.entries.map((entry) => entry.name) },
+					"*",
+					[bytes],
+				);
+			} catch (error) {
+				window.parent.postMessage({ type: "cozyclay:export-keyframe-pack-result", error: error?.message || String(error) }, "*");
+			}
+		};
+		const onMessage = (event) => {
+			if (event.data?.type === "cozyclay:capture-framing") capture();
+			if (event.data?.type === "cozyclay:export-keyframe-pack") void exportPack(event.data.shotId);
+		};
 		window.addEventListener("message", onMessage);
 		return () => window.removeEventListener("message", onMessage);
 	}, [embedMode]);
@@ -2902,6 +2951,25 @@ globalThis.playMode = centerTab === "play";
 			window.removeEventListener("keydown", onKeyDown);
 		};
 	}, [projectMenuOpen]);
+	// The PlayView reference-export menu (#165) dismisses the same way.
+	const [exportMenuOpen, setExportMenuOpen] = useState(false);
+	const [exportMenuAnchor, setExportMenuAnchor] = useState({ top: 0, right: 0 });
+	useEffect(() => {
+		if (!exportMenuOpen) return undefined;
+		const onPointerDown = (event) => {
+			if (event.target instanceof Element && event.target.closest(".export-menu-wrap")) return;
+			setExportMenuOpen(false);
+		};
+		const onKeyDown = (event) => {
+			if (event.key === "Escape") setExportMenuOpen(false);
+		};
+		document.addEventListener("pointerdown", onPointerDown);
+		window.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("pointerdown", onPointerDown);
+			window.removeEventListener("keydown", onKeyDown);
+		};
+	}, [exportMenuOpen]);
 	const projectHandleRef = useRef(null);
 	const projectSnapshotRef = useRef("");
 	const projectStateRef = useRef(null);
@@ -3382,6 +3450,13 @@ globalThis.playMode = centerTab === "play";
 		captureCurrentFraming,
 		captureFramingPng,
 		captureShotMeta,
+		// Reference exports (#165): the embed message handler and the QA hooks
+		// both go through this render's closures, so a pack always describes the
+		// cut as it stands now.
+		buildShotKeyframePack,
+		shotIndexForPack,
+		renderPassDataUrls,
+		shots,
 	};
 	if (!liveHandlersRef.current) {
 		const finitePatch = (args, fields) => {
@@ -4426,6 +4501,237 @@ globalThis.playMode = centerTab === "play";
 			setToast(isKo
 				? `OTIO 저장됨 · ${shots.length}샷 · ${frameCount}프레임`
 				: `OTIO saved · ${shots.length} shots · ${frameCount} frames`);
+		} catch (error) {
+			setToast(error?.message || String(error));
+		}
+	}
+
+	/* ======================= reference-pack exports (#165) =================
+	 * Three deliverables a video model actually asks for, all built from the
+	 * SAME offscreen capture rig the MP4 export uses, so what ships matches
+	 * what the editor previewed:
+	 *   - a per-shot keyframe pack (first/last frame, clip, camera, prompt),
+	 *   - depth + normal conditioning passes of the current framing,
+	 *   - a storyboard contact sheet of the whole cut.
+	 */
+
+	function saveDownload(href, name) {
+		const anchor = document.createElement("a");
+		anchor.href = href;
+		anchor.download = name;
+		document.body.appendChild(anchor);
+		anchor.click();
+		anchor.remove();
+	}
+
+	function loadImage(dataUrl) {
+		return new Promise((resolve, reject) => {
+			const image = new Image();
+			image.onload = () => resolve(image);
+			image.onerror = () => reject(new Error("A captured frame could not be decoded"));
+			image.src = dataUrl;
+		});
+	}
+
+	function dataUrlToBytes(dataUrl) {
+		const binary = atob(dataUrl.slice(dataUrl.indexOf(",") + 1));
+		const bytes = new Uint8Array(binary.length);
+		for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+		return bytes;
+	}
+
+	// One frame of the shot as the recorder would draw it: applyExportFrame
+	// poses every cast member and parks the shot camera for that absolute
+	// frame, exactly as the MP4 pass does. Bones and camera are put back
+	// afterwards, so a pack built mid-session leaves the viewport untouched.
+	function captureShotFramePng(frame) {
+		if (!captureRef.current || !shotCamRef.current) throw new Error(ko("The shot renderer is not ready", "샷 렌더러가 아직 준비되지 않았어요"));
+		const cam = shotCamRef.current;
+		const cameraSnapshot = {
+			position: cam.position.clone(),
+			quaternion: cam.quaternion.clone(),
+			rotationOrder: cam.rotation.order,
+			fov: cam.fov,
+			yaw: look.current.yaw,
+			pitch: look.current.pitch,
+		};
+		const rigSnapshots = Object.values(rigs).filter(Boolean).map((rig) => ({ rig, bones: snapshotPlaybackBones(rig) }));
+		try {
+			const buffer = applyExportFrame(frame);
+			return buffer ? bufferToPng(buffer) : null;
+		} finally {
+			for (const snapshot of rigSnapshots) restorePlaybackBones(snapshot.rig, snapshot.bones);
+			cam.position.copy(cameraSnapshot.position);
+			cam.rotation.order = cameraSnapshot.rotationOrder;
+			cam.quaternion.copy(cameraSnapshot.quaternion);
+			cam.fov = cameraSnapshot.fov;
+			cam.updateProjectionMatrix();
+			look.current.yaw = cameraSnapshot.yaw;
+			look.current.pitch = cameraSnapshot.pitch;
+		}
+	}
+
+	// The framing the shot camera stands in at a frame, in the same shape the
+	// camera keys use — camera.json carries it so a tool can rebuild the pull.
+	function shotFramingAtFrame(entry, frame) {
+		const sampled = sampleAt(playbackScene, entry, frame).camera;
+		if (!sampled) return null;
+		return { pos: { x: sampled.pos.x, y: sampled.pos.y, z: sampled.pos.z }, yaw: sampled.yaw, pitch: sampled.pitch, fovDeg: sampled.fovDeg };
+	}
+
+	function packMetaForShot(entry, shotIndex) {
+		return shotCaptureMeta({
+			shot: entry,
+			shotIndex,
+			stage: { keyLight },
+			cast: characters,
+			fps: tlFps,
+			aspectKey: shotAspectKey,
+			size: { width: shotOutput.width, height: shotOutput.height },
+			frame: entry.startFrame,
+			// The shot's camera block stores the MOVE; the lens lives on the
+			// stage, so the live focal length fills in when the block has none.
+			lens: { focalMm: shot.focalMm, fovDeg },
+		});
+	}
+
+	// Build one shot's pack: both endpoint frames, the clip between them, the
+	// camera state and the prompt. Returns the archive bytes plus the entry
+	// names, so the download path, the embed message and QA all share it.
+	async function buildShotKeyframePack(entry, index, onProgress = null) {
+		const packShot = { title: entry.name, index: index + 1, startFrame: entry.startFrame, endFrame: entry.endFrame };
+		onProgress?.(ko(`Rendering frames for "${entry.name}"`, `"${entry.name}" 프레임 렌더링 중`));
+		const firstUrl = captureShotFramePng(entry.startFrame);
+		if (!firstUrl) throw new Error(ko("The shot renderer is not ready", "샷 렌더러가 아직 준비되지 않았어요"));
+		const lastUrl = entry.endFrame > entry.startFrame ? captureShotFramePng(entry.endFrame) : null;
+		onProgress?.(ko(`Recording the clip for "${entry.name}"`, `"${entry.name}" 클립 녹화 중`));
+		const recorded = await runShotExport({ startFrame: entry.startFrame, endFrame: entry.endFrame, download: false });
+		const clipBytes = new Uint8Array(await recorded.blob.arrayBuffer());
+		const meta = packMetaForShot(entry, index);
+		const entries = keyframePackEntries({
+			shot: packShot,
+			fps: tlFps,
+			firstFramePng: dataUrlToBytes(firstUrl),
+			lastFramePng: lastUrl ? dataUrlToBytes(lastUrl) : null,
+			clip: { data: clipBytes, ext: recorded.mimeType === "video/webm" ? "webm" : "mp4" },
+			camera: {
+				...meta,
+				framing: {
+					start: shotFramingAtFrame(entry, entry.startFrame),
+					end: shotFramingAtFrame(entry, entry.endFrame),
+				},
+			},
+			prompt: buildShotPrompt(meta, { target: "video" }),
+		});
+		return { name: keyframePackName(packShot), entries, bytes: buildZip(entries) };
+	}
+
+	// The shot a pack is built for: an explicit id, else the one under the
+	// playhead, else the first authored shot.
+	function shotIndexForPack(shotId = null) {
+		if (shotId) {
+			const index = shots.findIndex((entry) => entry.id === shotId);
+			if (index < 0) throw new Error(`Unknown shots ID: ${shotId}`);
+			return index;
+		}
+		if (!shots.length) throw new Error(ko("Add at least one Shot before exporting a keyframe pack", "키프레임 팩을 내보내려면 샷을 하나 이상 추가하세요"));
+		const atPlayhead = shotIndexAtFrame(shots, tlFrame);
+		return atPlayhead >= 0 ? atPlayhead : 0;
+	}
+
+	/** Download the keyframe pack for one shot, or (Shift) for every shot. */
+	async function exportKeyframePacks(everyShot = false) {
+		try {
+			// shotIndexForPack runs either way: it is what rejects an empty cut.
+			const current = shotIndexForPack();
+			const targets = everyShot ? shots.map((_, index) => index) : [current];
+			for (const [order, index] of targets.entries()) {
+				const label = targets.length > 1 ? ` (${order + 1}/${targets.length})` : "";
+				const pack = await buildShotKeyframePack(shots[index], index, (message) => setToast(message + label));
+				const url = URL.createObjectURL(new Blob([pack.bytes], { type: "application/zip" }));
+				saveDownload(url, pack.name);
+				setTimeout(() => URL.revokeObjectURL(url), 10_000);
+				setToast(isKo
+					? `${pack.name} 저장됨 · 파일 ${pack.entries.length}개${label}`
+					: `Saved ${pack.name} · ${pack.entries.length} files${label}`);
+			}
+			trackFeature("export_keyframe_pack");
+		} catch (error) {
+			if (error?.name !== "AbortError") setToast(error?.message || String(error));
+		}
+	}
+
+	/** Depth and normal conditioning passes of the framing on screen now. */
+	function exportRenderPasses() {
+		try {
+			const dataUrls = renderPassDataUrls();
+			for (const kind of ["depth", "normal"]) saveDownload(dataUrls[kind], passFileName(kind));
+			setToast(ko("Depth and normal passes downloaded", "뎁스·노멀 패스를 다운로드했어요"));
+			trackFeature("export_render_pass");
+		} catch (error) {
+			setToast(error?.message || String(error));
+		}
+	}
+
+	// Both passes of the framing the shot camera stands in right now, as PNG
+	// data URLs. The rig draws through that same camera for the RGB plate, so
+	// the three images register pixel for pixel.
+	function renderPassDataUrls(kinds = ["depth", "normal"]) {
+		const capture = captureRef.current;
+		const cam = shotCamRef.current;
+		if (!capture || !cam) throw new Error(ko("The shot renderer is not ready", "샷 렌더러가 아직 준비되지 않았어요"));
+		const output = {};
+		for (const kind of kinds) {
+			const dataUrl = renderPass(capture, capture.scene, cam, kind, bufferToPng);
+			if (!dataUrl) throw new Error(ko("The shot renderer is not ready", "샷 렌더러가 아직 준비되지 않았어요"));
+			output[kind] = dataUrl;
+		}
+		return output;
+	}
+
+	/** Contact sheet of the whole cut: one thumbnail and prompt per shot. */
+	async function exportStoryboard() {
+		try {
+			if (!shots.length) throw new Error(ko("Add at least one Shot before exporting a storyboard", "스토리보드를 내보내려면 샷을 하나 이상 추가하세요"));
+			setToast(ko("Composing the storyboard…", "스토리보드 구성 중…"));
+			const cells = [];
+			for (const [index, entry] of shots.entries()) {
+				const dataUrl = captureShotFramePng(entry.startFrame);
+				const meta = packMetaForShot(entry, index);
+				cells.push({
+					title: storyboardLine(`${index + 1}. ${entry.name}`),
+					durationSeconds: Number(((entry.endFrame - entry.startFrame + 1) / tlFps).toFixed(2)),
+					// The sheet gives each shot one caption line, and the composer draws
+					// it unwrapped: the labelled prompt is folded down to the two lines a
+					// board is read for (what the shot is, and on what lens), cut to what
+					// fits the cell. The pack's prompt.txt keeps the full block.
+					prompt: storyboardCaption(buildShotPrompt(meta, { target: "image" })),
+					image: dataUrl ? await loadImage(dataUrl) : null,
+				});
+			}
+			const canvas = composeStoryboard({
+				shots: cells,
+				columns: Math.min(3, cells.length),
+				// 480x300 leaves a 464x164 thumbnail box (16:9 lands at 464x261 before
+				// the fit, so the frame is scaled to height) and a caption block wide
+				// enough for the 90 characters the composer draws at this size.
+				cell: { width: 480, height: 300 },
+				createCanvas: (width, height) => {
+					const element = document.createElement("canvas");
+					element.width = width;
+					element.height = height;
+					const ctx = element.getContext("2d");
+					// The sheet is a deliverable, so it uses the studio's own type
+					// stack rather than the canvas default (10px sans-serif).
+					ctx.font = STORYBOARD_FONT;
+					ctx.textAlign = "left";
+					ctx.textBaseline = "top";
+					return element;
+				},
+			});
+			saveDownload(canvas.toDataURL("image/png"), "cozyclay-storyboard.png");
+			setToast(isKo ? `스토리보드 저장됨 · ${cells.length}샷` : `Storyboard saved · ${cells.length} shots`);
+			trackFeature("export_storyboard");
 		} catch (error) {
 			setToast(error?.message || String(error));
 		}
@@ -6033,6 +6339,24 @@ globalThis.playMode = centerTab === "play";
 			// effect does not depend on the shot list, so a closure over it would
 			// answer with the cut as it stood when the effect last ran.
 			captureMeta: (frame) => liveStateRef.current.captureShotMeta(frame ?? liveStateRef.current.timeline.currentFrame),
+			// QA-only reference exports (#165): the production builders without the
+			// download, so a headless run can unzip a real pack and diff the passes
+			// instead of driving a file dialog. Same liveStateRef reasoning as
+			// captureMeta — the effect does not depend on the shot list.
+			exportKeyframePack: async (shotId) => {
+				const live = liveStateRef.current;
+				const index = live.shotIndexForPack(shotId ?? null);
+				const pack = await live.buildShotKeyframePack(live.shots[index], index);
+				// base64: a pack holds an MP4, and a megabyte-scale JS number array
+				// is not something to hand a CDP evaluate.
+				let binary = "";
+				for (const byte of pack.bytes) binary += String.fromCharCode(byte);
+				return { name: pack.name, entries: pack.entries.map((entry) => entry.name), byteLength: pack.bytes.byteLength, bytes: btoa(binary) };
+			},
+			renderPass: (kind) => liveStateRef.current.renderPassDataUrls([kind])[kind],
+			// The RGB plate the passes are compared against — same rig, same
+			// framing, no material override.
+			capturePlate: () => liveStateRef.current.captureFramingPng(liveStateRef.current.captureCurrentFraming()),
 			characterScale: activeChar?.scale ?? 1,
 			characterModel: activeChar?.model ?? null,
 			// QA-only framing: FlyControls rewrites the editor camera's rotation
@@ -10001,6 +10325,70 @@ function resizePromptClip(id, edge, rawFrame) {
 						>
 							OTIO
 						</button>
+						{/* Reference exports a video model asks for. They sit behind one
+						    trigger because each is a whole render pass, not a toggle — and
+						    the PlayView bar has no room for three more labelled buttons. */}
+						<div className="export-menu-wrap">
+							<button
+								type="button"
+								className="export-menu-trigger"
+								data-testid="export-menu-trigger"
+								aria-expanded={exportMenuOpen}
+								aria-haspopup="menu"
+								title={ko("Reference exports for AI video tools", "AI 영상 도구용 레퍼런스 내보내기")}
+								onClick={(event) => {
+									// The 27px title bar clips its own overflow (the scene
+									// toolbar scrolls inside it), so an absolutely positioned
+									// popover would be cut off at the bar's edge. The panel is
+									// fixed to the viewport instead, anchored to this trigger.
+									const box = event.currentTarget.getBoundingClientRect();
+									setExportMenuAnchor({ top: box.bottom + 6, right: Math.max(8, window.innerWidth - box.right) });
+									setExportMenuOpen((open) => !open);
+								}}
+							>
+								{ko("Export", "내보내기")}
+								<span className="caret">▾</span>
+							</button>
+							{exportMenuOpen && (
+								<div
+									className="project-menu export-menu"
+									role="menu"
+									style={{ top: `${exportMenuAnchor.top}px`, right: `${exportMenuAnchor.right}px` }}
+									onClick={() => setExportMenuOpen(false)}
+								>
+									<button
+										type="button"
+										role="menuitem"
+										data-testid="export-keyframe-pack"
+										disabled={!shots.length || recState === "recording"}
+										title={ko("First/last frames, clip, camera and prompt as one zip — hold Shift for every shot", "첫/마지막 프레임·클립·카메라·프롬프트를 zip 하나로 — Shift를 누르면 모든 샷")}
+										onClick={(event) => void exportKeyframePacks(event.shiftKey)}
+									>
+										{ko("Keyframe pack", "키프레임 팩")}
+										<small>{ko("Shift: every shot", "Shift: 모든 샷")}</small>
+									</button>
+									<button
+										type="button"
+										role="menuitem"
+										data-testid="export-render-passes"
+										title={ko("Depth and normal conditioning plates of the current framing", "현재 프레이밍의 뎁스·노멀 컨디션 플레이트")}
+										onClick={exportRenderPasses}
+									>
+										{ko("Depth + normal passes", "뎁스 + 노멀 패스")}
+									</button>
+									<button
+										type="button"
+										role="menuitem"
+										data-testid="export-storyboard"
+										disabled={!shots.length}
+										title={ko("Contact sheet of every shot with its prompt", "모든 샷과 프롬프트를 담은 콘택트 시트")}
+										onClick={() => void exportStoryboard()}
+									>
+										{ko("Storyboard", "스토리보드")}
+									</button>
+								</div>
+							)}
+						</div>
 						<button
 							type="button"
 							className={recState === "recording" ? "recording" : ""}

--- a/src/render-passes.js
+++ b/src/render-passes.js
@@ -1,0 +1,114 @@
+// Depth and normal passes for the blocking frame.
+//
+// A generator handed one RGB plate has to guess the geometry behind it. A
+// depth pass says how far away every pixel is, and a normal pass says which
+// way its surface faces — the two conditioning images ControlNet-style tools
+// ask for. Both are the SAME render the RGB plate came from, taken through
+// the same offscreen capture rig, with one material override swapped in for
+// the draw and taken back out immediately after.
+//
+// Nothing here owns the renderer: the capture rig is passed in, so the studio
+// and a headless test drive the identical path.
+
+import * as THREE from "three";
+
+export const PASS_KINDS = Object.freeze(["depth", "normal"]);
+
+// How far the grey ramp reaches, in metres. The shot camera's far plane sits
+// at 100 m and its near plane at 0.1 m; normalising across that whole range
+// would push every blocking distance a previs shot actually uses into the
+// darkest few percent of the ramp. 40 m is the working depth of the stage (the
+// viewport's own fog dissolves the deck by ~54 m), so the subject and the deck
+// under it spread across the full range instead of collapsing to black.
+export const DEPTH_RANGE_M = 40;
+
+/** File name for a downloaded pass: `blocking-frame-depth.png`. */
+export function passFileName(kind) {
+	if (!PASS_KINDS.includes(kind)) throw new Error(`Unknown render pass: ${kind}`);
+	return `blocking-frame-${kind}.png`;
+}
+
+// Linear view-space depth, near = white. THREE.MeshDepthMaterial writes the
+// non-linear window-space z instead: with a 0.1 m near plane that curve spends
+// most of its range in the first metre, so a blocking frame comes out as a
+// near-black plate with no readable falloff (RGBADepthPacking is worse again —
+// it spreads the value over four channels and reads as colour noise). This
+// shader is the plain depth-to-grey the deliverable wants, and the range it
+// normalises over is the stage's, not the projection's.
+const DEPTH_VERTEX = /* glsl */ `
+varying float vViewDepth;
+void main() {
+	vec4 viewPosition = modelViewMatrix * vec4(position, 1.0);
+	vViewDepth = -viewPosition.z;
+	gl_Position = projectionMatrix * viewPosition;
+}
+`;
+
+const DEPTH_FRAGMENT = /* glsl */ `
+varying float vViewDepth;
+uniform float uNear;
+uniform float uRange;
+void main() {
+	float normalized = clamp((vViewDepth - uNear) / max(uRange - uNear, 0.0001), 0.0, 1.0);
+	float grey = 1.0 - normalized;
+	gl_FragColor = vec4(vec3(grey), 1.0);
+}
+`;
+
+const BACKGROUND_FAR = new THREE.Color(0x000000);
+
+/** Build the override material for a pass. */
+function passMaterial(kind, camera) {
+	if (kind === "depth") {
+		return new THREE.ShaderMaterial({
+			vertexShader: DEPTH_VERTEX,
+			fragmentShader: DEPTH_FRAGMENT,
+			uniforms: {
+				uNear: { value: Number.isFinite(camera?.near) ? camera.near : 0.1 },
+				uRange: { value: DEPTH_RANGE_M },
+			},
+			// The stage's fog is a viewport look, not geometry: a depth plate that
+			// faded into the fog colour would report the horizon as near.
+			fog: false,
+		});
+	}
+	if (kind === "normal") return new THREE.MeshNormalMaterial();
+	throw new Error(`Unknown render pass: ${kind}`);
+}
+
+/**
+ * Render one pass through the capture rig.
+ *
+ * @param {{ render: () => (Uint8Array|null) }} capture the offscreen capture rig
+ * @param {{ overrideMaterial: unknown }} scene the scene the rig draws
+ * @param {{ near?: number }} camera the shot camera the rig renders through
+ *   (the rig clones it itself; the depth ramp reads its near plane)
+ * @param {"depth"|"normal"} kind
+ * @param {(buffer: Uint8Array) => string} [toDataUrl] converts the rig's RGBA
+ *   read-back into a PNG data URL; omitted, the raw buffer comes back
+ * @returns {string|Uint8Array|null} the PNG data URL (or the raw buffer)
+ */
+export function renderPass(capture, scene, camera, kind, toDataUrl = null) {
+	if (!capture || !scene || !camera) return null;
+	const material = passMaterial(kind, camera);
+	const previousMaterial = scene.overrideMaterial;
+	const previousBackground = scene.background;
+	let buffer = null;
+	try {
+		scene.overrideMaterial = material;
+		// Empty sky is infinitely far away, so on a depth plate it is black. The
+		// studio's pale stage colour would otherwise read as "nearest thing in
+		// the frame" to anything consuming the pass.
+		if (kind === "depth") scene.background = BACKGROUND_FAR;
+		buffer = capture.render();
+	} finally {
+		// The viewport draws from this same scene object, so the override must
+		// come off before anything else can paint with it — even if the render
+		// threw.
+		scene.overrideMaterial = previousMaterial;
+		scene.background = previousBackground;
+		material.dispose();
+	}
+	if (!buffer) return null;
+	return toDataUrl ? toDataUrl(buffer) : buffer;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -8901,6 +8901,72 @@ input[type=range] {
 	color: #ff8d86;
 }
 
+/* Reference exports menu in the PlayView bar (#165). It reuses the project
+   menu's popover, so the studio has one dropdown language; only the trigger
+   takes the toolbar's own flat button treatment. The 27px title bar clips its
+   own overflow, so the panel is fixed to the viewport and anchored to the
+   trigger in JS — it hangs from the right because this bar is right-aligned. */
+.export-menu-wrap {
+	position: relative;
+	flex: none;
+	align-self: stretch;
+	display: flex;
+	align-items: center;
+}
+
+.export-menu-trigger {
+	flex: none;
+	height: 26px;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 0 6px;
+	border: 0;
+	border-right: 1px solid var(--line);
+	background: transparent;
+	color: #bdbdbd;
+	font: inherit;
+	font-size: 9px;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.export-menu-trigger:hover,
+.export-menu-trigger[aria-expanded="true"] {
+	background: #363636;
+	color: #fff;
+}
+
+.export-menu-trigger .caret {
+	color: var(--muted2);
+	font-size: 8px;
+}
+
+.export-menu {
+	position: fixed;
+	left: auto;
+	min-width: 220px;
+	z-index: 80;
+}
+
+.export-menu button {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.export-menu button:disabled {
+	opacity: .38;
+	cursor: default;
+	background: none;
+}
+
+.export-menu button small {
+	color: var(--muted2);
+	font-size: 10px;
+}
+
 /* ----------------------------------------------------- Unity axis colors --- */
 /* X red / Y green / Z blue — Unity's axis colour-coding (class-Transform). */
 .vec3-row .number-field:nth-of-type(1) .axis { color: #e5484d; }

--- a/test/qa-keyframe-pack-browser.mjs
+++ b/test/qa-keyframe-pack-browser.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Browser QA for the reference exports (#165). Drives the real studio over
+// CDP: builds a keyframe pack through the production path, writes the zip to
+// disk and hands it to the system `unzip` — if the archive this ships is not
+// one a normal tool can open, the check fails. Then takes the depth and normal
+// passes and proves each is a DIFFERENT image from the RGB plate, which is the
+// only thing that separates a working material override from a silent no-op.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const out = process.env.QA_OUT || "/tmp/keyframe-pack-qa";
+mkdirSync(out, { recursive: true });
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params.exceptionDetails.exception?.description ?? message.params.exceptionDetails.text);
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true, timeout: 180_000 });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+const waitFor = async (expression, timeoutMs = 30_000) => {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		if (Date.now() >= deadline) return false;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+await send("Runtime.enable");
+await send("Page.enable");
+await send("Page.navigate", { url: process.env.QA_URL ?? "http://127.0.0.1:5180/app/" });
+await waitFor("location.href.startsWith('http')");
+
+// A one-second authored shot with a real camera move: short enough that the
+// WebCodecs clip encodes quickly, long enough that first.png and last.png are
+// different pictures.
+await evaluate(`(() => {
+	const shot = {
+		id: "pack-qa-shot",
+		name: "Pack QA push in",
+		startFrame: 0,
+		endFrame: 23,
+		cameraKeys: [
+			{ id: "pack-qa-key-a", frame: 0, framing: { pos: { x: 0, y: 1.6, z: 4 }, yaw: 0, pitch: -0.08, fovDeg: 45 } },
+			{ id: "pack-qa-key-b", frame: 23, framing: { pos: { x: 1.2, y: 1.5, z: 2.2 }, yaw: -0.35, pitch: -0.12, fovDeg: 34 } },
+		],
+		camera: { mode: "keys" },
+	};
+	const document = {
+		version: 4,
+		activeSceneId: "scene-pack-qa",
+		scenes: [{
+			id: "scene-pack-qa",
+			name: "PACK QA",
+			objects: [],
+			shotDocument: { version: 4, frameCount: 24, shots: [shot], waypoints: [] },
+			stage: {
+				characters: [{ id: "char-a", model: "y-bot-tpose", x: 0, z: 0, rot: 0, hidden: false, pose: null, subject: "a person" }],
+				hasCharSheet: false,
+				shotAspect: "16:9",
+			},
+		}],
+	};
+	localStorage.clear();
+	localStorage.setItem("cozyclay.locale", "en");
+	localStorage.setItem("cozyclay.project-session.v1", JSON.stringify({ name: "QA", updatedAt: Date.now() }));
+	localStorage.setItem("cozyclay.scenes.v4", JSON.stringify(document));
+})()`);
+await send("Page.reload");
+expect("the studio and its export hooks come up", await waitFor("!!window.__cozyclay?.rigA && typeof window.__cozyclay?.exportKeyframePack === 'function' && typeof window.__cozyclay?.renderPass === 'function' && !!window.__captureFrame", 60_000));
+
+/* --- the keyframe pack ---------------------------------------------------- */
+
+const pack = await evaluate("window.__cozyclay.exportKeyframePack()");
+expect("the pack is named after the shot", /^cozyclay-shot-1-[a-z0-9-]+\.zip$/.test(pack?.name ?? ""), String(pack?.name));
+const zipPath = `${out}/pack.zip`;
+writeFileSync(zipPath, Buffer.from(pack.bytes, "base64"));
+expect("the pack has bytes on disk", Buffer.from(pack.bytes, "base64").byteLength === pack.byteLength && pack.byteLength > 1000, `byteLength=${pack.byteLength}`);
+
+const listing = execFileSync("unzip", ["-l", zipPath], { encoding: "utf8" });
+console.log(`unzip -l ${zipPath}\n${listing}`);
+writeFileSync(`${out}/unzip-l.txt`, listing);
+const listed = (name) => new RegExp(`/${name.replace(".", "\\.")}$`, "m").test(listing);
+expect("the archive lists first.png", listed("first.png"));
+expect("the archive lists last.png", listed("last.png"));
+expect("the archive lists a clip", listed("clip.mp4") || listed("clip.webm"), listing);
+expect("the archive lists camera.json", listed("camera.json"));
+expect("the archive lists prompt.txt", listed("prompt.txt"));
+expect(
+	"the reported entry names match the archive",
+	["first.png", "last.png", "camera.json", "prompt.txt"].every((name) => pack.entries.some((entry) => entry.endsWith(`/${name}`))),
+	pack.entries.join(", "),
+);
+
+const cameraEntry = pack.entries.find((entry) => entry.endsWith("/camera.json"));
+const cameraJson = execFileSync("unzip", ["-p", zipPath, cameraEntry], { encoding: "utf8" });
+writeFileSync(`${out}/camera.json`, cameraJson);
+let camera = null;
+try { camera = JSON.parse(cameraJson); } catch (error) { expect("camera.json parses", false, error.message); }
+expect("camera.json parses with a numeric focalMm", Number.isFinite(camera?.focalMm), JSON.stringify({ focalMm: camera?.focalMm }));
+expect("camera.json carries the frame range and fps", camera?.startFrame === 0 && camera?.endFrame === 23 && camera?.fps > 0, JSON.stringify({ startFrame: camera?.startFrame, endFrame: camera?.endFrame, fps: camera?.fps }));
+expect(
+	"camera.json carries the framing at both ends of the shot",
+	Number.isFinite(camera?.framing?.start?.pos?.z) && Number.isFinite(camera?.framing?.end?.fovDeg) && camera.framing.start.pos.z !== camera.framing.end.pos.z,
+	JSON.stringify(camera?.framing),
+);
+
+const promptEntry = pack.entries.find((entry) => entry.endsWith("/prompt.txt"));
+const promptText = execFileSync("unzip", ["-p", zipPath, promptEntry], { encoding: "utf8" });
+writeFileSync(`${out}/prompt.txt`, promptText);
+expect("prompt.txt is a labelled video prompt", /^SHOT: /m.test(promptText) && /^LENS: /m.test(promptText) && /^MOTION: /m.test(promptText), promptText.slice(0, 120));
+
+/* --- the depth and normal passes ------------------------------------------ */
+
+// The RGB reference is the shipped framing capture: the same rig and the same
+// framing with no override in place.
+const rgbPlate = await evaluate("window.__cozyclay.capturePlate()");
+const passes = {
+	depth: await evaluate('window.__cozyclay.renderPass("depth")'),
+	normal: await evaluate('window.__cozyclay.renderPass("normal")'),
+};
+expect("the RGB plate renders a PNG", typeof rgbPlate === "string" && rgbPlate.startsWith("data:image/png;base64,"), String(rgbPlate).slice(0, 40));
+writeFileSync(`${out}/blocking-frame-rgb.png`, Buffer.from(rgbPlate.split(",")[1], "base64"));
+for (const [kind, dataUrl] of Object.entries(passes)) {
+	expect(`the ${kind} pass renders a PNG`, typeof dataUrl === "string" && dataUrl.startsWith("data:image/png;base64,"), String(dataUrl).slice(0, 40));
+	if (typeof dataUrl === "string") writeFileSync(`${out}/blocking-frame-${kind}.png`, Buffer.from(dataUrl.split(",")[1], "base64"));
+}
+expect("the depth and normal passes are different images", passes.depth !== passes.normal);
+expect("the depth pass differs from the RGB capture", passes.depth !== rgbPlate);
+expect("the normal pass differs from the RGB capture", passes.normal !== rgbPlate);
+expect("the studio still renders in colour after the passes", await waitFor("(() => { const f = window.__captureFrame(); return f && f.pixels > 0; })()", 10_000));
+
+expect("browser run has no uncaught page errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+ws.close();
+if (failures) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log(`PASS keyframe pack + render passes — ${pack.entries.length} entries in ${pack.name}, evidence in ${out}`);

--- a/test/verify-render-passes.mjs
+++ b/test/verify-render-passes.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Depth/normal passes (#165). The override material is borrowed from the LIVE
+// scene the viewport draws from, so the only thing that keeps the studio from
+// turning permanently grey is putting it back. These checks pin the naming and
+// that restore, including on a render that throws.
+import assert from "node:assert/strict";
+import * as THREE from "three";
+import { passFileName, renderPass, PASS_KINDS, DEPTH_RANGE_M } from "../src/render-passes.js";
+
+assert.equal(passFileName("depth"), "blocking-frame-depth.png");
+assert.equal(passFileName("normal"), "blocking-frame-normal.png");
+assert.throws(() => passFileName("albedo"), /Unknown render pass: albedo/, "an unknown pass is a hard error, not a mystery file name");
+assert.deepEqual(PASS_KINDS, ["depth", "normal"]);
+console.log("PASS render passes: file names for depth and normal, unknown kinds rejected");
+
+// A stub rig that records what the scene looked like at the moment of the draw.
+function stubCapture(scene, { fail = false } = {}) {
+	const seen = [];
+	const backgrounds = [];
+	return {
+		seen,
+		backgrounds,
+		render() {
+			seen.push(scene.overrideMaterial);
+			backgrounds.push(scene.background);
+			if (fail) throw new Error("context lost");
+			return new Uint8Array([1, 2, 3, 255]);
+		},
+	};
+}
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, 16 / 9, 0.25, 100);
+
+const depthRig = stubCapture(scene);
+const depthBuffer = renderPass(depthRig, scene, camera, "depth");
+assert.equal(depthRig.seen.length, 1, "the depth pass renders exactly once");
+assert.ok(depthRig.seen[0] instanceof THREE.ShaderMaterial, "the depth pass overrides with the depth-to-grey shader");
+assert.equal(depthRig.seen[0].uniforms.uNear.value, 0.25, "the ramp starts at the shot camera's near plane");
+assert.equal(depthRig.seen[0].uniforms.uRange.value, DEPTH_RANGE_M, "the ramp spans the stage's working depth");
+assert.equal(depthRig.seen[0].fog, false, "the stage fog does not tint the depth plate");
+assert.match(depthRig.seen[0].fragmentShader, /1\.0 - normalized/, "near reads white, far reads black");
+assert.equal(scene.overrideMaterial, null, "the depth override is taken back off the scene");
+assert.deepEqual([...depthBuffer], [1, 2, 3, 255], "without a converter the raw read-back comes back");
+
+// Empty sky is infinitely far away: on a depth plate it reads black, not the
+// studio's pale stage colour.
+const stageBackground = new THREE.Color("#eef4f3");
+scene.background = stageBackground;
+const backgroundRig = stubCapture(scene);
+renderPass(backgroundRig, scene, camera, "depth");
+assert.equal(backgroundRig.backgrounds[0].getHex(), 0x000000, "the depth pass draws over a black sky");
+assert.equal(scene.background, stageBackground, "the stage colour is put back after the depth pass");
+const normalBackgroundRig = stubCapture(scene);
+renderPass(normalBackgroundRig, scene, camera, "normal");
+assert.equal(normalBackgroundRig.backgrounds[0], stageBackground, "the normal pass leaves the sky alone");
+scene.background = null;
+
+const normalRig = stubCapture(scene);
+const dataUrl = renderPass(normalRig, scene, camera, "normal", (buffer) => `data:image/png;base64,${buffer.length}`);
+assert.ok(normalRig.seen[0] instanceof THREE.MeshNormalMaterial, "the normal pass overrides with MeshNormalMaterial");
+assert.equal(scene.overrideMaterial, null, "the normal override is taken back off the scene");
+assert.equal(dataUrl, "data:image/png;base64,4", "the buffer goes through the caller's PNG encoder");
+console.log("PASS render passes: overrideMaterial is set for the draw and restored after");
+
+// A pass taken while another override is in place must restore THAT one, not null.
+const existing = new THREE.MeshBasicMaterial();
+scene.overrideMaterial = existing;
+renderPass(stubCapture(scene), scene, camera, "depth");
+assert.equal(scene.overrideMaterial, existing, "an override that was already in place survives the pass");
+scene.overrideMaterial = null;
+
+// A render that throws still gives the scene back.
+const brokenRig = stubCapture(scene, { fail: true });
+assert.throws(() => renderPass(brokenRig, scene, camera, "normal"), /context lost/);
+assert.equal(scene.overrideMaterial, null, "a failed render does not leave the studio wearing the pass material");
+console.log("PASS render passes: a failed render restores the scene material");
+
+// Missing rig, scene or camera is "not ready", not a crash.
+assert.equal(renderPass(null, scene, camera, "depth"), null);
+assert.equal(renderPass(stubCapture(scene), null, camera, "depth"), null);
+assert.equal(renderPass(stubCapture(scene), scene, null, "depth"), null);
+// A rig that renders nothing (no shot camera yet) reports nothing.
+assert.equal(renderPass({ render: () => null }, scene, camera, "depth", () => "never"), null);
+assert.throws(() => renderPass(stubCapture(scene), scene, camera, "albedo"), /Unknown render pass/);
+assert.equal(scene.overrideMaterial, null, "the rejected kind never touched the scene");
+console.log("PASS render passes: an unready rig reports null instead of throwing");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -145,6 +145,7 @@ const NODE_FILES = [
 	"test/verify-usd-camera.mjs",
 	"test/verify-video-frames.mjs",
 	"test/verify-zip-store.mjs",
+	"test/verify-render-passes.mjs",
 	"mcp/verify.mjs",
 	"mcp/verify-http-origin.mjs",
 	"mcp/verify-live.mjs",
@@ -171,7 +172,13 @@ const BROWSER_FILES = [
 	"test/verify-object-gizmo.mjs",
 	"test/verify-offscreen-export-browser.mjs",
 	"test/verify-project-menu-browser.mjs",
+	"test/qa-keyframe-pack-browser.mjs",
 ];
+
+// The inventory sweep only picks up `verify*.mjs`; a browser suite named for
+// the QA runner it needs is listed here so it still shows up in the manifest
+// (as an EXCLUDE with its reason) instead of going unmentioned.
+const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })
@@ -278,7 +285,7 @@ if (!mcpDepsInstalled) {
 }
 
 const { listOnly, scope } = parseArguments(process.argv.slice(2));
-const inventory = [...verificationFiles("test"), ...verificationFiles("mcp")];
+const inventory = [...verificationFiles("test"), ...verificationFiles("mcp"), ...EXTRA_INVENTORY].sort();
 const unclassified = inventory.filter((file) => !categories.has(file));
 const stale = [...categories.keys()].filter((file) => !inventory.includes(file));
 if (unclassified.length > 0 || stale.length > 0) {


### PR DESCRIPTION
## What changed

Three reference exports for AI video tools, all built from the **same offscreen capture rig the MP4 export already uses**, so what ships is what the editor previewed. They live behind one `Export ▾` menu in the PlayView bar, next to `OTIO`.

**`src/render-passes.js` (new)**
- `renderPass(capture, scene, camera, kind, toDataUrl?)` sets `scene.overrideMaterial` for exactly one draw through the capture rig and restores it in a `finally` (a failed render must not leave the studio wearing the pass material). `passFileName(kind)` is pure.
- Depth uses a **linear depth-to-grey shader**, not `MeshDepthMaterial`. `MeshDepthMaterial` writes non-linear window-space z: with a 0.1 m near plane the curve spends its range in the first metre, and a blocking frame comes out near-black (RGBADepthPacking is worse — colour noise). The shader normalises view-space depth across the stage's working depth (`DEPTH_RANGE_M = 40`, the viewport's own fog dissolves the deck by ~54 m) with near = white, and blacks out the sky for the pass so empty space does not read as "nearest thing in frame".

**`src/App.jsx`**
- **Keyframe pack** (current shot; Shift = every shot): `first.png` at `startFrame` and `last.png` at `endFrame` rendered through the shot camera (`applyExportFrame` + full bone/camera restore), `clip.mp4` from `runShotExport({ download: false })`, `camera.json` = `shotCaptureMeta(...)` plus the framing (pos/yaw/pitch/fovDeg) at both ends, `prompt.txt` = `buildShotPrompt(meta, { target: "video" })`. Assembled with `keyframePackEntries` + `buildZip`, named by `keyframePackName`. Progress and errors ride the existing toast.
- **Depth + normal passes** download `blocking-frame-depth.png` / `blocking-frame-normal.png` for the current framing.
- **Storyboard** composes every shot (thumbnail through the shot camera, duration, folded prompt) with `composeStoryboard` and downloads `cozyclay-storyboard.png`.
- **Embed message**: `cozyclay:export-keyframe-pack` `{ shotId? }` → `cozyclay:export-keyframe-pack-result` `{ name, bytes: ArrayBuffer (transferred), entries }` or `{ error }`.
- **QA-only hooks**: `window.__cozyclay.exportKeyframePack(shotId?)` (bytes base64 — a pack holds an MP4, a megabyte-scale number array is not something to hand a CDP evaluate), `.renderPass(kind)`, `.capturePlate()`.

**`src/styles.css`** — the menu reuses the project menu's `.project-menu` popover so the studio keeps one dropdown language; only the trigger takes the toolbar's flat button treatment. The 27px `.viewport-titlebar` clips its own overflow (the scene toolbar scrolls inside it), so the panel is `position: fixed` and anchored to the trigger's rect — verified with `elementFromPoint`, which now returns the menu item instead of the canvas behind it.

Library modules (`zip-store.js`, `keyframe-pack.js`, `storyboard.js`, `shot-meta.js`, `shot-prompt.js`) are used unchanged.

## How it was verified

### Unit — `node test/verify-render-passes.mjs`

```
PASS render passes: file names for depth and normal, unknown kinds rejected
PASS render passes: overrideMaterial is set for the draw and restored after
PASS render passes: a failed render restores the scene material
PASS render passes: an unready rig reports null instead of throwing
```

Covers `passFileName`, the shader's uniforms/near plane/fog-off, the stub-renderer check that `overrideMaterial` is set **during** the render and restored after (including when a prior override was in place, and when the render throws), and the black-sky swap being restored.

### Browser QA — `QA_URL=http://127.0.0.1:5310/app/ CDP_PORT=9465 node tools/qa-browser.mjs -- node test/qa-keyframe-pack-browser.mjs`

```
PASS the studio and its export hooks come up
PASS the pack is named after the shot
PASS the pack has bytes on disk
unzip -l /tmp/keyframe-pack-qa/pack.zip
Archive:  /tmp/keyframe-pack-qa/pack.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
   415278  01-01-2026 00:00   1-pack-qa-push-in/first.png
   551731  01-01-2026 00:00   1-pack-qa-push-in/last.png
   325534  01-01-2026 00:00   1-pack-qa-push-in/clip.mp4
      895  01-01-2026 00:00   1-pack-qa-push-in/camera.json
      266  01-01-2026 00:00   1-pack-qa-push-in/prompt.txt
      724  01-01-2026 00:00   1-pack-qa-push-in/README.txt
---------                     -------
  1294428                     6 files

PASS the archive lists first.png
PASS the archive lists last.png
PASS the archive lists a clip
PASS the archive lists camera.json
PASS the archive lists prompt.txt
PASS the reported entry names match the archive
PASS camera.json parses with a numeric focalMm
PASS camera.json carries the frame range and fps
PASS camera.json carries the framing at both ends of the shot
PASS prompt.txt is a labelled video prompt
PASS the RGB plate renders a PNG
PASS the depth pass renders a PNG
PASS the normal pass renders a PNG
PASS the depth and normal passes are different images
PASS the depth pass differs from the RGB capture
PASS the normal pass differs from the RGB capture
PASS the studio still renders in colour after the passes
PASS browser run has no uncaught page errors
PASS keyframe pack + render passes — 6 entries in cozyclay-shot-1-pack-qa-push-in.zip, evidence in /tmp/keyframe-pack-qa
```

`camera.json` from that run (excerpt): `"focalMm": 24, "fovDeg": 45, "aspect": "16:9", "fps": 24, "frameRange": {"start":0,"end":23}, "framing": {"start": {...z:4, fovDeg:45}, "end": {...z:2.2, fovDeg:34}}`.
`prompt.txt`: `SHOT: Pack QA push in, 1s, 16:9 / LENS: 24mm, long shot / CAMERA: … / LIGHT: … / CAST: … / LOOK: … / MOTION: …`.

### Menu paths driven through the real DOM (dev server on :5310)

- Depth + normal menu item → downloads named `["blocking-frame-depth.png","blocking-frame-normal.png"]`.
- Keyframe pack menu item → `cozyclay-shot-1-push-in.zip`, toast `Saved cozyclay-shot-1-push-in.zip · 6 files`.
- Shift-click → `["cozyclay-shot-1-push-in.zip","cozyclay-shot-2-wide.zip"]`, toast `Saved cozyclay-shot-2-wide.zip · 6 files (2/2)`.
- Storyboard menu item → `data:image/png` download, toast `Storyboard saved · 2 shots`.
- Embed (`/app/?embed=playview`): `{"name":"cozyclay-shot-1-embed-pack.zip","entries":[…6 names…],"byteLength":1159559,"error":null}`; an unknown `shotId` answers `{"error":"Unknown shots ID: nope"}`.

### Full suite — `NO_COLOR=1 npm test` (EXIT 0)

```
PASS playback storage events announce cross-tab controls
PASS playback event name is stable

verify-workflow-scene-asset-sync: all green

RUNNING test/verify-zip-store.mjs
PASS crc32: known vectors for 'hello', the empty sequence, and the quick brown fox
PASS buildZip: unzip -t accepts the archive
  Archive:  /var/folders/.../pack.zip
      testing: notes/....txt         OK
      testing: frame.png                OK
  No errors detected in compressed data of /var/folders/.../pack.zip.
PASS zip-store: crc32 vectors, structure, and unzip -t on a written archive

PASS 153 Node verification files
```

Both new files are registered in `tools/run-tests.mjs` (`test/verify-render-passes.mjs` as `RUN node`, `test/qa-keyframe-pack-browser.mjs` as `EXCLUDE browser` — the inventory sweep only picks up `verify*.mjs`, so an explicit list keeps the QA suite named in the manifest instead of unmentioned).

### Evidence / screenshots

- `/tmp/keyframe-pack-qa/pack.zip`, `unzip-l.txt`, `camera.json`, `prompt.txt`
- `/tmp/keyframe-pack-qa/blocking-frame-rgb.png`, `blocking-frame-depth.png`, `blocking-frame-normal.png`
- `/tmp/keyframe-pack-qa/export-menu.png` (menu open in the PlayView bar)
- `/tmp/keyframe-pack-qa/storyboard.png` (2-shot contact sheet)

Closes #165
