### PR TITLE
feat(workflow): Send to AI exports the Scene node's keyframe pack (#168)

### DIFF
--- a/src/workflow/CozySceneNode.jsx
+++ b/src/workflow/CozySceneNode.jsx
@@ -1,4 +1,6 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { track } from "../analytics.js";
+import { downloadPack, requestKeyframePack } from "./keyframe-pack-request.js";
 import {
 	applyCozyScenePatch,
 	COZY_SCENE_OUTPUTS,
@@ -42,6 +44,30 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 	const change = onDataChange || callbackFrom(rawData, "onDataChange");
 	const run = onRun || callbackFrom(rawData, "onRun");
 	const openScene = onOpenScene || callbackFrom(rawData, "onOpenScene");
+	// The pack export is a one-shot side trip, not graph state: it never has to
+	// survive a reload or reach the workflow runner, so it stays on the node.
+	const [pack, setPack] = useState({ pending: false, message: "", error: "" });
+
+	const sendToAi = async () => {
+		setPack({ pending: true, message: "", error: "" });
+		try {
+			const frame = document.querySelector(`[data-node-id="${id}"] iframe`)?.contentWindow;
+			// No shotId: the Scene node tracks a scene, not a shot, so the embed
+			// packs the shot under its own playhead — the one being previewed.
+			const result = await requestKeyframePack(frame);
+			downloadPack(result);
+			track("export:keyframe_pack", { entries: result.entries.length, source: "workflow" });
+			// QA hook, mirroring window.__cozyclay in the Studio: the analytics
+			// module is a no-op outside production, so a headless run has nothing
+			// else to assert the export was reported against.
+			if (typeof window !== "undefined") {
+				window.__cozyclayWorkflow = { ...(window.__cozyclayWorkflow || {}), lastTrack: { event: "export:keyframe_pack", entries: result.entries.length, source: "workflow" } };
+			}
+			setPack({ pending: false, message: `Pack ready: ${result.name} (${result.entries.length} files)`, error: "" });
+		} catch (error) {
+			setPack({ pending: false, message: "", error: error?.message || String(error) });
+		}
+	};
 
 	const emit = (patch, { syncPlayback = true } = {}) => {
 		const nextData = applyCozyScenePatch(data, patch);
@@ -80,7 +106,7 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 					<span className="cozy-scene-node-kicker">COZYCLAY</span>
 					<h3>{data.sceneName}</h3>
 				</div>
-				<span className={`cozy-scene-node-status status-${data.status}`} role="status">{statusLabel(data.status)}</span>
+				<span className={`cozy-scene-node-status status-${pack.error ? "error" : pack.message ? "complete" : data.status}${pack.error || pack.message ? " has-pack" : ""}`} role="status">{pack.error || pack.message || statusLabel(data.status)}</span>
 			</header>
 
 			<section className="cozy-scene-preview" aria-label="3D scene preview">
@@ -92,6 +118,7 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 				<div className="cozy-scene-control-row">
 					<button type="button" className="cozy-scene-button" onClick={() => emit({ controls: { playing: !data.controls.playing } })} aria-label={data.controls.playing ? "Pause scene" : "Play scene"} aria-pressed={data.controls.playing}>{data.controls.playing ? "Pause" : "Play"}</button>
 					<button type="button" className="cozy-scene-button" onClick={() => openScene?.({ id, data })}>Open Studio</button>
+					<button type="button" className="cozy-scene-send" onClick={sendToAi} disabled={pack.pending} title="Export this shot's keyframe pack for an AI video model">{pack.pending ? "Packing…" : "Send to AI"}</button>
 					<button type="button" className="cozy-scene-run" onClick={() => run?.({ id, data })} disabled={data.status === "running"}>{data.status === "running" ? "Rendering…" : "Run"}</button>
 				</div>
 				<label className="cozy-scene-frame-control">Frame <input aria-label="Scene frame" type="range" min="0" max={maxFrame} value={Math.min(data.frame, maxFrame)} onChange={(event) => emit({ frame: Number(event.currentTarget.value), controls: { playing: false } })} /> <output aria-live="polite">{Math.min(data.frame, maxFrame)}/{maxFrame}</output></label>

--- a/src/workflow/cozy-scene-node.css
+++ b/src/workflow/cozy-scene-node.css
@@ -14,6 +14,9 @@
 .cozy-scene-node-kicker { color: #78a9d3; font-size: 9px; font-weight: 800; letter-spacing: .14em; }
 .cozy-scene-node h3 { margin: 2px 0 0; font-size: 14px; font-weight: 700; }
 .cozy-scene-node-status { max-width: 112px; color: #aebccc; font-size: 10px; text-align: right; }
+/* A pack result names a zip and counts its files, so it needs more room than
+ * the one-word node states this span usually carries. */
+.cozy-scene-node-status.has-pack { max-width: 178px; word-break: break-word; }
 .status-running { color: #f0c979; }.status-complete { color: #8dd5b1; }.status-error { color: #f08d8d; }
 .cozy-scene-preview { position: relative; height: 134px; margin: 0 10px; overflow: hidden; border: 1px solid #3c4b5d; border-radius: 6px; background: linear-gradient(145deg, #32475d, #121820 70%); }
 .cozy-scene-canvas { position: absolute; inset: 0; }
@@ -30,7 +33,11 @@
 .cozy-scene-stage-mark { position: absolute; top: 25px; left: 50%; width: 78px; height: 78px; transform: translateX(-50%) rotate(45deg); border: 2px solid rgba(180, 215, 241, .72); border-radius: 8px; background: rgba(121, 183, 232, .18); }
 .cozy-scene-stage-mark span { position: absolute; width: 8px; height: 8px; border: 1px solid #c3e5ff; border-radius: 50%; background: #527c9d; }.cozy-scene-stage-mark span:nth-child(1) { top: -5px; left: -5px; }.cozy-scene-stage-mark span:nth-child(2) { top: -5px; right: -5px; }.cozy-scene-stage-mark span:nth-child(3) { right: -5px; bottom: -5px; }
 .cozy-scene-preview-copy { position: absolute; right: 10px; bottom: 8px; display: grid; gap: 1px; color: #d7e4ef; text-align: right; }.cozy-scene-preview-copy span { color: #9eb0c2; font-size: 10px; }
-.cozy-scene-controls { display: grid; gap: 8px; padding: 11px 13px 9px; }.cozy-scene-control-row { display: flex; gap: 6px; }.cozy-scene-button, .cozy-scene-run, .cozy-scene-camera-row button { padding: 5px 8px; border: 1px solid #465668; border-radius: 5px; color: #d8e5f0; background: #2c3846; font: inherit; cursor: pointer; }.cozy-scene-button:hover, .cozy-scene-camera-row button:hover { background: #344658; }.cozy-scene-run { margin-left: auto; border-color: #5f96c3; background: #35658c; }.cozy-scene-run:disabled { cursor: wait; opacity: .7; }
+.cozy-scene-controls { display: grid; gap: 8px; padding: 11px 13px 9px; }.cozy-scene-control-row { display: flex; gap: 6px; }.cozy-scene-button, .cozy-scene-send, .cozy-scene-run, .cozy-scene-camera-row button { padding: 5px 8px; border: 1px solid #465668; border-radius: 5px; color: #d8e5f0; background: #2c3846; font: inherit; cursor: pointer; }.cozy-scene-button:hover, .cozy-scene-camera-row button:hover { background: #344658; }.cozy-scene-run { margin-left: auto; border-color: #5f96c3; background: #35658c; }.cozy-scene-run:disabled, .cozy-scene-send:disabled { cursor: wait; opacity: .7; }
+/* "Send to AI" hands the shot off rather than rendering it: same control
+ * weight as Play/Open Studio, tinted with the node's accent so the export
+ * reads as the secondary action next to the primary Run. */
+.cozy-scene-send { border-color: #4d6c88; color: #cfe6f8; background: #2a4256; }.cozy-scene-send:hover:not(:disabled) { background: #33506a; }
 .cozy-scene-frame-control { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 7px; color: #acbbc9; font-size: 10px; }.cozy-scene-frame-control input { width: 100%; accent-color: #79b7e8; }.cozy-scene-frame-control output { min-width: 40px; color: #dce7f1; font-family: ui-monospace, monospace; text-align: right; }
 .cozy-scene-camera-row { display: flex; align-items: center; justify-content: center; gap: 8px; color: #9eafbf; font-size: 10px; }.cozy-scene-camera-row button { padding: 2px 7px; }
 .cozy-scene-node-footer { border-top: 1px solid #33404e; color: #8799aa; font-size: 10px; }.cozy-scene-node-footer span + span { margin-left: auto; }

--- a/src/workflow/keyframe-pack-request.js
+++ b/src/workflow/keyframe-pack-request.js
@@ -1,0 +1,64 @@
+/**
+ * Ask the embedded Studio for a shot's keyframe pack (#168).
+ *
+ * The Workflow page never builds a pack itself: the zip is assembled inside
+ * the Scene node's <iframe>, where the rig, the timeline and the renderer
+ * actually live. This module owns the postMessage handshake and nothing else,
+ * so the request can be tested without a DOM: the caller injects the target
+ * window and the listener pair.
+ */
+
+export const KEYFRAME_PACK_REQUEST = "cozyclay:export-keyframe-pack";
+export const KEYFRAME_PACK_RESULT = "cozyclay:export-keyframe-pack-result";
+
+/**
+ * Post an export request to `iframeWindow` and resolve with that frame's reply.
+ *
+ * Resolves `{ name, bytes, entries }`, rejects on a `{ error }` reply or when
+ * the pack takes longer than `timeoutMs` (packs encode a video clip, so the
+ * default is generous). The message listener is removed on every path.
+ */
+export function requestKeyframePack(iframeWindow, {
+	shotId = null,
+	timeoutMs = 120000,
+	addListener = typeof window === "undefined" ? null : window.addEventListener.bind(window),
+	removeListener = typeof window === "undefined" ? null : window.removeEventListener.bind(window),
+	setTimer = typeof setTimeout === "function" ? setTimeout : null,
+	clearTimer = typeof clearTimeout === "function" ? clearTimeout : null,
+} = {}) {
+	return new Promise((resolve, reject) => {
+		if (!iframeWindow || typeof iframeWindow.postMessage !== "function") {
+			reject(new Error("Scene preview is unavailable."));
+			return;
+		}
+		let timer = null;
+		const finish = (error, value) => {
+			removeListener?.("message", onMessage);
+			if (timer !== null) clearTimer?.(timer);
+			if (error) reject(error); else resolve(value);
+		};
+		const onMessage = (event) => {
+			// Only this frame's reply counts: a Workflow page can hold several
+			// Scene nodes, each with its own embedded Studio.
+			if (event?.source !== iframeWindow || event?.data?.type !== KEYFRAME_PACK_RESULT) return;
+			if (event.data.error) { finish(new Error(event.data.error)); return; }
+			finish(null, { name: event.data.name, bytes: event.data.bytes, entries: Array.isArray(event.data.entries) ? event.data.entries : [] });
+		};
+		addListener?.("message", onMessage);
+		if (timeoutMs > 0) timer = setTimer?.(() => finish(new Error("The keyframe pack timed out.")), timeoutMs) ?? null;
+		iframeWindow.postMessage({ type: KEYFRAME_PACK_REQUEST, ...(shotId ? { shotId } : {}) }, "*");
+	});
+}
+
+/** Save a pack the browser already holds in memory. */
+export function downloadPack({ name, bytes }) {
+	const url = URL.createObjectURL(new Blob([bytes], { type: "application/zip" }));
+	const anchor = document.createElement("a");
+	anchor.href = url;
+	anchor.download = name || "cozyclay-shot.zip";
+	anchor.click();
+	// Revoking synchronously can race the download in some browsers; one task
+	// later is enough for the click to have been handed off.
+	setTimeout(() => URL.revokeObjectURL(url), 0);
+	return { name: anchor.download, url };
+}

--- a/test/qa-send-to-ai-browser.mjs
+++ b/test/qa-send-to-ai-browser.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Browser contract for "Send to AI" on the Workflow Scene node (#168). The
+// button has to reach the node's own embedded Studio, get a real keyframe pack
+// back across the frame boundary, hand the bytes to the browser as a download
+// and report the export. Nothing here is stubbed on the app side: the pack is
+// built by the embedded Studio from a seeded shot, the only interception is
+// HTMLAnchorElement.prototype.click, so the run does not open a file dialog.
+//
+// Run: `COZYCLAY_LIVE_PORT=5344 npm run dev -- --port 5340` in one shell, then
+// `QA_URL=http://127.0.0.1:5340/workflow/ CDP_PORT=9468 node tools/qa-browser.mjs -- node test/qa-send-to-ai-browser.mjs`
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+
+const cdpPort = Number(process.env.CDP_PORT || 9468);
+const out = process.env.QA_OUT || "/tmp/send-to-ai-qa";
+const targets = await (await fetch(`http://127.0.0.1:${cdpPort}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.url.includes("/workflow/")) || targets.find((target) => target.type === "page");
+assert.ok(page, "workflow page is not open");
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let seq = 0;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const item = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) item.reject(new Error(JSON.stringify(message.error)));
+	else item.resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => { const id = ++seq; pending.set(id, { resolve, reject }); ws.send(JSON.stringify({ id, method, params })); });
+const evaluate = async (expression, timeoutMs = 180000) => {
+	const result = await send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true, timeout: timeoutMs });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "browser evaluation failed");
+	return result.result?.value;
+};
+const waitFor = async (label, probe, timeoutMs = 90000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const value = await probe().catch(() => null);
+		if (value) return value;
+		await new Promise((resolve) => setTimeout(resolve, 150));
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+};
+const clickSelector = async (selector) => {
+	const box = await evaluate(`(() => { const el = document.querySelector(${JSON.stringify(selector)}); if (!el) return null; const r = el.getBoundingClientRect(); return { x: Math.round(r.left + r.width / 2), y: Math.round(r.top + r.height / 2) }; })()`);
+	assert.ok(box, `no element matches ${selector}`);
+	for (const type of ["mousePressed", "mouseReleased"]) await send("Input.dispatchMouseEvent", { type, x: box.x, y: box.y, button: "left", clickCount: 1, buttons: type === "mousePressed" ? 1 : 0 });
+};
+
+await mkdir(out, { recursive: true });
+
+// A one-second authored shot with a camera move: the embedded Studio has to
+// have something to pack, and both endpoint frames have to be renderable.
+const sceneDocument = {
+	version: 4,
+	activeSceneId: "scene-send-qa",
+	scenes: [{
+		id: "scene-send-qa",
+		name: "SEND QA",
+		objects: [],
+		shotDocument: {
+			version: 4,
+			frameCount: 24,
+			shots: [{
+				id: "send-qa-shot",
+				name: "Send QA push in",
+				startFrame: 0,
+				endFrame: 23,
+				camera: { mode: "keys" },
+				cameraKeys: [
+					{ id: "send-qa-key-a", frame: 0, framing: { pos: { x: 0, y: 1.6, z: 4 }, yaw: 0, pitch: -0.08, fovDeg: 45 } },
+					{ id: "send-qa-key-b", frame: 23, framing: { pos: { x: 1.2, y: 1.5, z: 2.2 }, yaw: -0.35, pitch: -0.12, fovDeg: 34 } },
+				],
+			}],
+			waypoints: [],
+		},
+		stage: {
+			characters: [{ id: "char-a", model: "y-bot-tpose", x: 0, z: 0, rot: 0, hidden: false, pose: null, subject: "a person" }],
+			hasCharSheet: false,
+			shotAspect: "16:9",
+		},
+	}],
+};
+const graph = {
+	version: 1,
+	nodes: [{ id: "scene-qa", type: "scene", position: { x: 120, y: 120 }, data: { label: "CozyClay Scene", sceneName: "CozyClay Scene", status: "idle", preview: "scene" } }],
+	edges: [],
+};
+
+await evaluate(`(() => {
+	localStorage.setItem("cozyclay.locale", "en");
+	localStorage.setItem("cozyclay.project-session.v1", JSON.stringify({ name: "QA", updatedAt: Date.now() }));
+	localStorage.setItem("cozyclay.scenes.v4", ${JSON.stringify(JSON.stringify(sceneDocument))});
+	localStorage.setItem("cozyclay.workflow.v1", ${JSON.stringify(JSON.stringify(graph))});
+})(), true`);
+await send("Page.reload", { ignoreCache: true });
+
+await waitFor("the Scene node", () => evaluate("!!document.querySelector('.cozy-scene-node .cozy-scene-send')"));
+const idleStatus = await evaluate("document.querySelector('.cozy-scene-node .cozy-scene-node-status').textContent");
+console.log(`PASS the Scene node renders a Send to AI button (status: ${JSON.stringify(idleStatus)})`);
+
+// The embedded Studio is same-origin, so readiness is its own QA hook plus the
+// seeded shot: exactly what the pack build reads. Waiting on this instead of a
+// timer is what keeps the run from failing on a slow first WebGL context.
+await waitFor("the embedded Studio to finish loading its shot", () => evaluate(`(() => {
+	const frame = document.querySelector('.cozy-scene-node iframe');
+	const live = frame && frame.contentWindow && frame.contentWindow.__cozyclay;
+	return !!(live && live.rigA && typeof live.exportKeyframePack === "function");
+})()`));
+console.log("PASS the node's embedded Studio came up with the seeded shot");
+
+// Intercept the download instead of letting Chrome write a zip to the QA
+// profile: the assertion is about what the app hands the browser.
+await evaluate(`(() => {
+	window.__qaAnchors = [];
+	const original = HTMLAnchorElement.prototype.click;
+	HTMLAnchorElement.prototype.click = function () {
+		if (this.download) { window.__qaAnchors.push({ download: this.download, href: this.href }); return; }
+		return original.apply(this, arguments);
+	};
+	delete window.__cozyclayWorkflow;
+})(), true`);
+
+await clickSelector(".cozy-scene-node .cozy-scene-send");
+const packing = await evaluate("(() => { const b = document.querySelector('.cozy-scene-node .cozy-scene-send'); return { label: b.textContent, disabled: b.disabled }; })()");
+assert.equal(packing.label, "Packing…", "the button reports the pending export");
+assert.equal(packing.disabled, true, "the button is disabled while the pack is being built");
+console.log("PASS clicking Send to AI puts the button into its Packing… state");
+
+const status = await waitFor("the pack result on the node", async () => {
+	const text = await evaluate("document.querySelector('.cozy-scene-node .cozy-scene-node-status').textContent");
+	return text && text !== "Ready when connected" && text !== "Rendering…" ? text : null;
+});
+assert.match(status, /^Pack ready: cozyclay-shot-\d+-[a-z0-9-]+\.zip \(\d+ files\)$/, `the node should show the pack name and file count, got: ${status}`);
+console.log(`PASS the node reports the finished pack: ${JSON.stringify(status)}`);
+
+const anchors = await evaluate("window.__qaAnchors");
+assert.equal(anchors.length, 1, `exactly one download should have been triggered, got ${anchors.length}`);
+assert.ok(anchors[0].download.startsWith("cozyclay-shot-"), `the download is named for the shot, got: ${anchors[0].download}`);
+assert.ok(anchors[0].download.endsWith(".zip"), `the download is a zip, got: ${anchors[0].download}`);
+assert.ok(anchors[0].href.startsWith("blob:"), `the download points at in-memory bytes, got: ${anchors[0].href}`);
+assert.ok(status.includes(anchors[0].download), "the node names the same pack the browser was handed");
+console.log(`PASS the pack reaches the browser as a download: ${anchors[0].download} -> ${anchors[0].href.slice(0, 24)}...`);
+
+// track() is a no-op outside production builds, so the export report is
+// asserted through the hook the click handler sets right after it.
+const tracked = await evaluate("window.__cozyclayWorkflow && window.__cozyclayWorkflow.lastTrack");
+assert.ok(tracked, "the click handler records the analytics event on its QA hook");
+assert.equal(tracked.event, "export:keyframe_pack");
+assert.equal(tracked.source, "workflow");
+assert.ok(Number.isInteger(tracked.entries) && tracked.entries > 0, `the event carries the entry count, got: ${JSON.stringify(tracked)}`);
+assert.ok(status.includes(`(${tracked.entries} files)`), "the reported entry count matches the line on the node");
+console.log(`PASS the export is reported to analytics: ${JSON.stringify(tracked)}`);
+
+const button = await evaluate("(() => { const b = document.querySelector('.cozy-scene-node .cozy-scene-send'); return { label: b.textContent, disabled: b.disabled }; })()");
+assert.equal(button.label, "Send to AI", "the button returns to its idle label");
+assert.equal(button.disabled, false, "the button is clickable again for the next export");
+console.log("PASS the button returns to Send to AI when the export finishes");
+
+await writeFile(`${out}/after.png`, Buffer.from((await send("Page.captureScreenshot", { format: "png" })).data, "base64"));
+console.log(`PASS qa-send-to-ai-browser: ${out}/after.png`);
+ws.close();
+process.exit(0);

--- a/test/verify-keyframe-pack-request.mjs
+++ b/test/verify-keyframe-pack-request.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// The Workflow page's "Send to AI" handshake (#168). The Scene node cannot
+// build a keyframe pack itself — the rig and the renderer live inside its
+// embedded Studio — so the whole feature rests on one postMessage round trip.
+// These checks drive it against a fake frame window and fake listeners: the
+// request has to reach the right frame, only that frame's reply may resolve
+// it, an { error } reply and a silent frame both have to reject, and the
+// message listener must be gone on every path (a leaked listener would resolve
+// a later, unrelated export into the wrong node).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { KEYFRAME_PACK_REQUEST, KEYFRAME_PACK_RESULT, requestKeyframePack } from "../src/workflow/keyframe-pack-request.js";
+
+function harness() {
+	const posted = [];
+	const listeners = [];
+	const timers = [];
+	const frame = { postMessage: (message, origin, transfer) => posted.push({ message, origin, transfer }) };
+	const context = {
+		frame,
+		posted,
+		listeners,
+		addListener: (type, handler) => listeners.push({ type, handler }),
+		removeListener: (type, handler) => {
+			const index = listeners.findIndex((entry) => entry.type === type && entry.handler === handler);
+			if (index >= 0) listeners.splice(index, 1);
+		},
+		setTimer: (handler) => { timers.push(handler); return timers.length; },
+		clearTimer: (id) => { timers[id - 1] = null; },
+		fireTimers: () => { for (const handler of timers.splice(0)) handler?.(); },
+		deliver: (event) => { for (const entry of [...listeners]) entry.handler(event); },
+	};
+	return context;
+}
+
+const options = (context, extra = {}) => ({
+	addListener: context.addListener,
+	removeListener: context.removeListener,
+	setTimer: context.setTimer,
+	clearTimer: context.clearTimer,
+	...extra,
+});
+
+/* --- the happy path -------------------------------------------------------- */
+{
+	const context = harness();
+	const bytes = new ArrayBuffer(8);
+	const promise = requestKeyframePack(context.frame, options(context, { shotId: "shot-2" }));
+	assert.equal(context.posted.length, 1, "the request is posted to the frame window");
+	assert.deepEqual(context.posted[0].message, { type: KEYFRAME_PACK_REQUEST, shotId: "shot-2" });
+	assert.equal(context.posted[0].origin, "*");
+	assert.equal(context.listeners.length, 1, "one message listener is installed while the request is open");
+
+	// Noise first: another frame's reply, and this frame's reply to a different
+	// request. Neither may settle this promise.
+	context.deliver({ source: {}, data: { type: KEYFRAME_PACK_RESULT, name: "other.zip", bytes, entries: [] } });
+	context.deliver({ source: context.frame, data: { type: "cozyclay:capture-framing-result", dataUrl: "data:," } });
+	assert.equal(context.listeners.length, 1, "unrelated messages leave the request open");
+
+	context.deliver({ source: context.frame, data: { type: KEYFRAME_PACK_RESULT, name: "cozyclay-shot-2-take.zip", bytes, entries: ["shot/first.png", "shot/last.png"] } });
+	const pack = await promise;
+	assert.deepEqual(pack, { name: "cozyclay-shot-2-take.zip", bytes, entries: ["shot/first.png", "shot/last.png"] });
+	assert.equal(context.listeners.length, 0, "the listener is removed once the pack arrives");
+	console.log("PASS requestKeyframePack posts the request and resolves on that frame's reply");
+}
+
+/* --- the Studio reports a failure ------------------------------------------ */
+{
+	const context = harness();
+	const promise = requestKeyframePack(context.frame, options(context));
+	assert.deepEqual(context.posted[0].message, { type: KEYFRAME_PACK_REQUEST }, "no shotId means the Studio picks the current shot");
+	context.deliver({ source: context.frame, data: { type: KEYFRAME_PACK_RESULT, error: "The shot renderer is not ready" } });
+	await assert.rejects(promise, /The shot renderer is not ready/);
+	assert.equal(context.listeners.length, 0, "the listener is removed after an error reply");
+	console.log("PASS requestKeyframePack rejects with the Studio's error message");
+}
+
+/* --- the Studio never answers ---------------------------------------------- */
+{
+	const context = harness();
+	const promise = requestKeyframePack(context.frame, options(context, { timeoutMs: 1000 }));
+	assert.equal(context.listeners.length, 1);
+	context.fireTimers();
+	await assert.rejects(promise, /timed out/);
+	assert.equal(context.listeners.length, 0, "the listener is removed after a timeout");
+	console.log("PASS requestKeyframePack rejects when the embedded Studio never answers");
+}
+
+/* --- there is no embedded Studio ------------------------------------------- */
+{
+	const context = harness();
+	await assert.rejects(requestKeyframePack(null, options(context)), /Scene preview is unavailable/);
+	assert.equal(context.listeners.length, 0, "a missing frame installs no listener at all");
+	assert.equal(context.posted.length, 0);
+	console.log("PASS requestKeyframePack rejects without an embedded Studio and installs no listener");
+}
+
+/* --- the node wiring ------------------------------------------------------- */
+// The helper is only useful if the node actually reaches its own frame, sends
+// the pack to disk and reports the export. Assert the wiring in source: a
+// browser QA run (test/qa-send-to-ai-browser.mjs) proves it end to end.
+{
+	const node = readFileSync(new URL("../src/workflow/CozySceneNode.jsx", import.meta.url), "utf8");
+	assert.match(node, /cozy-scene-send/, "the node renders the Send to AI control");
+	assert.match(node, /Packing…/, "the pending label replaces the button text");
+	assert.match(node, /\[data-node-id="\$\{id\}"\] iframe/, "the handler looks up this node's own embedded Studio");
+	assert.match(node, /requestKeyframePack\(/);
+	assert.match(node, /downloadPack\(/);
+	assert.match(node, /track\("export:keyframe_pack", \{ entries: result\.entries\.length, source: "workflow" \}\)/, "the export is reported to analytics");
+	assert.match(node, /Pack ready: \$\{result\.name\} \(\$\{result\.entries\.length\} files\)/, "success shows the pack name and file count");
+	const css = readFileSync(new URL("../src/workflow/cozy-scene-node.css", import.meta.url), "utf8");
+	assert.match(css, /\.cozy-scene-send \{/, "the control is styled with the node's own button vocabulary");
+	console.log("PASS the Scene node wires Send to AI to the helper, the download and analytics");
+}

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -82,6 +82,7 @@ const NODE_FILES = [
 	"test/verify-motion-trail.mjs",
 	"test/verify-kimodo-waypoints.mjs",
 	"test/verify-keyframe-pack.mjs",
+	"test/verify-keyframe-pack-request.mjs",
 	"test/verify-korean-ui.mjs",
 	"test/verify-label-tooltips.mjs",
 	"test/verify-layout.mjs",
@@ -174,12 +175,13 @@ const BROWSER_FILES = [
 	"test/verify-offscreen-export-browser.mjs",
 	"test/verify-project-menu-browser.mjs",
 	"test/qa-keyframe-pack-browser.mjs",
+	"test/qa-send-to-ai-browser.mjs",
 ];
 
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-send-to-ai-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
## What changed

"Send to AI" on the Workflow Scene node. The node can now hand its shot to an AI video model without a detour through the Studio: the button asks the node's **own** embedded Studio for the shot's keyframe pack over `postMessage`, downloads the returned zip, shows progress/result on the node and reports the export to analytics.

- **`src/workflow/keyframe-pack-request.js`** (new) — the handshake as a pure helper. `requestKeyframePack(iframeWindow, { shotId, timeoutMs = 120000, addListener, removeListener })` posts `cozyclay:export-keyframe-pack`, resolves `{ name, bytes, entries }` on the matching `…-result` **from that frame**, rejects on an `{ error }` reply or a timeout, and removes its listener on every path — a leaked listener would resolve a later export into the wrong node. `downloadPack({ name, bytes })` turns the bytes into a Blob URL and clicks an anchor.
- **`src/workflow/CozySceneNode.jsx`** — a `cozy-scene-send` button next to Run. While pending it reads `Packing…` and is disabled; on success the existing header status area shows `Pack ready: <name> (<n> files)`, on failure the error message. The handler resolves the node's frame with `document.querySelector(\`[data-node-id="${id}"] iframe\`)?.contentWindow` and calls `track("export:keyframe_pack", { entries, source: "workflow" })`. No `shotId` is sent: the Scene node tracks a *scene*, not a shot, so the embed packs the shot under its own playhead (passing the scene id would throw `Unknown shots ID`).
- **`src/workflow/cozy-scene-node.css`** — `.cozy-scene-send` reuses the node's existing button rule (same padding, radius, border colour family), tinted as the secondary action next to the primary Run; `.cozy-scene-node-status.has-pack` widens the status span so a zip name wraps to two lines instead of five.
- Pack state is component state, not graph data: it never has to survive a reload or reach the workflow runner, so `cozy-scene-node.js` needed no change.

## How it was verified

**Unit — `node test/verify-keyframe-pack-request.mjs` (EXIT 0)**, driving the helper against a fake frame window and fake listeners:

```
PASS requestKeyframePack posts the request and resolves on that frame's reply
PASS requestKeyframePack rejects with the Studio's error message
PASS requestKeyframePack rejects when the embedded Studio never answers
PASS requestKeyframePack rejects without an embedded Studio and installs no listener
PASS the Scene node wires Send to AI to the helper, the download and analytics
```

It also proves the noise cases: another frame's reply and this frame's `capture-framing-result` both leave the request open, and the listener count is asserted to be 0 after success, error, timeout and the no-frame path.

**Browser QA — `QA_URL=http://127.0.0.1:5340/workflow/ CDP_PORT=9468 node tools/qa-browser.mjs -- node test/qa-send-to-ai-browser.mjs` (EXIT 0)**. Nothing is stubbed on the app side: a real one-second shot is seeded, the embedded Studio builds a real pack, and the only interception is `HTMLAnchorElement.prototype.click` so no file dialog opens. Readiness is the frame's own `__cozyclay` hook (same-origin), not a timer.

```
PASS the Scene node renders a Send to AI button (status: "Ready when connected")
PASS the node's embedded Studio came up with the seeded shot
PASS clicking Send to AI puts the button into its Packing… state
PASS the node reports the finished pack: "Pack ready: cozyclay-shot-1-send-qa-push-in.zip (6 files)"
PASS the pack reaches the browser as a download: cozyclay-shot-1-send-qa-push-in.zip -> blob:http://127.0.0.1:53...
PASS the export is reported to analytics: {"event":"export:keyframe_pack","entries":6,"source":"workflow"}
PASS the button returns to Send to AI when the export finishes
PASS qa-send-to-ai-browser: /tmp/send-to-ai-qa/after.png
```

Evidence: `/tmp/send-to-ai-qa/after.png` (the node after a successful export). Run twice, identical result.

**`NO_COLOR=1 npm test` — EXIT 0**, 155 runnable Node verification files (was 154); both new test files are registered in `tools/run-tests.mjs` (`verify-keyframe-pack-request.mjs` as RUN, `qa-send-to-ai-browser.mjs` as an EXCLUDE with its reason, alongside the existing keyframe-pack QA suite). Last 15 lines:

```
PASS playback storage events announce cross-tab controls
PASS playback event name is stable

verify-workflow-scene-asset-sync: all green

RUNNING test/verify-zip-store.mjs
PASS crc32: known vectors for 'hello', the empty sequence, and the quick brown fox
PASS buildZip: unzip -t accepts the archive
  Archive:  /var/folders/.../cozyclay-zip-store-N3DFrS/pack.zip
      testing: notes/______.txt         OK
      testing: frame.png                OK
  No errors detected in compressed data of /var/folders/.../cozyclay-zip-store-N3DFrS/pack.zip.
PASS zip-store: crc32 vectors, structure, and unzip -t on a written archive

PASS 155 Node verification files
```

`npm run build` also passes clean.

Closes #168
