### PR TITLE
feat(references): identity and environment reference slots ride with the capture (#167)

### DIFF
--- a/bin/agent/agent-routes.mjs
+++ b/bin/agent/agent-routes.mjs
@@ -21,6 +21,41 @@ export function allowAgentOrigin(req, port) {
 // Two 1920x1080 PNG data URLs (frame + reference) fit comfortably in this.
 const IMAGE_BODY_LIMIT = 24 * 1024 * 1024;
 
+// Attached scene references (#167): identity sheets and the environment
+// reference. Capped because every one of them is another full image the
+// backend has to read, and a shot with seven of them is a prompt nobody wrote.
+const IMAGE_REFERENCES_MAX = 6;
+
+/** Reject anything that is not a list of {role, name?, dataUrl} inline images. */
+function validReferences(references) {
+	if (references === undefined) return true;
+	if (!Array.isArray(references) || references.length > IMAGE_REFERENCES_MAX) return false;
+	return references.every((entry) => entry && typeof entry === "object" && !Array.isArray(entry)
+		&& typeof entry.role === "string" && entry.role
+		&& (entry.name === undefined || typeof entry.name === "string")
+		&& typeof entry.dataUrl === "string" && entry.dataUrl.startsWith("data:image/"));
+}
+
+/**
+ * What the attached pictures MEAN, in the order they are attached. Without
+ * this the backend sees a pile of images and guesses; with it the clay frame
+ * owns the geometry, each character sheet owns one performer's look and the
+ * environment reference owns the location.
+ */
+export function referenceGuidance(references = []) {
+	const list = Array.isArray(references) ? references : [];
+	if (!list.length) return "";
+	const lines = ["Geometry, camera and blocking come from the first image (the clay frame)."];
+	for (const entry of list) {
+		if (entry.role === "character") {
+			lines.push(`Character ${entry.name || "reference"}: match the identity, face, hair and wardrobe from the attached character sheet.`);
+		} else if (entry.role === "environment") {
+			lines.push("Environment: take the location look, materials, palette and lighting from the attached environment reference.");
+		}
+	}
+	return `\n${lines.join("\n")}`;
+}
+
 async function readBody(req, limit = 64 * 1024) {
 	let text = "";
 	for await (const chunk of req) {
@@ -132,14 +167,17 @@ export function createAgentHandler({ auth = defaultAuth, codex, handlers, liveHu
 			let value;
 			try {
 				value = await readBody(req, IMAGE_BODY_LIMIT);
-				if (typeof value.prompt !== "string" || !value.prompt.trim() || typeof value.imageDataUrl !== "string" || !value.imageDataUrl.startsWith("data:image/") || (value.referenceDataUrl !== undefined && (typeof value.referenceDataUrl !== "string" || !value.referenceDataUrl.startsWith("data:image/"))) || (value.quality !== undefined && !["auto", "low", "medium", "high"].includes(value.quality))) throw new Error("Invalid request.");
+				if (typeof value.prompt !== "string" || !value.prompt.trim() || typeof value.imageDataUrl !== "string" || !value.imageDataUrl.startsWith("data:image/") || (value.referenceDataUrl !== undefined && (typeof value.referenceDataUrl !== "string" || !value.referenceDataUrl.startsWith("data:image/"))) || !validReferences(value.references) || (value.quality !== undefined && !["auto", "low", "medium", "high"].includes(value.quality))) throw new Error("Invalid request.");
 			} catch { json(res, 400, { error: "invalid request" }); return true; }
 			if (!await auth.getAccessToken()) { json(res, 401, { error: { code: "auth", message: "Sign in with ChatGPT in the Agent panel." } }); return true; }
 			try {
 				// Same composition guidance the agent's render_from_frame appends: the
 				// node's prompt is intent only; camera, cast and set come from the scene.
-				const prompt = `${value.prompt}${await renderGuidance(value.prompt)}`;
-				const result = await codex.editImage({ ...value, prompt });
+				// Scene references (#167) are appended after the frame/reference pair,
+				// and the prompt says what each attachment is for.
+				const references = Array.isArray(value.references) ? value.references : [];
+				const prompt = `${value.prompt}${await renderGuidance(value.prompt)}${referenceGuidance(references)}`;
+				const result = await codex.editImage({ ...value, prompt, extraImages: references.map((entry) => entry.dataUrl) });
 				json(res, 200, { dataUrl: `data:image/png;base64,${result.pngBase64}`, width: result.width, height: result.height });
 			} catch (error) { json(res, error.status === 401 ? 401 : 502, { error: errorInfo(error) }); }
 			return true;

--- a/bin/agent/codex-client.mjs
+++ b/bin/agent/codex-client.mjs
@@ -231,8 +231,14 @@ export function createCodexClient({
 		return { history: continued, finalText };
 	}
 
-	async function editImage({ prompt, imageDataUrl, referenceDataUrl, quality = "auto", signal }) {
-		const images = [imageDataUrl, referenceDataUrl].filter((value) => typeof value === "string" && value);
+	/**
+	 * `extraImages` are the scene's reference pictures (#167) — identity sheets
+	 * and the environment reference. They are appended AFTER the frame and the
+	 * reference image, because the prompt describes the attachments in that
+	 * order and the first image is always the clay frame.
+	 */
+	async function editImage({ prompt, imageDataUrl, referenceDataUrl, extraImages = [], quality = "auto", signal }) {
+		const images = [imageDataUrl, referenceDataUrl, ...(Array.isArray(extraImages) ? extraImages : [])].filter((value) => typeof value === "string" && value);
 		const response = await postJson("/images/edits", {
 			model: "gpt-image-2",
 			prompt,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,6 +169,7 @@ import {
 	assetUsageCounts,
 	deleteAsset,
 	deleteAssetWithGraphGuard,
+	downscaleTarget,
 	getAsset,
 	imageFilesFromClipboard,
 	importImageFile,
@@ -196,6 +197,7 @@ import {
 	CHARACTER_MODEL_IDS,
 	duplicateScene,
 	migrateStageFrames,
+	normalizeReferenceImage,
 	readSceneDocument,
 	removeScene,
 	renameScene,
@@ -588,6 +590,47 @@ function poseMemberAtFrame(rig, clip, ikState, frame, blendFrames = 0) {
 	}
 }
 
+/** The longest edge a stored reference picture may have. A character sheet is
+ * read as a LOOK, not as texture detail, and the whole thing has to survive
+ * inside the project document — 1024 px keeps a face legible at a fraction of
+ * the bytes a phone photo would cost. */
+export const REFERENCE_IMAGE_MAX_DIMENSION = 1024;
+
+/**
+ * Read one picked file into the data URL a reference slot stores: FileReader
+ * for the bytes (so the result survives save/load exactly like an Upload node's
+ * image), then a canvas pass to cap the long side. The source type is kept, so
+ * a JPEG photo stays a JPEG instead of being re-encoded into a much larger PNG.
+ */
+export async function readReferenceImage(file, { maxDimension = REFERENCE_IMAGE_MAX_DIMENSION } = {}) {
+	if (!file) throw new Error("No file");
+	if (!ASSET_IMAGE_TYPES.includes(String(file.type).toLowerCase())) {
+		throw new Error("unsupported image type");
+	}
+	const dataUrl = await new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onerror = () => reject(new Error("could not read the file"));
+		reader.onload = () => resolve(String(reader.result));
+		reader.readAsDataURL(file);
+	});
+	const bitmap = await createImageBitmap(file);
+	try {
+		const target = downscaleTarget(bitmap.width, bitmap.height, maxDimension);
+		if (!target) throw new Error("could not decode that image");
+		if (!target.scaled) return dataUrl;
+		const canvas = document.createElement("canvas");
+		canvas.width = target.width;
+		canvas.height = target.height;
+		const context = canvas.getContext("2d");
+		context.drawImage(bitmap, 0, 0, target.width, target.height);
+		// GIF and WebP re-encode to PNG: a still frame is what a reference is.
+		const type = file.type === "image/jpeg" ? "image/jpeg" : "image/png";
+		return canvas.toDataURL(type, type === "image/jpeg" ? 0.92 : undefined);
+	} finally {
+		bitmap.close?.();
+	}
+}
+
 export default function App() {
 	const embedMode = ["scene", "playview"].includes(new URLSearchParams(globalThis.location?.search || "").get("embed"));
 	useEffect(() => {
@@ -599,7 +642,11 @@ export default function App() {
 				if (!dataUrl) throw new Error("The shot renderer is not ready");
 				const output = SHOT_ASPECT_PRESETS[live.stage.shotAspect] ?? SHOT_ASPECT_PRESETS["16:9"];
 				const meta = live.captureShotMeta(live.timeline.currentFrame);
-				window.parent.postMessage({ type: "cozyclay:capture-framing-result", dataUrl, width: output.width, height: output.height, meta }, "*");
+				// The identity sheets and the environment reference ride with the
+				// frame (#167): the PNG says where the bodies stand, these say who
+				// they are and what the location is made of.
+				const references = live.captureShotReferences();
+				window.parent.postMessage({ type: "cozyclay:capture-framing-result", dataUrl, width: output.width, height: output.height, meta, references }, "*");
 			} catch (error) { window.parent.postMessage({ type: "cozyclay:capture-framing-result", error: error.message }, "*"); }
 		};
 		// The Workflow page's Scene node asks the embed for a whole reference
@@ -645,6 +692,10 @@ export default function App() {
 	const [preset, setPreset] = useState("medium");
 	const [fovDeg, setFovDeg] = useState(PRESETS.medium.fov);
 	const [shotAspectKey, setShotAspectKey] = useState(startupStage.shotAspect);
+	// The set's look reference (#167): one picture that says what this location
+	// is made of. Persisted on the stage envelope exactly like shotAspect, and
+	// attached to every framing capture so the generator sees it.
+	const [environmentImage, setEnvironmentImage] = useState(startupStage.environmentImage ?? null);
 	const shotOutput = SHOT_ASPECT_PRESETS[shotAspectKey] ?? SHOT_ASPECT_PRESETS["16:9"];
 	// Which named camera framing the shot camera currently stands in, or null
 	// after any manual placement. Recorded on the scene so a take says how it
@@ -2877,6 +2928,7 @@ globalThis.playMode = centerTab === "play";
 		// too heavy for the stage envelope; paths and prompt blocks persist.
 		characters: characters.map(({ sessionMotion, ...entry }) => entry),
 		hasCharSheet,
+		environmentImage,
 		shotAspect: shotAspectKey,
 		cameraPresetId,
 		sensorId,
@@ -3278,6 +3330,7 @@ globalThis.playMode = centerTab === "play";
 		setCharacters(stage.characters);
 		setRigMountEpoch((value) => value + 1);
 		setHasCharSheet(stage.hasCharSheet);
+		setEnvironmentImage(stage.environmentImage ?? null);
 		setShotAspectKey(stage.shotAspect);
 		setCameraPresetId(stage.cameraPresetId ?? null);
 		setSensorFormat(stage.sensorId);
@@ -3428,7 +3481,7 @@ globalThis.playMode = centerTab === "play";
 		camera: cameraPos,
 		fovDeg,
 		filmback,
-		stage: { shotAspect: shotAspectKey, cameraPresetId, sensorId, hasCharSheet },
+		stage: { shotAspect: shotAspectKey, cameraPresetId, sensorId, hasCharSheet, environmentImage },
 		timeline: { currentFrame: tlFrame, frameCount: tlFrameCount, fps: tlFps },
 		activeCharacterId,
 		partColours: partColoursEnabled ? PART_COLOURS : null,
@@ -3450,6 +3503,8 @@ globalThis.playMode = centerTab === "play";
 		captureCurrentFraming,
 		captureFramingPng,
 		captureShotMeta,
+		// The identity / environment reference pictures a capture carries (#167).
+		captureShotReferences,
 		// Reference exports (#165): the embed message handler and the QA hooks
 		// both go through this render's closures, so a pack always describes the
 		// cut as it stands now.
@@ -3953,6 +4008,8 @@ globalThis.playMode = centerTab === "play";
 					// The production notes the PNG cannot carry: lens, delivery
 					// aspect, cast and the video model this shot is aimed at.
 					meta: live.captureShotMeta(live.timeline.currentFrame),
+					// Identity sheets per cast member plus the environment reference.
+					references: live.captureShotReferences(),
 				};
 			},
 			load_motion: async (args) => {
@@ -4038,7 +4095,7 @@ globalThis.playMode = centerTab === "play";
 		dirtyRef.current = true;
 		const timer = setTimeout(flushScenes, 400);
 		return () => clearTimeout(timer);
-	}, [sceneObjects, shots, waypoints, tlFrameCount, charA, charB, showB, poseA, poseB, hasCharSheet, subject, subject2, shotAspectKey, sensorId, keyLight, scenes, activeSceneId]);
+	}, [sceneObjects, shots, waypoints, tlFrameCount, charA, charB, showB, poseA, poseB, hasCharSheet, environmentImage, subject, subject2, shotAspectKey, sensorId, keyLight, scenes, activeSceneId]);
 	useEffect(() => {
 		const onPageHide = () => flushScenes();
 		const onVisibility = () => {
@@ -4065,7 +4122,7 @@ globalThis.playMode = centerTab === "play";
 		setProjectDirty(dirty);
 		setProjectSaveState((current) => current === "saving" ? current : dirty ? "dirty" : "saved");
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [scenes, activeSceneId, workspaceLayout, customPoses, characters, shots, waypoints, promptClips, projectName, keyLight, sceneObjects, shotAspectKey, sensorId, tlFrameCount, workflowRevision]);
+	}, [scenes, activeSceneId, workspaceLayout, customPoses, characters, shots, waypoints, promptClips, projectName, keyLight, sceneObjects, shotAspectKey, environmentImage, sensorId, tlFrameCount, workflowRevision]);
 	const [selectedPromptId, setSelectedPromptId] = useState(null);
 	// Loaded motion: decoded arrays plus the world anchor captured at load.
 	const [motion, setMotion] = useState(null);
@@ -4749,6 +4806,23 @@ globalThis.playMode = centerTab === "play";
 	// still handed to a generator arrives with its production notes.
 	// A frame that falls in a gap between shots describes the first shot — a
 	// pull still belongs to the piece even when the playhead sits outside a cut.
+	/**
+	 * The reference pictures a capture travels with (#167): every visible cast
+	 * member's identity sheet, then the set's environment reference. Slots that
+	 * are empty simply do not appear — the array is the pictures that EXIST,
+	 * never a fixed-length list with holes in it, so a consumer can attach the
+	 * whole thing without filtering.
+	 */
+	function captureShotReferences() {
+		const references = characters
+			.filter((entry) => !entry.hidden && typeof entry.identityImage === "string" && entry.identityImage)
+			.map((entry) => ({ role: "character", name: entry.subject || entry.id, dataUrl: entry.identityImage }));
+		if (typeof environmentImage === "string" && environmentImage) {
+			references.push({ role: "environment", dataUrl: environmentImage });
+		}
+		return references;
+	}
+
 	function captureShotMeta(frame) {
 		const index = shotIndexAtFrame(shots, frame);
 		const resolvedIndex = index >= 0 ? index : shots.length ? 0 : null;
@@ -6339,6 +6413,18 @@ globalThis.playMode = centerTab === "play";
 			// effect does not depend on the shot list, so a closure over it would
 			// answer with the cut as it stood when the effect last ran.
 			captureMeta: (frame) => liveStateRef.current.captureShotMeta(frame ?? liveStateRef.current.timeline.currentFrame),
+			// QA-only reference slots (#167): set the pictures a headless run cannot
+			// reach through a file dialog, then take the capture the live
+			// capture_framing_png command returns — references included.
+			setCharacterIdentityImage: (index, dataUrl) => {
+				updateCharacterAt(index, { identityImage: normalizeReferenceImage(dataUrl) });
+				return true;
+			},
+			setEnvironmentImage: (dataUrl) => {
+				setEnvironmentImage(normalizeReferenceImage(dataUrl));
+				return true;
+			},
+			captureWithReferences: () => liveHandlersRef.current.capture_framing_png({}),
 			// QA-only reference exports (#165): the production builders without the
 			// download, so a headless run can unzip a real pack and diff the passes
 			// instead of driving a file dialog. Same liveStateRef reasoning as
@@ -11331,6 +11417,24 @@ function resizePromptClip(id, edge, rawFrame) {
 					>
 						{ko("Save current pose", "지금 자세 저장")}
 					</button>
+					{/* Identity sits beside "Pose from photo" on purpose: both take a
+					    picture of a person, but that one reads a SHAPE off it while
+					    this one keeps the picture itself as who the character is. */}
+					<ReferenceImageField
+						label={ko("Identity image", "인물 이미지")}
+						hint={ko(
+							"A character sheet or photo of this person. It travels with every framing capture so a render keeps the same face, hair and wardrobe.",
+							"이 인물의 캐릭터 시트나 사진입니다. 모든 프레이밍 캐프처에 함께 실려 얼굴·머리·의상을 유지합니다.",
+						)}
+						value={activeChar.identityImage ?? null}
+						alt={ko("Identity reference", "인물 참고 이미지")}
+						inputProps={{ "data-identity-image-input": "" }}
+						onPick={(dataUrl) => {
+							updateCharacterAt(activeCharIndex, { identityImage: dataUrl });
+							setToast(ko("Identity image set", "인물 이미지를 설정했어요"));
+						}}
+						onClear={() => updateCharacterAt(activeCharIndex, { identityImage: null })}
+					/>
 				</Foldout>
 
 				<Foldout hidden={!advancedMode || !isCharacterSelection} defaultOpen={false} title={ko("Video capture", "영상 모캡")}>
@@ -12102,6 +12206,21 @@ function resizePromptClip(id, edge, rawFrame) {
 					<Field label={ko("Look / style", "룩 / 스타일")}>
 							<input type="text" value={style} onChange={(event) => setStyle(event.target.value)} />
 						</Field>
+						<ReferenceImageField
+							label={ko("Environment reference", "환경 참고 이미지")}
+							hint={ko(
+								"A picture of this location. It travels with every framing capture so a render takes its materials, palette and lighting from the real place.",
+								"이 장소의 사진입니다. 모든 프레이밍 캐프처에 함께 실려 재질·색감·조명을 실제 장소에서 가져옵니다.",
+							)}
+							value={environmentImage}
+							alt={ko("Environment reference", "환경 참고 이미지")}
+							inputProps={{ "data-environment-image-input": "" }}
+							onPick={(dataUrl) => {
+								setEnvironmentImage(dataUrl);
+								setToast(ko("Environment reference set", "환경 참고 이미지를 설정했어요"));
+							}}
+							onClear={() => setEnvironmentImage(null)}
+						/>
 					</Foldout>
 
 				<Foldout hidden={!advancedMode || selectedHierarchyId !== "props"} title={ko("Props", "소품")}>
@@ -13223,6 +13342,72 @@ function fmtMeters(value) {
 }
 
 /** Mid-clip frame of a base motion, the sensible default for the destination. */
+
+/**
+ * One reference-picture slot (#167): pick a file, see what is loaded, clear it.
+ * Used by the cast member's identity sheet and by the set's environment
+ * reference, so both slots behave identically — same picker, same thumbnail,
+ * same Clear — rather than growing two dialects of the same control.
+ *
+ * The value IS the stored data URL: there is no separate "pending" state, so
+ * what the panel shows is exactly what a capture will attach.
+ */
+function ReferenceImageField({ label, hint, value, alt, onPick, onClear, inputProps = {} }) {
+	const inputRef = useRef(null);
+	const [error, setError] = useState("");
+	return (
+		<div className="reference-slot">
+			<div className="reference-slot-head">
+				<span className="reference-slot-label">{label}</span>
+				{value && (
+					<button type="button" className="btn ghost small" onClick={() => { setError(""); onClear(); }}>
+						{ko("Clear", "지우기")}
+					</button>
+				)}
+			</div>
+			<div className="reference-slot-body">
+				<button
+					type="button"
+					className="reference-slot-thumb"
+					data-empty={value ? undefined : "true"}
+					onClick={() => inputRef.current?.click()}
+					title={ko("Choose a reference picture", "참고 이미지를 선택합니다")}
+				>
+					{value
+						? <img src={value} alt={alt ?? label} />
+						: <span className="reference-slot-plus" aria-hidden="true">＋</span>}
+				</button>
+				<div className="reference-slot-copy">
+					<p className="inspector-hint">{hint}</p>
+					<button type="button" className="btn ghost small" onClick={() => inputRef.current?.click()}>
+						{value ? ko("Replace", "교체") : ko("Choose image", "이미지 선택")}
+					</button>
+				</div>
+			</div>
+			{error && <p className="inspector-hint reference-slot-error" role="status">{error}</p>}
+			<input
+				ref={inputRef}
+				type="file"
+				className="multimodel-file-input"
+				accept="image/*"
+				{...inputProps}
+				onChange={async (event) => {
+					const file = event.target.files?.[0];
+					// Cleared before the await: re-picking the same file after an
+					// error must fire change again.
+					event.target.value = "";
+					if (!file) return;
+					setError("");
+					try {
+						onPick(await readReferenceImage(file));
+					} catch (failure) {
+						setError(isKo ? `이미지를 불러오지 못했어요 — ${failure.message}` : `Could not load that image — ${failure.message}`);
+					}
+				}}
+			/>
+		</div>
+	);
+}
 
 /** Unity Inspector-style foldout: a titled section the user can collapse.
  * Cards default to open; the fold state is per-title session state. */

--- a/src/scenes.js
+++ b/src/scenes.js
@@ -41,6 +41,8 @@ export const DEFAULT_SCENE_STAGE = Object.freeze({
 		Object.freeze({ id: "char-a", model: DEFAULT_CHARACTER_MODEL, x: 0, z: 0, rot: 0, hidden: false, pose: null, subject: DEFAULT_SUBJECT_ONE }),
 	]),
 	hasCharSheet: false,
+	// The look reference for the location: a data URL so it survives save/load
+	environmentImage: null,
 	shotAspect: "16:9",
 	cameraPresetId: null,
 	sensorId: DEFAULT_SENSOR_FORMAT,
@@ -98,6 +100,14 @@ function cloneValue(value, copies = new WeakMap()) {
 
 const finiteOr = (value, fallback) => (Number.isFinite(value) ? value : fallback);
 
+/** A reference picture kept inside the document. Only inline data URLs are
+ * accepted: a file:// or http:// path would break the moment the project is
+ * moved or reopened elsewhere, so a slot either holds its own bytes or is
+ * empty. */
+export function normalizeReferenceImage(value) {
+	return typeof value === "string" && value.startsWith("data:image/") ? value : null;
+}
+
 /** Stature band for a cast member. Wider than ardy/npz.js's mocap band
  * (0.6-1.5, a sanity clamp on ESTIMATED statures): the gizmo's scale handles
  * are a deliberate artistic ask, and a previs giant or child is legitimate. */
@@ -139,6 +149,10 @@ export function createCharacterEntry(source = null, index = 0) {
 		// whiter clay) so the entry survives future default tweaks.
 		tint: typeof s.tint === "string" && /^#[0-9a-fA-F]{6}$/.test(s.tint) ? s.tint : null,
 		pose: plainObject(s.pose) ? cloneValue(s.pose) : null,
+		// Who this cast member IS: a character sheet / reference photo that rides
+		// with the capture so a generator matches face, hair and wardrobe instead
+		// of re-inventing them per shot.
+		identityImage: normalizeReferenceImage(s.identityImage),
 		// Stature multiplier: 1 is the canonical body, an extracted take carries
 		// the FILMED person's leg ratio. It persists with the entry because the
 		// take's root travel was authored against it — see the render path.
@@ -254,7 +268,7 @@ function migrateLegacyCast(source) {
 }
 
 const STAGE_ENVELOPE_KEYS = new Set([
-	"characters", "hasCharSheet", "shotAspect", "cameraPresetId", "sensorId", "keyLight",
+	"characters", "hasCharSheet", "environmentImage", "shotAspect", "cameraPresetId", "sensorId", "keyLight",
 	"charA", "charB", "showB", "poseA", "poseB", "subject", "subject2",
 ]);
 
@@ -273,6 +287,9 @@ export function createSceneStage(stage = null) {
 		...extras,
 		characters,
 		hasCharSheet: source.hasCharSheet === true,
+		// Persisted exactly like shotAspect: part of the stage envelope, written
+		// on every save and read back on load.
+		environmentImage: normalizeReferenceImage(source.environmentImage),
 		shotAspect: ["16:9", "2.39:1", "9:16", "1:1", "4:3", "12:7"].includes(source.shotAspect)
 			? source.shotAspect
 			: DEFAULT_SCENE_STAGE.shotAspect,

--- a/src/styles.css
+++ b/src/styles.css
@@ -10401,3 +10401,110 @@ input[type=range] {
 	font-size: 11px;
 	line-height: 1.45;
 }
+
+/* Reference slots (#167): the cast member's identity sheet and the set's
+   environment reference. One control, two homes — the picture is the control,
+   so the thumbnail itself is the picker and an empty slot reads as a hole
+   waiting to be filled rather than as a disabled button. */
+.reference-slot {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px solid var(--line2);
+}
+
+.reference-slot-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.reference-slot-label {
+	color: var(--fg);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: -.01em;
+}
+
+.reference-slot-body {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+}
+
+.reference-slot-thumb {
+	flex: 0 0 auto;
+	display: grid;
+	place-items: center;
+	width: 58px;
+	height: 58px;
+	padding: 0;
+	overflow: hidden;
+	border: 1px solid var(--line2);
+	border-radius: 8px;
+	background: var(--card2);
+	box-shadow: none;
+	cursor: pointer;
+	transition: border-color var(--fast), background var(--fast);
+}
+
+.reference-slot-thumb:hover {
+	border-color: var(--accent);
+	background: var(--hover);
+}
+
+.reference-slot-thumb[data-empty] {
+	border-style: dashed;
+}
+
+.reference-slot-thumb img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.reference-slot-plus {
+	color: var(--muted2);
+	font-size: 16px;
+	line-height: 1;
+}
+
+.reference-slot-copy {
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.reference-slot-copy .inspector-hint {
+	margin: 0;
+}
+
+/* Slot buttons are secondary to the thumbnail: the panel's small control size,
+   not the full-width `.btn.ghost` action the inspector uses for a primary
+   gesture, so the width and its stacking margin are both reset here. */
+.reference-slot .btn.ghost {
+	align-self: flex-start;
+	width: auto;
+	margin-top: 0;
+	padding: 5px 10px;
+	border-radius: 6px;
+	font-size: 10px;
+	font-weight: 600;
+	box-shadow: none;
+}
+
+.reference-slot .btn.ghost:hover {
+	transform: none;
+	box-shadow: none;
+}
+
+.reference-slot-error {
+	margin: 0;
+	color: #e08a7a;
+}

--- a/src/workflow/WorkflowBuilder.jsx
+++ b/src/workflow/WorkflowBuilder.jsx
@@ -430,6 +430,9 @@ export default function WorkflowBuilder() {
 		// Everything runWorkflow writes to a node also lands in the graph it
 		// returns, so a caller that republishes that graph keeps the results.
 		const patches = new Map();
+		// This run's captured references per Scene node, for the Image nodes fed
+		// by it — same precedence as sceneMeta: a fresh capture wins.
+		const sceneReferences = new Map();
 		const patchNode = (id, patch) => { patches.set(id, { ...(patches.get(id) || {}), ...patch }); updateNode(id, patch); };
 		for (const id of result.order) {
 			const current = result.nodes.find((node) => node.id === id);
@@ -439,9 +442,13 @@ export default function WorkflowBuilder() {
 					const frame = await captureSceneFrame(id);
 					values.set(id, frame.dataUrl);
 					// The capture metadata rides along on lastOutput so a downstream
-					// Shot Prompt node can describe the shot without re-capturing.
-					patchNode(id, { status: "complete", statusMessage: "Captured framing PNG", preview: "render", lastOutput: { renderUrl: frame.dataUrl, sceneUrl: "/app/", jobId: null, meta: frame.meta ?? null }, outputs: [{ value: frame.dataUrl }], resultUrl: frame.dataUrl });
+					// Shot Prompt node can describe the shot without re-capturing, and
+					// the identity/environment references (#167) ride with it so an
+					// Image node downstream can attach them.
+					const references = Array.isArray(frame.references) ? frame.references : [];
+					patchNode(id, { status: "complete", statusMessage: "Captured framing PNG", preview: "render", lastOutput: { renderUrl: frame.dataUrl, sceneUrl: "/app/", jobId: null, meta: frame.meta ?? null, references }, outputs: [{ value: frame.dataUrl }], resultUrl: frame.dataUrl });
 					sceneMeta.set(id, frame.meta ?? current.data?.lastOutput?.meta ?? null);
+					sceneReferences.set(id, references);
 				} catch (error) { patchNode(id, { status: "error", errorMsg: error.message, statusMessage: error.message }); }
 			} else if (current.type === "shot-prompt") {
 				const incoming = (graph.edges || []).filter((edge) => edge.target === id).map((edge) => result.nodes.find((node) => node.id === edge.source)).filter(Boolean);
@@ -481,8 +488,13 @@ export default function WorkflowBuilder() {
 				// one, otherwise the structured prompt from an upstream Shot Prompt.
 				const upstreamPrompt = incoming.map((entry) => entry.node?.type === "shot-prompt" ? entry.value : null).find((value) => typeof value === "string" && value.trim());
 				const prompt = String(current.data.prompt || "").trim() || upstreamPrompt || "";
+				// Identity sheets and the environment reference come from whichever
+				// Scene node feeds this one: this run's capture first, else the one
+				// stored on the node from an earlier run.
+				const sceneNode = incoming.find((entry) => entry.node?.type === "scene")?.node;
+				const references = (sceneNode && sceneReferences.get(sceneNode.id)) || (Array.isArray(sceneNode?.data?.lastOutput?.references) ? sceneNode.data.lastOutput.references : []);
 				patchNode(id, { isLoading: true, errorMsg: null });
-				try { const output = await createHttpTransport().image({ prompt, imageDataUrl: source, referenceDataUrl: reference || (typeof current.data.image_url === "string" && current.data.image_url.startsWith("data:image/") ? current.data.image_url : undefined), quality: "auto" }); values.set(id, output.dataUrl); patchNode(id, { isLoading: false, status: "complete", errorMsg: null, ...appendVersion(current.data, { dataUrl: output.dataUrl, prompt, referenceDataUrl: reference || null, frameDataUrl: source, at: Date.now() }) }); }
+				try { const output = await createHttpTransport().image({ prompt, imageDataUrl: source, referenceDataUrl: reference || (typeof current.data.image_url === "string" && current.data.image_url.startsWith("data:image/") ? current.data.image_url : undefined), ...(references.length ? { references } : {}), quality: "auto" }); values.set(id, output.dataUrl); patchNode(id, { isLoading: false, status: "complete", errorMsg: null, ...appendVersion(current.data, { dataUrl: output.dataUrl, prompt, referenceDataUrl: reference || null, frameDataUrl: source, at: Date.now() }) }); }
 				catch (error) { patchNode(id, { isLoading: false, status: "error", errorMsg: error.message }); }
 			} else values.set(id, current.data?.outputs?.[0]?.value);
 		}
@@ -519,7 +531,7 @@ export default function WorkflowBuilder() {
 	}, [nodeSchemas, setEdges, setNodes]);
 	const runScene = useCallback(async ({ id, data }) => {
 		updateScene({ id, patch: { status: "running", statusMessage: "Capturing framing PNG" } });
-		try { const frame = await captureSceneFrame(id); updateScene({ id, patch: { status: "complete", statusMessage: "Captured framing PNG", preview: "render", lastOutput: { renderUrl: frame.dataUrl, sceneUrl: "/app/", jobId: null }, outputs: [{ value: frame.dataUrl }], resultUrl: frame.dataUrl } }); toast.success("Scene frame captured"); }
+		try { const frame = await captureSceneFrame(id); updateScene({ id, patch: { status: "complete", statusMessage: "Captured framing PNG", preview: "render", lastOutput: { renderUrl: frame.dataUrl, sceneUrl: "/app/", jobId: null, meta: frame.meta ?? null, references: Array.isArray(frame.references) ? frame.references : [] }, outputs: [{ value: frame.dataUrl }], resultUrl: frame.dataUrl } }); toast.success("Scene frame captured"); }
 		catch (error) { updateScene({ id, patch: { status: "error", errorMsg: error.message, statusMessage: error.message } }); }
 	}, [updateScene]);
 

--- a/src/workflow/agent-client.js
+++ b/src/workflow/agent-client.js
@@ -185,8 +185,11 @@ export function createHttpTransport({ fetchImpl = globalThis.fetch?.bind(globalT
 		async stop(sessionId) {
 			return request("/agent/stop", { method: "POST", body: JSON.stringify({ sessionId }) });
 		},
-		async image({ prompt, imageDataUrl, referenceDataUrl, quality = "auto" }, signal) {
-			return request("/agent/image", { method: "POST", body: JSON.stringify({ prompt, imageDataUrl, ...(referenceDataUrl ? { referenceDataUrl } : {}), quality }), signal });
+		// `references` are the scene's identity / environment slots (#167): extra
+		// attached pictures with a role, passed through untouched so the sidecar
+		// decides how they are described to the model.
+		async image({ prompt, imageDataUrl, referenceDataUrl, references, quality = "auto" }, signal) {
+			return request("/agent/image", { method: "POST", body: JSON.stringify({ prompt, imageDataUrl, ...(referenceDataUrl ? { referenceDataUrl } : {}), ...(Array.isArray(references) && references.length ? { references } : {}), quality }), signal });
 		},
 		async video(payload, signal) {
 			return request("/agent/video", { method: "POST", body: JSON.stringify(payload), signal });

--- a/test/qa-reference-slots-browser.mjs
+++ b/test/qa-reference-slots-browser.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+// Browser QA for the reference slots (#167). Drives the real studio over CDP:
+// sets an identity image on a cast member and an environment reference on the
+// stage, then takes the SAME capture the live capture_framing_png command
+// returns and proves both pictures rode along with it. The inspector is
+// screenshotted with the identity thumbnail on screen, because "the data is
+// there" and "the operator can see it" are two different claims.
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const out = process.env.QA_OUT || "/tmp/reference-slots-qa";
+mkdirSync(out, { recursive: true });
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params.exceptionDetails.exception?.description ?? message.params.exceptionDetails.text);
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true, timeout: 120_000 });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+const waitFor = async (expression, timeoutMs = 30_000) => {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		if (Date.now() >= deadline) return false;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+// Two visibly different 1x1 PNGs, so a mixed-up slot cannot pass by accident.
+const IDENTITY_PNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const ENVIRONMENT_PNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+await send("Runtime.enable");
+await send("Page.enable");
+await send("Page.navigate", { url: process.env.QA_URL ?? "http://127.0.0.1:5180/app/" });
+await waitFor("location.href.startsWith('http')");
+
+// A one-shot scene with a named cast member: the reference entry has to carry
+// the subject description as its name, which is what the prompt then says.
+await evaluate(`(() => {
+	const document = {
+		version: 4,
+		activeSceneId: "scene-ref-qa",
+		scenes: [{
+			id: "scene-ref-qa",
+			name: "REF QA",
+			objects: [],
+			shotDocument: { version: 4, frameCount: 24, shots: [{ id: "ref-qa-shot", name: "Ref QA", startFrame: 0, endFrame: 23, cameraKeys: [], camera: { mode: "keys" } }], waypoints: [] },
+			stage: {
+				characters: [{ id: "char-a", model: "y-bot-tpose", x: 0, z: 0, rot: 0, hidden: false, pose: null, subject: "Alpha in a tan coat" }],
+				hasCharSheet: false,
+				shotAspect: "16:9",
+			},
+		}],
+	};
+	localStorage.clear();
+	localStorage.setItem("cozyclay.locale", "en");
+	localStorage.setItem("cozyclay.project-session.v1", JSON.stringify({ name: "QA", updatedAt: Date.now() }));
+	localStorage.setItem("cozyclay.scenes.v4", JSON.stringify(document));
+})()`);
+await send("Page.reload");
+expect(
+	"the studio comes up with the reference-slot hooks",
+	await waitFor("!!window.__cozyclay?.rigA && typeof window.__cozyclay?.setCharacterIdentityImage === 'function' && typeof window.__cozyclay?.setEnvironmentImage === 'function' && typeof window.__cozyclay?.captureWithReferences === 'function'", 60_000),
+);
+
+/* --- set both slots -------------------------------------------------------- */
+
+await evaluate(`window.__cozyclay.setCharacterIdentityImage(0, ${JSON.stringify(IDENTITY_PNG)})`);
+await evaluate(`window.__cozyclay.setEnvironmentImage(${JSON.stringify(ENVIRONMENT_PNG)})`);
+expect("a non-image value is refused by the slot", await evaluate(`(() => {
+	window.__cozyclay.setEnvironmentImage("https://example.com/set.png");
+	const rejected = !window.__cozyclay.captureWithReferences().references.some((entry) => entry.role === "environment");
+	window.__cozyclay.setEnvironmentImage(${JSON.stringify(ENVIRONMENT_PNG)});
+	return rejected;
+})()`));
+expect("the slots survive a React commit", await waitFor(`window.__cozyclay.captureWithReferences().references.length === 2`, 10_000));
+
+/* --- the capture ----------------------------------------------------------- */
+
+const capture = await evaluate("window.__cozyclay.captureWithReferences()");
+writeFileSync(`${out}/capture.json`, JSON.stringify({
+	width: capture?.width,
+	height: capture?.height,
+	frame: capture?.frame,
+	meta: capture?.meta,
+	references: capture?.references,
+	dataUrlPrefix: String(capture?.dataUrl ?? "").slice(0, 32),
+}, null, 2));
+
+expect("the capture is a PNG with the shot's delivery size", typeof capture?.dataUrl === "string" && capture.dataUrl.startsWith("data:image/png;base64,") && capture.width > 0 && capture.height > 0, JSON.stringify({ width: capture?.width, height: capture?.height }));
+expect("the capture still carries its shot metadata", capture?.meta && typeof capture.meta.aspect === "string", JSON.stringify(capture?.meta ?? null).slice(0, 120));
+
+const references = Array.isArray(capture?.references) ? capture.references : [];
+const character = references.find((entry) => entry.role === "character");
+const environment = references.find((entry) => entry.role === "environment");
+expect("the capture carries a character reference", Boolean(character), JSON.stringify(references));
+expect("the character reference is named after the subject", character?.name === "Alpha in a tan coat", String(character?.name));
+expect("the character reference carries the identity picture", character?.dataUrl === IDENTITY_PNG, String(character?.dataUrl).slice(0, 48));
+expect("the capture carries an environment reference", Boolean(environment), JSON.stringify(references));
+expect("the environment reference carries the environment picture", environment?.dataUrl === ENVIRONMENT_PNG, String(environment?.dataUrl).slice(0, 48));
+expect("the two slots hold different pictures", character?.dataUrl !== environment?.dataUrl);
+
+// Clearing a slot removes its entry rather than leaving a hole in the list.
+await evaluate("window.__cozyclay.setCharacterIdentityImage(0, null)");
+const clearedOk = await waitFor(`(() => { const list = window.__cozyclay.captureWithReferences().references; return list.length === 1 && list[0].role === "environment"; })()`, 10_000);
+expect("clearing the identity slot drops its reference", clearedOk, JSON.stringify(await evaluate("window.__cozyclay.captureWithReferences().references")));
+await evaluate(`window.__cozyclay.setCharacterIdentityImage(0, ${JSON.stringify(IDENTITY_PNG)})`);
+await waitFor("window.__cozyclay.captureWithReferences().references.length === 2", 10_000);
+
+/* --- the inspector on screen ----------------------------------------------- */
+
+// The Identity image slot lives in the character's Pose panel; open it and put
+// the thumbnail on screen, so the screenshot shows the control, not the theory.
+const opened = await evaluate(`(() => {
+	const pose = [...document.querySelectorAll(".foldout-title")].find((node) => /^(Pose|포즈)$/.test(node.textContent.trim()));
+	const head = pose?.closest(".foldout-head");
+	if (head && head.getAttribute("aria-expanded") !== "true") head.click();
+	return Boolean(head);
+})()`);
+expect("the character's Pose panel opens", opened);
+await waitFor(`[...document.querySelectorAll(".reference-slot")].some((node) => /Identity image/.test(node.textContent))`, 10_000);
+await evaluate(`[...document.querySelectorAll(".reference-slot")].find((node) => /Identity image/.test(node.textContent))?.scrollIntoView({ block: "center" })`);
+expect("the Identity image slot is in the character inspector", await evaluate(`[...document.querySelectorAll(".reference-slot")].some((node) => /Identity image/.test(node.textContent))`));
+expect(
+	"the slot shows the picked picture as a thumbnail",
+	await waitFor(`(() => { const img = [...document.querySelectorAll(".reference-slot img")].find((node) => node.src === ${JSON.stringify(IDENTITY_PNG)}); return !!img && img.getBoundingClientRect().width > 0; })()`, 10_000),
+);
+expect(
+	"the slot offers Replace and Clear once it holds a picture",
+	await evaluate(`(() => { const slot = [...document.querySelectorAll(".reference-slot")].find((node) => /Identity image/.test(node.textContent)); const labels = [...slot.querySelectorAll("button")].map((node) => node.textContent.trim()); return labels.includes("Clear") && labels.includes("Replace"); })()`),
+);
+
+/* --- the real file path ----------------------------------------------------- */
+
+// Everything above sets the slot through the QA hook. This drives the actual
+// <input type=file> with a 2048 px picture, which is the only way to prove the
+// FileReader read and the 1024 px cap the stored data URL depends on.
+const picked = await evaluate(`(async () => {
+	const canvas = document.createElement("canvas");
+	canvas.width = 2048; canvas.height = 1024;
+	const context = canvas.getContext("2d");
+	context.fillStyle = "#2d5c8a"; context.fillRect(0, 0, 2048, 1024);
+	context.fillStyle = "#ef759d"; context.fillRect(64, 64, 640, 512);
+	const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+	const file = new File([blob], "identity.png", { type: "image/png" });
+	const input = document.querySelector("input[data-identity-image-input]");
+	if (!input) return { error: "no identity input" };
+	const transfer = new DataTransfer();
+	transfer.items.add(file);
+	input.files = transfer.files;
+	input.dispatchEvent(new Event("change", { bubbles: true }));
+	for (let i = 0; i < 100; i += 1) {
+		const entry = window.__cozyclay.captureWithReferences().references.find((r) => r.role === "character");
+		if (entry && entry.dataUrl !== ${JSON.stringify(IDENTITY_PNG)}) {
+			const decoded = await createImageBitmap(await (await fetch(entry.dataUrl)).blob());
+			return { width: decoded.width, height: decoded.height, prefix: entry.dataUrl.slice(0, 22), bytes: entry.dataUrl.length };
+		}
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+	}
+	return { error: "the picked file never reached the slot" };
+})()`);
+expect("a picked file reaches the slot as a PNG data URL", picked?.prefix === "data:image/png;base64,", JSON.stringify(picked));
+expect("the stored picture is capped at 1024 px on the long side", picked?.width === 1024 && picked?.height === 512, JSON.stringify(picked));
+writeFileSync(`${out}/picked-reference.json`, JSON.stringify(picked, null, 2));
+
+const pane = await evaluate(`(() => { const node = document.querySelector(".inspector-pane"); if (!node) return null; const r = node.getBoundingClientRect(); return { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) }; })()`);
+const shot = await send("Page.captureScreenshot", pane ? { format: "png", clip: { ...pane, scale: 2 } } : { format: "png" });
+writeFileSync(`${out}/inspector.png`, Buffer.from(shot.data, "base64"));
+expect("the inspector screenshot has bytes", Buffer.from(shot.data, "base64").byteLength > 2000);
+
+expect("browser run has no uncaught page errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+ws.close();
+if (failures) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log(`PASS reference slots — ${references.length} references on the capture, evidence in ${out}`);

--- a/test/verify-agent-image-references.mjs
+++ b/test/verify-agent-image-references.mjs
@@ -1,0 +1,114 @@
+// /agent/image with scene references (#167). Boots the real route handler with
+// a fake codex client (same pattern as test/verify-agent-routes.mjs) and proves
+// three things: every reference reaches the backend as another attached image,
+// the prompt says what each attachment is for, and a reference that is not an
+// inline image is a 400 rather than something the backend has to sort out.
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { createAgentHandler, referenceGuidance } from "../bin/agent/agent-routes.mjs";
+import { createCodexClient } from "../bin/agent/codex-client.mjs";
+
+const png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+const jpeg = "data:image/jpeg;base64,/9j/4AAQSkZJRg==";
+
+const seen = [];
+const fakeCodex = {
+	parseQuotaHeaders: () => ({ planType: "Plus", primary: {}, credits: { hasCredits: true } }),
+	editImage: async (args) => { seen.push(args); return { pngBase64: png.split(",")[1], width: 1, height: 1 }; },
+};
+
+let server;
+const handler = createAgentHandler({
+	auth: { getAccessToken: async () => "token" },
+	codex: fakeCodex,
+	liveHub: { command: async () => ({}) },
+	handlers: [],
+	port: () => server.address().port,
+});
+server = createServer((req, res) => handler(req, res).catch((error) => { res.writeHead(500); res.end(error.message); }));
+server.listen(0, "127.0.0.1");
+await once(server, "listening");
+const { port } = server.address();
+const post = (body) => fetch(`http://127.0.0.1:${port}/agent/image`, {
+	method: "POST",
+	headers: { "content-type": "application/json", origin: `http://127.0.0.1:${port}` },
+	body: JSON.stringify(body),
+});
+
+/* --- the happy path --------------------------------------------------------- */
+
+const references = [
+	{ role: "character", name: "Alpha", dataUrl: png },
+	{ role: "character", name: "Beta", dataUrl: jpeg },
+	{ role: "environment", dataUrl: png },
+];
+const withReference = await post({ prompt: "golden hour", imageDataUrl: png, referenceDataUrl: jpeg, references });
+assert.equal(withReference.status, 200, "a request with references is accepted");
+const call = seen.at(-1);
+assert.equal(call.extraImages.length, references.length, "every reference is forwarded to the client");
+assert.deepEqual(call.extraImages, references.map((entry) => entry.dataUrl), "references keep their order");
+assert.ok(call.prompt.includes("Character Alpha"), `prompt names the character: ${call.prompt}`);
+assert.ok(call.prompt.includes("Character Beta"), "prompt names every character");
+assert.ok(call.prompt.includes("Environment:"), "prompt describes the environment reference");
+assert.ok(call.prompt.includes("Geometry, camera and blocking come from the first image (the clay frame)."), "the clay frame keeps the geometry");
+assert.ok(call.prompt.startsWith("golden hour"), "the node's own prompt still leads");
+
+// What the codex client actually attaches: frame + reference + the references.
+const attached = [call.imageDataUrl, call.referenceDataUrl, ...call.extraImages].filter(Boolean);
+assert.equal(attached.length, 1 + 1 + references.length, `images length = 1 + referenceDataUrl + references (${attached.length})`);
+
+// Without a referenceDataUrl the count drops by exactly one.
+await post({ prompt: "golden hour", imageDataUrl: png, references: [references[0]] });
+const bare = seen.at(-1);
+assert.equal([bare.imageDataUrl, bare.referenceDataUrl, ...bare.extraImages].filter(Boolean).length, 1 + 0 + 1);
+
+// No references at all: the prompt is untouched and nothing extra is attached.
+await post({ prompt: "golden hour", imageDataUrl: png });
+assert.equal(seen.at(-1).prompt, "golden hour", "an unreferenced shot sends the prompt as written");
+assert.deepEqual(seen.at(-1).extraImages, []);
+
+/* --- rejections ------------------------------------------------------------- */
+
+const before = seen.length;
+assert.equal((await post({ prompt: "x", imageDataUrl: png, references: [{ role: "character", name: "Alpha", dataUrl: "https://example.com/a.png" }] })).status, 400, "a remote reference URL is rejected");
+assert.equal((await post({ prompt: "x", imageDataUrl: png, references: [{ role: "environment", dataUrl: "data:text/plain;base64,aGk=" }] })).status, 400, "a non-image data URL is rejected");
+assert.equal((await post({ prompt: "x", imageDataUrl: png, references: [{ name: "Alpha", dataUrl: png }] })).status, 400, "a reference without a role is rejected");
+assert.equal((await post({ prompt: "x", imageDataUrl: png, references: png })).status, 400, "references must be a list");
+assert.equal((await post({ prompt: "x", imageDataUrl: png, references: Array.from({ length: 7 }, () => ({ role: "character", dataUrl: png })) })).status, 400, "at most six references");
+assert.equal(seen.length, before, "a rejected request never reaches the backend");
+
+/* --- the guidance itself ---------------------------------------------------- */
+
+assert.equal(referenceGuidance([]), "", "no references, no appended guidance");
+assert.equal(
+	referenceGuidance([{ role: "character", name: "Alpha", dataUrl: png }, { role: "environment", dataUrl: png }]),
+	"\nGeometry, camera and blocking come from the first image (the clay frame)."
+	+ "\nCharacter Alpha: match the identity, face, hair and wardrobe from the attached character sheet."
+	+ "\nEnvironment: take the location look, materials, palette and lighting from the attached environment reference.",
+);
+
+/* --- what the backend finally receives -------------------------------------- */
+
+// The route hands `extraImages` to the client; the client is what turns them
+// into the images[] the backend reads, frame first.
+{
+	const calls = [];
+	const client = createCodexClient({
+		getAccessToken: async () => "t",
+		getAccountId: async () => "a",
+		fetch: async (url, init) => { calls.push({ url, body: JSON.parse(init.body) }); return new Response(JSON.stringify({ data: [{ b64_json: png.split(",")[1] }] }), { status: 200, headers: { "content-type": "application/json" } }); },
+	});
+	await client.editImage({ prompt: "p", imageDataUrl: png, referenceDataUrl: jpeg, extraImages: references.map((entry) => entry.dataUrl) });
+	assert.deepEqual(
+		calls[0].body.images,
+		[png, jpeg, ...references.map((entry) => entry.dataUrl)].map((image_url) => ({ image_url })),
+		"the clay frame leads, then the reference image, then the scene references",
+	);
+	await client.editImage({ prompt: "p", imageDataUrl: png });
+	assert.deepEqual(calls[1].body.images, [{ image_url: png }], "no references, one image");
+}
+
+server.close();
+await handler.close();
+console.log("PASS /agent/image references: forwarded as extra images, described in the prompt, validated");

--- a/test/verify-agent-routes.mjs
+++ b/test/verify-agent-routes.mjs
@@ -58,6 +58,13 @@ assert.equal(calls[0][0].content[0].text.includes(png), false);
 	await post({ prompt: "x", imageDataUrl: png, referenceDataUrl: png }, refServer.address().port);
 	assert.equal(seen[0].referenceDataUrl, png, "the reference image reaches codex");
 	assert.equal(seen[0].prompt, "x", "without a scene to describe, the prompt is sent as written");
+	// Scene reference slots (#167) attach after the frame/reference pair and are
+	// named in the prompt. test/verify-agent-image-references.mjs covers the
+	// validation matrix; this pins that the shipped route carries them at all.
+	await post({ prompt: "x", imageDataUrl: png, referenceDataUrl: png, references: [{ role: "character", name: "Alpha", dataUrl: png }, { role: "environment", dataUrl: png }] }, refServer.address().port);
+	assert.equal([seen[1].imageDataUrl, seen[1].referenceDataUrl, ...seen[1].extraImages].filter(Boolean).length, 4, "frame + reference + two scene references");
+	assert.ok(seen[1].prompt.includes("Character Alpha"), seen[1].prompt);
+	assert.equal((await post({ prompt: "x", imageDataUrl: png, references: [{ role: "character", dataUrl: "data:text/plain;base64,aGk=" }] }, refServer.address().port)).status, 400, "a reference that is not an image is rejected");
 	refServer.close();
 	const guided = [];
 	const guideLive = { ...fakeLive, connected: true, workspaceHandleDetails: () => [{ handle: "w", meta: { commands: ["capture_framing_png", "import_asset"] } }], resolveWorkspace: () => "w" };
@@ -66,7 +73,7 @@ assert.equal(calls[0][0].content[0].text.includes(png), false);
 	await post({ prompt: "golden hour", imageDataUrl: png }, guideServer.address().port);
 	assert.equal(guided[0], "golden hour\n[image] medium shot, 24mm, subject faces camera (golden hour)", "scene guidance is appended to the node prompt like render_from_frame does");
 	guideServer.close();
-	console.log("PASS /agent/image: full-size frame accepted, validation, reference forwarded");
+	console.log("PASS /agent/image: full-size frame accepted, validation, reference and scene references forwarded");
 }
 {
 	// Attaching the frame captures through the sidecar's internal tool even though

--- a/test/verify-reference-slots.mjs
+++ b/test/verify-reference-slots.mjs
@@ -1,0 +1,58 @@
+// Reference slots (#167): the cast member's identity image and the stage's
+// environment reference live in the scene document, so they must survive a
+// save/load round trip and must never hold anything but inline image bytes —
+// a file:// or http:// path would break the moment the project moves.
+import assert from "node:assert/strict";
+import {
+	createCharacterEntry,
+	createSceneStage,
+	normalizeReferenceImage,
+	readSceneDocument,
+	SCENES_VERSION,
+	serializeSceneDocument,
+} from "../src/scenes.js";
+
+const png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+const jpeg = "data:image/jpeg;base64,/9j/4AAQSkZJRg==";
+
+/* --- the character slot ---------------------------------------------------- */
+
+assert.equal(createCharacterEntry(null, 0).identityImage, null, "a fresh cast member has no identity image");
+assert.equal(createCharacterEntry({ identityImage: png }, 0).identityImage, png, "a PNG data URL is kept");
+assert.equal(createCharacterEntry({ identityImage: jpeg }, 0).identityImage, jpeg, "a JPEG data URL is kept");
+for (const bad of ["https://example.com/face.png", "file:///tmp/face.png", "data:text/plain;base64,aGk=", "", 42, {}, [], true, null, undefined]) {
+	assert.equal(createCharacterEntry({ identityImage: bad }, 0).identityImage, null, `rejected: ${JSON.stringify(bad)}`);
+}
+assert.equal(normalizeReferenceImage(png), png);
+assert.equal(normalizeReferenceImage("data:video/mp4;base64,AAA"), null, "only images are references");
+
+/* --- the stage slot -------------------------------------------------------- */
+
+assert.equal(createSceneStage().environmentImage, null, "a fresh stage has no environment reference");
+assert.equal(createSceneStage({ environmentImage: png }).environmentImage, png);
+assert.equal(createSceneStage({ environmentImage: "https://example.com/set.png" }).environmentImage, null, "a remote URL is not a stored reference");
+
+/* --- persistence ----------------------------------------------------------- */
+
+const stage = createSceneStage({
+	characters: [{ id: "char-a", subject: "Alpha", identityImage: png }, { id: "char-b", subject: "Beta" }],
+	environmentImage: jpeg,
+});
+const document = { version: SCENES_VERSION, activeSceneId: "s1", scenes: [{ id: "s1", name: "SCENE 01", objects: [], shotDocument: null, stage }] };
+const read = readSceneDocument(serializeSceneDocument(document));
+assert.equal(read.status, "valid");
+const loaded = read.document.scenes[0].stage;
+assert.equal(loaded.characters[0].identityImage, png, "the identity image survives save/load");
+assert.equal(loaded.characters[1].identityImage, null, "an empty slot stays empty");
+assert.equal(loaded.environmentImage, jpeg, "the environment reference survives save/load like shotAspect");
+
+// An older document has neither field; loading it must not invent one.
+const legacy = readSceneDocument(JSON.stringify({
+	version: SCENES_VERSION,
+	activeSceneId: "s1",
+	scenes: [{ id: "s1", name: "SCENE 01", objects: [], shotDocument: null, stage: { characters: [{ id: "char-a" }], shotAspect: "16:9" } }],
+}));
+assert.equal(legacy.document.scenes[0].stage.characters[0].identityImage, null);
+assert.equal(legacy.document.scenes[0].stage.environmentImage, null);
+
+console.log("PASS reference slots: identityImage / environmentImage validated and persisted");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -43,6 +43,7 @@ const NODE_FILES = [
 	"test/process/verify-lifecycle.mjs",
 	"test/process/verify-mcp-package-isolation.mjs",
 	"test/process/verify-package-telemetry.mjs",
+	"test/verify-agent-image-references.mjs",
 	"test/verify-agent-panel.mjs",
 	"test/verify-agent-routes.mjs",
 	"test/verify-canvas-commands.mjs",
@@ -121,6 +122,7 @@ const NODE_FILES = [
 	"test/verify-scene-asset-cache.mjs",
 	"test/verify-scene-assets.mjs",
 	"test/verify-scene-objects.mjs",
+	"test/verify-reference-slots.mjs",
 	"test/verify-scenes.mjs",
 	"test/verify-cozy-scene-node.mjs",
 	"test/verify-motion-input.mjs",
@@ -175,13 +177,14 @@ const BROWSER_FILES = [
 	"test/verify-offscreen-export-browser.mjs",
 	"test/verify-project-menu-browser.mjs",
 	"test/qa-keyframe-pack-browser.mjs",
+	"test/qa-reference-slots-browser.mjs",
 	"test/qa-send-to-ai-browser.mjs",
 ];
 
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-send-to-ai-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-send-to-ai-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
Every cast member now has an **Identity image** and the stage has an **Environment reference**. Both are stored inside the scene document as data URLs, so they survive save/load exactly like an Upload node's image, and both ride along with every framing capture into image generation.

## What changed

**Data (`src/scenes.js`)**
- `createCharacterEntry` gains `identityImage: string|null`, validated through the new `normalizeReferenceImage` — a value is kept only when it is a string starting with `data:image/`, otherwise it is `null`. A remote URL is deliberately refused: it would break the moment the project moves.
- The stage envelope gains `environmentImage: string|null`, persisted like `shotAspect` (default, envelope key, `createSceneStage` validation).

**UI (`src/App.jsx`, `src/styles.css`)**
- One `ReferenceImageField` control serves both slots: thumbnail-as-picker, `Choose image`/`Replace`, `Clear`, and an inline error line. It lives in the character inspector's Pose panel (right beside "Pose from photo", which reads a *shape* off a picture where this keeps the picture itself) and in the Environment panel.
- A picked file is read with `FileReader` as a data URL, then capped at **1024 px** on the long side through a canvas (`readReferenceImage`), keeping JPEG as JPEG.
- Styling uses the existing token scale (`--card2`, `--line2`, `--muted`, `--fast`, `.btn.ghost`, `.inspector-hint`) — no new colours or magic numbers; the slot buttons only reset `.btn.ghost`'s full-width behaviour.
- Studio state: startup value, setter, save/load and the project snapshot all carry `environmentImage`.

**Capture (`src/App.jsx`)**
- `shotCaptureMeta` is untouched. Both capture paths — the live `capture_framing_png` command and the embed `cozyclay:capture-framing-result` message — now also return `references: [{ role: "character", name, dataUrl }, ..., { role: "environment", dataUrl }]`. Only slots that hold a picture appear; a hidden cast member never contributes.

**Workflow (`src/workflow/WorkflowBuilder.jsx`, `src/workflow/agent-client.js`)**
- The Scene node stores `lastOutput.references` (both the Run path and the single-node capture).
- The image-generation branch reads them from the upstream Scene node (this run's capture first, else the stored one) and sends `references` alongside `referenceDataUrl`; `agent-client.image()` passes the array through.

**Server (`bin/agent/agent-routes.mjs`, `bin/agent/codex-client.mjs`)**
- `/agent/image` accepts optional `references: [{ role, name?, dataUrl }]` — each `dataUrl` must start with `data:image/`, at most 6 — and answers **400** otherwise.
- `codex.editImage` gains `extraImages: string[]`, appended after `referenceDataUrl` in `images[]`.
- The prompt gets the composed guidance appended: `Geometry, camera and blocking come from the first image (the clay frame).`, then per character `Character <name>: match the identity, face, hair and wardrobe from the attached character sheet.`, then for the environment `Environment: take the location look, materials, palette and lighting from the attached environment reference.`

## How this was verified

**Unit + route tests** (new files registered in `tools/run-tests.mjs`)

```
$ node test/verify-reference-slots.mjs
PASS reference slots: identityImage / environmentImage validated and persisted

$ node test/verify-agent-image-references.mjs
PASS /agent/image references: forwarded as extra images, described in the prompt, validated

$ node test/verify-agent-routes.mjs | head -1
PASS /agent/image: full-size frame accepted, validation, reference and scene references forwarded
```

`test/verify-agent-image-references.mjs` boots the real route handler with a fake codex client and asserts the attached image count is `1 + (referenceDataUrl ? 1 : 0) + references.length`, that the prompt contains `Character Alpha`, that a non-image reference / a missing role / a non-array / a 7th reference are each 400 and never reach the backend, and — through the real `createCodexClient` — that `images[]` is frame, reference, then the scene references in order.

**Browser QA** — `QA_URL=http://127.0.0.1:5330/app/ CDP_PORT=9467 node tools/qa-browser.mjs -- node test/qa-reference-slots-browser.mjs`

```
PASS the studio comes up with the reference-slot hooks
PASS a non-image value is refused by the slot
PASS the slots survive a React commit
PASS the capture is a PNG with the shot's delivery size
PASS the capture still carries its shot metadata
PASS the capture carries a character reference
PASS the character reference is named after the subject
PASS the character reference carries the identity picture
PASS the capture carries an environment reference
PASS the environment reference carries the environment picture
PASS the two slots hold different pictures
PASS clearing the identity slot drops its reference
PASS the character's Pose panel opens
PASS the Identity image slot is in the character inspector
PASS the slot shows the picked picture as a thumbnail
PASS the slot offers Replace and Clear once it holds a picture
PASS a picked file reaches the slot as a PNG data URL
PASS the stored picture is capped at 1024 px on the long side
PASS the inspector screenshot has bytes
PASS browser run has no uncaught page errors
PASS reference slots — 2 references on the capture, evidence in /tmp/reference-slots-qa
```

The QA hooks it drives are new on `window.__cozyclay`: `setCharacterIdentityImage(index, dataUrl)`, `setEnvironmentImage(dataUrl)` and `captureWithReferences()` (returns exactly what the live `capture_framing_png` command returns). It also drives the real `<input type="file">` with a generated 2048x1024 PNG and reads the stored picture back: 1024x512, `data:image/png;base64,` — the FileReader + downscale path, not the hook.

`/tmp/reference-slots-qa/capture.json` (references section):

```json
[
 { "role": "character", "name": "Alpha in a tan coat", "dataUrl": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" },
 { "role": "environment", "dataUrl": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" }
]
```

Evidence paths: `/tmp/reference-slots-qa/capture.json`, `/tmp/reference-slots-qa/inspector.png` (character inspector with the Identity thumbnail), `/tmp/reference-slots-qa/picked-reference.json`, plus `/tmp/reference-slots-qa/environment-inspector.png` from a supplementary look at the Environment panel.

**Full suite** — rebased onto `f3f60f9` (PR #176) and re-run: `NO_COLOR=1 npm test` → **EXIT 0**, last 15 lines:

```
PASS playback storage events announce cross-tab controls
PASS playback event name is stable

verify-workflow-scene-asset-sync: all green

RUNNING test/verify-zip-store.mjs
PASS crc32: known vectors for 'hello', the empty sequence, and the quick brown fox
PASS buildZip: unzip -t accepts the archive
  Archive:  /var/folders/.../cozyclay-zip-store-IFXnEJ/pack.zip
      testing: notes/....txt            OK
      testing: frame.png                OK
  No errors detected in compressed data of .../pack.zip.
PASS zip-store: crc32 vectors, structure, and unzip -t on a written archive

PASS 157 Node verification files
```

157 runnable files now, up from 156 — #176's `test/verify-keyframe-pack-request.mjs` is included in the run. `npm run build` also succeeds, and the browser QA above was re-run against the rebased tree (21/21 PASS).

### Rebase note

The only conflict was `tools/run-tests.mjs`, where #176 added `test/qa-send-to-ai-browser.mjs` to the same two lists this branch touches. Both entries are kept, in `BROWSER_FILES` and in `EXTRA_INVENTORY`:

```js
	"test/qa-keyframe-pack-browser.mjs",
	"test/qa-reference-slots-browser.mjs",
	"test/qa-send-to-ai-browser.mjs",
];
...
const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-send-to-ai-browser.mjs"];
```

`node --check tools/run-tests.mjs` passes and the manifest lists both suites as browser EXCLUDEs.

Closes #167
