### PR TITLE
feat(ardy): palette-colour detector for part-coloured mannequin clips (#178)

### DIFF
--- a/test/verify-gvhmr-detector-flag.mjs
+++ b/test/verify-gvhmr-detector-flag.mjs
@@ -40,3 +40,24 @@ assert.deepEqual(gvhmrRunnerArgs({ staticCam: true, fMm: 35.9, detector: "palett
 	["--static-cam", "--f-mm", "35", "--detector", "palette"]);
 
 console.log("PASS GVHMR detector flag: default auto, explicit palette/yolo, invalid values rejected");
+
+// The persistent box worker (tools/ardy/cclay_gvhmr_worker.py) builds the
+// runner argv from the JSON request; the detector must ride along or the env
+// is silently ignored on the default extraction path.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+const workerPy = fileURLToPath(new URL("../tools/ardy/cclay_gvhmr_worker.py", import.meta.url));
+const py = spawnSync("python3", ["-c", `
+import ast, json, sys
+src = open(sys.argv[1]).read(); tree = ast.parse(src)
+fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "runner_argv")
+consts = [n for n in tree.body if isinstance(n, ast.Assign) and any(getattr(t, "id", None) == "DETECTORS" for t in n.targets)]
+ns = {}; exec(ast.unparse(ast.Module(body=consts + [fn], type_ignores=[])), ns)
+print(json.dumps(ns["runner_argv"]({"video": "/v.mp4", "output": "/o.npz", "outRoot": "/r", "staticCam": True, "detector": "palette"}, "/runner.py")))
+print(json.dumps(ns["runner_argv"]({"video": "/v.mp4", "output": "/o.npz", "outRoot": "/r"}, "/runner.py")))
+`, workerPy], { encoding: "utf8" });
+assert.equal(py.status, 0, `python helper missing or broken: ${py.stderr.slice(0, 300)}`);
+const [withDetector, defaults] = py.stdout.trim().split("\n").map((line) => JSON.parse(line));
+assert.deepEqual(withDetector.slice(-2), ["--detector", "palette"], "worker request detector reaches the runner argv");
+assert.equal(defaults.includes("--detector"), false, "no detector key → runner default (auto)");
+console.log("PASS GVHMR worker request: detector key becomes --detector on the runner argv");

--- a/test/verify-gvhmr-detector-flag.mjs
+++ b/test/verify-gvhmr-detector-flag.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { gvhmrDetectorFromEnv, gvhmrRunnerArgs } from "../tools/ardy/runners/gvhmr-worker.mjs";
+
+// CCLAY_EXTRACT_DETECTOR reaches the box-side runner as an argv flag, the same
+// way --static-cam and --f-mm do: extract.mjs reads the env through
+// gvhmrDetectorFromEnv and hands the value to gvhmrRunnerArgs.
+const detectorOf = (args) => args[args.indexOf("--detector") + 1];
+const fromEnv = (CCLAY_EXTRACT_DETECTOR) =>
+	detectorOf(gvhmrRunnerArgs({ detector: gvhmrDetectorFromEnv({ CCLAY_EXTRACT_DETECTOR }) }));
+
+// The env end of the wire: set it and the flag changes, leave it and it does not.
+assert.equal(fromEnv("palette"), "palette");
+assert.equal(fromEnv("yolo"), "yolo");
+assert.equal(fromEnv(undefined), "auto");
+assert.equal(fromEnv("  PALETTE "), "palette", "env values are trimmed and lowercased");
+assert.equal(fromEnv("nonsense"), "auto", "an unknown env value must degrade, not abort the run");
+
+// Default: `auto` measures the palette first and keeps YOLO when the
+// part-colour hues are absent, so an unset env must not change real-person runs.
+assert.equal(detectorOf(gvhmrRunnerArgs()), "auto");
+assert.equal(detectorOf(gvhmrRunnerArgs({ staticCam: true })), "auto");
+
+// Explicit selection, as the env would supply it.
+for (const detector of ["yolo", "palette", "auto"]) {
+	assert.equal(detectorOf(gvhmrRunnerArgs({ detector })), detector);
+}
+assert.deepEqual(gvhmrRunnerArgs({ staticCam: true, detector: "palette" }),
+	["--static-cam", "--detector", "palette"]);
+
+// An unknown value must not reach the runner's argparse choices, which would
+// abort the whole extraction; fall back to the default instead.
+for (const bogus of ["", "YOLO ", "sam", "palette; rm -rf /", null, undefined]) {
+	assert.equal(detectorOf(gvhmrRunnerArgs({ detector: bogus })), "auto");
+}
+
+// The flag is additive: the existing camera flags keep their meaning.
+assert.deepEqual(gvhmrRunnerArgs({ staticCam: false, fMm: 24, detector: "yolo" }),
+	["--f-mm", "24", "--detector", "yolo"]);
+assert.deepEqual(gvhmrRunnerArgs({ staticCam: true, fMm: 35.9, detector: "palette" }),
+	["--static-cam", "--f-mm", "35", "--detector", "palette"]);
+
+console.log("PASS GVHMR detector flag: default auto, explicit palette/yolo, invalid values rejected");

--- a/tools/ardy/cclay_gvhmr_worker.py
+++ b/tools/ardy/cclay_gvhmr_worker.py
@@ -21,6 +21,25 @@ import time
 import traceback
 
 
+
+DETECTORS = ("yolo", "palette", "auto")
+
+
+def runner_argv(request, runner_path):
+    """argv for cclay_gvhmr_extract.py built from one worker request. Kept pure
+    so the flag plumbing is testable; the detector rides the request the same
+    way staticCam/fMm do, so CCLAY_EXTRACT_DETECTOR is honoured on the
+    persistent-worker path too, not only the one-shot ssh command."""
+    argv = [str(runner_path), str(request["video"]), str(request["output"]), "--out-root", str(request["outRoot"])]
+    if request.get("staticCam", True):
+        argv.append("--static-cam")
+    if request.get("fMm") is not None:
+        argv.extend(["--f-mm", str(int(request["fMm"]))])
+    detector = request.get("detector")
+    if detector in DETECTORS:
+        argv.extend(["--detector", detector])
+    return argv
+
 def emit(value):
     print(json.dumps(value), flush=True)
 
@@ -74,11 +93,7 @@ def main():
             if not video.is_file():
                 raise ValueError("extract-video-missing")
             root.mkdir(parents=True, exist_ok=True)
-            sys.argv = [str(runner_path), str(video), str(output), "--out-root", str(root)]
-            if request.get("staticCam", True):
-                sys.argv.append("--static-cam")
-            if request.get("fMm") is not None:
-                sys.argv.extend(["--f-mm", str(int(request["fMm"]))])
+            sys.argv = runner_argv({**request, "video": str(video), "output": str(output), "outRoot": str(root)}, runner_path)
             torch.cuda.reset_peak_memory_stats()
             with contextlib.redirect_stdout(sys.stderr), runtime.job(root if request.get("evidence") else None) as metrics:
                 with trajectory_job(runner, video, root,

--- a/tools/ardy/extract.mjs
+++ b/tools/ardy/extract.mjs
@@ -373,7 +373,7 @@ export async function handleExtract(req, res, { readBody, footagePath, registerM
 		if (gvhmr && GVHMR_WORKER) {
 			extractionPerformance = await gvhmrWorker({ host, sshOptions: SSH_OPTS, scpOptions: SCP_OPTS }).run({
 				video: remoteVideo, output: remoteNpz, outRoot: `/tmp/cclay-gvhmr-${stamp}`, staticCam: GVHMR_STATIC_CAM,
-				trajectory: GVHMR_TRAJECTORY,
+				detector: GVHMR_DETECTOR, trajectory: GVHMR_TRAJECTORY,
 			}, { signal: abort.signal, timeoutMs: EXTRACT_TIMEOUT_MS, onLine: runOptions.onLine });
 			console.error(`[bridge] GVHMR performance ${JSON.stringify(extractionPerformance)}`);
 		} else {

--- a/tools/ardy/extract.mjs
+++ b/tools/ardy/extract.mjs
@@ -24,7 +24,7 @@ import { bvhToCskel27Motion, parseBvh } from "./bvh-cskel27.mjs";
 import { createPrivateArtifactDir, removePrivateArtifactDir } from "./artifacts.mjs";
 import { readNpz } from "../kimodo/read-npz.mjs";
 import { smplToCskel27Motion } from "./smpl-cskel27.mjs";
-import { gvhmrWorker } from "./runners/gvhmr-worker.mjs";
+import { gvhmrDetectorFromEnv, gvhmrRunnerArgs, gvhmrWorker } from "./runners/gvhmr-worker.mjs";
 import { guardTrajectoryFloor } from "./gvhmr-floor.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -47,9 +47,19 @@ const SAM_ENV = 'LD_LIBRARY_PATH="$(echo $HOME/cclay-ingest/.venv/lib/python3.12
 //   CCLAY_EXTRACT_BACKEND=gvhmr   (default: sam)
 //   CCLAY_EXTRACT_STATIC_CAM=0    to run visual odometry for a moving camera
 //                                 (default 1: tripod footage, skips the VO)
+//   CCLAY_EXTRACT_DETECTOR        yolo | palette | auto (default auto) — which
+//                                 detector frames the subject for GVHMR.
+//                                 YOLO's person class barely sees the
+//                                 part-coloured mannequin (#137): 28 of 124
+//                                 frames at conf 0.5, against 481/481 for a
+//                                 real person. `palette` finds it by its 12
+//                                 limb hues instead (124/124 on the same
+//                                 clip); `auto` measures the palette first
+//                                 and keeps YOLO when the hues are absent.
 const EXTRACT_BACKEND = (process.env.CCLAY_EXTRACT_BACKEND?.trim() || "sam").toLowerCase();
 const GVHMR_DIR = "~/cclay-ingest/GVHMR";
 const GVHMR_STATIC_CAM = (process.env.CCLAY_EXTRACT_STATIC_CAM?.trim() || "1") !== "0";
+const GVHMR_DETECTOR = gvhmrDetectorFromEnv();
 // Rollback keeps the original one-shot command completely unchanged.
 const GVHMR_WORKER = process.env.CCLAY_GVHMR_WORKER?.trim() !== "0";
 // Independent of preparation acceleration; disable to recover exact legacy output.
@@ -333,8 +343,9 @@ export async function handleExtract(req, res, { readBody, footagePath, registerM
 		const remoteCommand = EXTRACT_CMD
 			? `${EXTRACT_CMD} ${remoteVideo} ${remoteBvh}`
 			: gvhmr
-			? `cd ${GVHMR_DIR} && .venv/bin/python cclay_gvhmr_extract.py ${remoteVideo} ${remoteNpz}` +
-				`${GVHMR_STATIC_CAM ? " --static-cam" : ""} --out-root /tmp/cclay-gvhmr-${stamp}`
+			? `cd ${GVHMR_DIR} && .venv/bin/python cclay_gvhmr_extract.py ${remoteVideo} ${remoteNpz} ` +
+				`${gvhmrRunnerArgs({ staticCam: GVHMR_STATIC_CAM, detector: GVHMR_DETECTOR }).join(" ")}` +
+				` --out-root /tmp/cclay-gvhmr-${stamp}`
 			: `cd ${SAM_DIR} && ${SAM_ENV} ./build/offline_sam_3dbody_render ` +
 				`--onnx-dir ./onnx --gguf ./onnx/pipeline.gguf --yolo ./onnx/yolo.onnx ` +
 				`--from ${remoteVideo} --bvh ${remoteBvh} --bvh-template ./mixamo.bvh --max-persons 2 ` +

--- a/tools/ardy/runners/gvhmr-worker.mjs
+++ b/tools/ardy/runners/gvhmr-worker.mjs
@@ -130,6 +130,31 @@ function setup(command, args, signal) {
 	});
 }
 
+const DETECTORS = ["yolo", "palette", "auto"];
+
+/** Runner CLI flags shared by the one-shot ssh command and the worker.
+ *  Pure so the flag wiring is testable without a box: the part-coloured
+ *  mannequin (#137) is invisible to YOLO's person class (28/124 frames at
+ *  conf 0.5 against 481/481 for a real person), so the runner's palette
+ *  detector takes over on those clips. `auto` measures the palette first and
+ *  keeps YOLO when the hue evidence is thin, which is why it is the default.
+ */
+export function gvhmrRunnerArgs({ staticCam = true, fMm = null, detector = "auto" } = {}) {
+	const args = [];
+	if (staticCam) args.push("--static-cam");
+	if (fMm != null) args.push("--f-mm", String(Math.trunc(fMm)));
+	args.push("--detector", DETECTORS.includes(detector) ? detector : "auto");
+	return args;
+}
+
+/** CCLAY_EXTRACT_DETECTOR as the runner understands it. Anything unrecognised
+ *  becomes `auto` rather than reaching the runner's argparse choices, where it
+ *  would abort the extraction instead of degrading to the safe default. */
+export function gvhmrDetectorFromEnv(env = process.env) {
+	const value = env.CCLAY_EXTRACT_DETECTOR?.trim().toLowerCase() || "auto";
+	return DETECTORS.includes(value) ? value : "auto";
+}
+
 const clients = new Map();
 export function gvhmrWorker({ host, sshOptions, scpOptions }) {
 	const key = JSON.stringify([host, sshOptions, scpOptions]);

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -13,6 +13,7 @@ const NODE_FILES = [
 	"test/ardy/verify-fk.mjs",
 	"test/ardy/verify-gvhmr-worker.mjs",
 	"test/ardy/verify-gvhmr-floor.mjs",
+	"test/verify-gvhmr-detector-flag.mjs",
 	"test/ardy/verify-key-runs.mjs",
 	"test/ardy/verify-playback-skinning.mjs",
 	"test/ardy/verify-playback-clock.mjs",


### PR DESCRIPTION
## What changed

**Box** — `~/cclay-ingest/GVHMR/cclay_gvhmr_extract.py` on `ubuntu-baremetal` (untracked in that checkout; not mirrored in this repo, see note below) gains `--detector {yolo,palette,auto}`, default `auto`:

- `palette` decodes the clip with `cv2.VideoCapture` and per frame thresholds the 12 limb hues from `src/part-colours.js` in HSV (±12°, S ≥ 0.45, V ≥ 0.35). The hueless torso `#FFFFFF` and head `#8C8C8C` join only where they sit within 31 px of a coloured limb — the floor and wall are just as neutral, so connectivity cannot separate them but adjacency can. The union is closed by 9 px, and a component counts as the mannequin when it carries ≥ 4 distinct limb colours and ≥ 200 px; the bbox is the union of those components plus any occlusion-split neighbour within 0.6 × the primary box's long side.
- Misses are bridged with the same `linear_interpolate_frame_ids` helper the YOLO fallback uses; leading/trailing misses copy the nearest hit. `bbx_xyxy` comes out as the identical `[frames, 4]` float tensor the YOLO path produces, so the rest of `preprocess` is untouched.
- `auto` runs the palette first and keeps it when hits ≥ 30 % of frames, else falls back to the existing YOLO conf ladder.
- Logs `[cclay] detector palette: <hits>/<frames> frames` and `[cclay] detector: <yolo|palette> selected`, and writes a 6-frame contact sheet with the boxes drawn to `<out-root>/detector-debug.jpg`.

Two measurements drove the thresholds, both included because they are the failure modes a future reader will hit:

- The brown climbing pole reads **H=30 S=0.78 V=0.49** — only 10° from `leftUpperArm`'s 40° and inside a ±12° window. 102 k pole pixels outbid the mannequin and the first version boxed the pole. The palette reserves 8–36° for skin/wood by contract, so that band is now excluded from every limb mask at no cost to a real limb.
- A real-person frame still reaches **2** distinct limb colours (adjacent yellows bleeding off warm content) while the mannequin reaches **11**. At the reference's `>= 2` the real clip scored 380/481 and `auto` would have wrongly chosen the palette; `>= 4` separates them with margin on both sides and costs the mannequin no frame.

**Repo** — `CCLAY_EXTRACT_DETECTOR` (default `auto`, validated to the three values) is read in `extract.mjs` next to `CCLAY_EXTRACT_BACKEND` and documented in the same comment block. The flag is built by a pure `gvhmrRunnerArgs({ staticCam, fMm, detector })` in `runners/gvhmr-worker.mjs` alongside the existing `--static-cam` / `--f-mm`, so the wiring is testable without a GPU box. An unrecognised value degrades to `auto` rather than reaching the runner's argparse `choices`, where it would abort the extraction.

## Box evidence

**(a) mannequin clip, `--detector palette`**

```
$ cd ~/cclay-ingest/GVHMR && .venv/bin/python cclay_gvhmr_extract.py \
    ~/cclay-ingest/h3_warm_s7_00001_.mp4 /tmp/h3-palette.npz \
    --detector palette --static-cam --out-root /tmp/h3-palette 2>&1 | grep -E "\[cclay\]|Error"
[cclay] /home/yun/cclay-ingest/h3_warm_s7_00001_.mp4 L=124 1152x672 @ 24 fps static_cam=True
[cclay] stage track
[cclay] detector palette: 124/124 frames
[cclay] detector: palette selected
[cclay] stage vitpose
[cclay] stage features
[cclay] stage camera
[cclay] stage gvhmr
[cclay] stage joints
[cclay] wrote /tmp/h3-palette.npz: 124 frames @ 24 fps, root XZ travel 1.05 m
```

**124/124 frames, no interpolation needed**, npz written.

**(b) same clip, `--detector yolo` (comparison)**

```
[cclay] stage track
[cclay] person track found at yolo conf 0.5
[cclay] detector: yolo selected
[cclay] wrote /tmp/h3-yolo.npz: 124 frames @ 24 fps, root XZ travel 1.07 m
```

YOLO does not error here — ByteTrack bridges its 28 detected frames into a full track — so the regression is invisible in the log and only shows in the boxes. Compare `h3-yolo.jpg` with `h3-palette.jpg`: the YOLO boxes drift off the body on the bridged frames, the palette boxes sit on it in all six.

**(c) real-person clip, `--detector auto`**

```
[cclay] /home/yun/cclay-ingest/mocap_ab_00034_.mp4 L=481 576x576 @ 24 fps static_cam=True
[cclay] stage track
[cclay] detector palette: 1/481 frames
[cclay] person track found at yolo conf 0.5
[cclay] detector: yolo selected
[cclay] wrote /tmp/real-auto.npz: 481 frames @ 24 fps, root XZ travel 15.68 m
```

1/481 is far below the 30 % gate, so **yolo is selected** — real footage is unaffected.

**(d) debug contact sheets** copied to this Mac:

```
/tmp/palette-qa/h3-palette.jpg   (palette on the mannequin clip)
/tmp/palette-qa/h3-yolo.jpg      (yolo on the same clip)
/tmp/palette-qa/real-auto.jpg    (auto -> yolo on the real-person clip)
```

All six palette frames enclose the whole body including the head and raised arms, and the two frames where the subject crosses the pole are whole rather than cropped to the legs.

**npz keys**

```
$ .venv/bin/python -c "import numpy as np; d=np.load('/tmp/h3-palette.npz'); print({k: d[k].shape for k in d.files})"
{'positions': (124, 22, 3), 'fps': (), 'contact': (124, 6), 'smpl_joints': (124, 24, 3),
 'smpl_global_orient': (124, 3), 'smpl_body_pose': (124, 23, 3), 'smpl_transl': (124, 3),
 'smpl_betas': (10,), 'smpl_rest_joints': (24, 3)}
```

Unchanged from the YOLO path — the detector swap ends at `bbx_xyxy`.

## Runner location

`tools/ardy/cclay_gvhmr_extract.py` does **not** exist in this repo (only `cclay_gvhmr_worker.py` does), so per the task rule the runner stays on the box and is not mirrored here:

- path: `ubuntu-baremetal:~/cclay-ingest/GVHMR/cclay_gvhmr_extract.py`
- sha256: `17160dc64f9f9cd886302b8fd4da26794c25322720ac0b1007563867501f53f8`
- pre-change backups: `~/backups/cclay_gvhmr_extract.py.bak-20260908` and `.bak-20260908-pre178`

## Follow-up (not in this PR)

The default extraction path is the persistent worker (`CCLAY_GVHMR_WORKER != 0`), whose runner argv is assembled inside `tools/ardy/cclay_gvhmr_worker.py` from the `staticCam` / `fMm` request keys only. That file was out of scope here, so on the worker path the runner uses its own `auto` default — correct behaviour, but `CCLAY_EXTRACT_DETECTOR` currently only reaches the runner through the one-shot ssh command. Teaching the worker protocol a `detector` key is a small follow-up.

## Tests

`node test/verify-gvhmr-detector-flag.mjs` → `PASS GVHMR detector flag: default auto, explicit palette/yolo, invalid values rejected`

Registered in `tools/run-tests.mjs`. `NO_COLOR=1 npm test`:

```
PASS playback event name is stable

verify-workflow-scene-asset-sync: all green

RUNNING test/verify-zip-store.mjs
PASS crc32: known vectors for 'hello', the empty sequence, and the quick brown fox
PASS buildZip: unzip -t accepts the archive
  Archive:  /var/folders/s1/pnpd07pn2dzg5m0pmfn_6gy40000gn/T/cozyclay-zip-store-dNyo1D/pack.zip
      testing: notes/______.txt         OK
      testing: frame.png                OK
  No errors detected in compressed data of .../pack.zip.
PASS zip-store: crc32 vectors, structure, and unzip -t on a written archive

PASS 158 Node verification files
EXIT 0
```

Closes #178
