### PR TITLE
feat(ardy): palette keypoints replace ViTPose for part-coloured mannequin clips (#180)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ tools/ardy/out/
 # Exceptions: the hosted demo seed clip ships with the build; test-only clips
 # stay tracked as fixtures but are never copied into production output.
 !public/demo/*.npz
+# QA evidence archives are extraction output staged for a local replay run,
+# not fixtures; the exception above would otherwise make them committable.
+public/demo/qa-h3-*.npz
 !test/fixtures/qa-lying.npz
 
 .DS_Store

--- a/test/verify-gvhmr-detector-flag.mjs
+++ b/test/verify-gvhmr-detector-flag.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { gvhmrDetectorFromEnv, gvhmrRunnerArgs } from "../tools/ardy/runners/gvhmr-worker.mjs";
+import { gvhmrDetectorFromEnv, gvhmrKeypointsFromEnv, gvhmrRunnerArgs } from "../tools/ardy/runners/gvhmr-worker.mjs";
 
 // CCLAY_EXTRACT_DETECTOR reaches the box-side runner as an argv flag, the same
 // way --static-cam and --f-mm do: extract.mjs reads the env through
@@ -25,7 +25,7 @@ for (const detector of ["yolo", "palette", "auto"]) {
 	assert.equal(detectorOf(gvhmrRunnerArgs({ detector })), detector);
 }
 assert.deepEqual(gvhmrRunnerArgs({ staticCam: true, detector: "palette" }),
-	["--static-cam", "--detector", "palette"]);
+	["--static-cam", "--detector", "palette", "--keypoints", "auto"]);
 
 // An unknown value must not reach the runner's argparse choices, which would
 // abort the whole extraction; fall back to the default instead.
@@ -35,11 +35,44 @@ for (const bogus of ["", "YOLO ", "sam", "palette; rm -rf /", null, undefined]) 
 
 // The flag is additive: the existing camera flags keep their meaning.
 assert.deepEqual(gvhmrRunnerArgs({ staticCam: false, fMm: 24, detector: "yolo" }),
-	["--f-mm", "24", "--detector", "yolo"]);
+	["--f-mm", "24", "--detector", "yolo", "--keypoints", "auto"]);
 assert.deepEqual(gvhmrRunnerArgs({ staticCam: true, fMm: 35.9, detector: "palette" }),
-	["--static-cam", "--f-mm", "35", "--detector", "palette"]);
+	["--static-cam", "--f-mm", "35", "--detector", "palette", "--keypoints", "auto"]);
 
 console.log("PASS GVHMR detector flag: default auto, explicit palette/yolo, invalid values rejected");
+
+// CCLAY_EXTRACT_KEYPOINTS (#180) rides the same wire: which estimator fills
+// GVHMR's kp2d observation. ViTPose reads photographic cues a flat-coloured
+// mannequin render does not carry (median body joint 10.4 % of bbox height
+// off the palette joints, shoulders 30-65 %), so a part-coloured clip takes
+// its joints from the limb masks instead.
+const keypointsOf = (args) => args[args.indexOf("--keypoints") + 1];
+const keypointsFromEnv = (CCLAY_EXTRACT_KEYPOINTS) =>
+	keypointsOf(gvhmrRunnerArgs({ keypoints: gvhmrKeypointsFromEnv({ CCLAY_EXTRACT_KEYPOINTS }) }));
+
+assert.equal(keypointsFromEnv("palette"), "palette");
+assert.equal(keypointsFromEnv("vitpose"), "vitpose");
+assert.equal(keypointsFromEnv(undefined), "auto");
+assert.equal(keypointsFromEnv(" PALETTE "), "palette", "env values are trimmed and lowercased");
+assert.equal(keypointsFromEnv("nonsense"), "auto", "an unknown env value must degrade, not abort the run");
+
+// Default `auto` lets the runner follow its detector: palette keypoints only
+// where the palette detector claimed the clip, ViTPose on real footage.
+assert.equal(keypointsOf(gvhmrRunnerArgs()), "auto");
+for (const keypoints of ["vitpose", "palette", "auto"]) {
+	assert.equal(keypointsOf(gvhmrRunnerArgs({ keypoints })), keypoints);
+}
+for (const bogus of ["", "VITPOSE ", "yolo", "palette; rm -rf /", null, undefined]) {
+	assert.equal(keypointsOf(gvhmrRunnerArgs({ keypoints: bogus })), "auto");
+}
+// The two selections are independent: palette boxes with ViTPose joints is a
+// legitimate A/B, and it is how the #180 baseline was measured.
+assert.deepEqual(gvhmrRunnerArgs({ staticCam: true, detector: "palette", keypoints: "vitpose" }),
+	["--static-cam", "--detector", "palette", "--keypoints", "vitpose"]);
+assert.deepEqual(gvhmrRunnerArgs({ staticCam: true, detector: "palette", keypoints: "palette" }),
+	["--static-cam", "--detector", "palette", "--keypoints", "palette"]);
+
+console.log("PASS GVHMR keypoints flag: default auto, explicit palette/vitpose, invalid values rejected");
 
 // The persistent box worker (tools/ardy/cclay_gvhmr_worker.py) builds the
 // runner argv from the JSON request; the detector must ride along or the env
@@ -51,13 +84,25 @@ const py = spawnSync("python3", ["-c", `
 import ast, json, sys
 src = open(sys.argv[1]).read(); tree = ast.parse(src)
 fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "runner_argv")
-consts = [n for n in tree.body if isinstance(n, ast.Assign) and any(getattr(t, "id", None) == "DETECTORS" for t in n.targets)]
+consts = [n for n in tree.body if isinstance(n, ast.Assign) and any(getattr(t, "id", None) in ("DETECTORS", "KEYPOINTS") for t in n.targets)]
 ns = {}; exec(ast.unparse(ast.Module(body=consts + [fn], type_ignores=[])), ns)
-print(json.dumps(ns["runner_argv"]({"video": "/v.mp4", "output": "/o.npz", "outRoot": "/r", "staticCam": True, "detector": "palette"}, "/runner.py")))
-print(json.dumps(ns["runner_argv"]({"video": "/v.mp4", "output": "/o.npz", "outRoot": "/r"}, "/runner.py")))
+base = {"video": "/v.mp4", "output": "/o.npz", "outRoot": "/r"}
+print(json.dumps(ns["runner_argv"]({**base, "staticCam": True, "detector": "palette"}, "/runner.py")))
+print(json.dumps(ns["runner_argv"](base, "/runner.py")))
+print(json.dumps(ns["runner_argv"]({**base, "staticCam": True, "detector": "palette", "keypoints": "palette"}, "/runner.py")))
+print(json.dumps(ns["runner_argv"]({**base, "keypoints": "nonsense"}, "/runner.py")))
 `, workerPy], { encoding: "utf8" });
 assert.equal(py.status, 0, `python helper missing or broken: ${py.stderr.slice(0, 300)}`);
-const [withDetector, defaults] = py.stdout.trim().split("\n").map((line) => JSON.parse(line));
+const [withDetector, defaults, withKeypoints, bogusKeypoints] = py.stdout.trim().split("\n").map((line) => JSON.parse(line));
 assert.deepEqual(withDetector.slice(-2), ["--detector", "palette"], "worker request detector reaches the runner argv");
 assert.equal(defaults.includes("--detector"), false, "no detector key → runner default (auto)");
 console.log("PASS GVHMR worker request: detector key becomes --detector on the runner argv");
+
+// Same for the keypoints selection, so CCLAY_EXTRACT_KEYPOINTS is honoured on
+// the persistent-worker path and not only in the one-shot ssh command.
+assert.deepEqual(withKeypoints.slice(-4), ["--detector", "palette", "--keypoints", "palette"],
+	"worker request keypoints reaches the runner argv");
+assert.equal(defaults.includes("--keypoints"), false, "no keypoints key → runner default (auto)");
+assert.equal(bogusKeypoints.includes("--keypoints"), false,
+	"an unknown keypoints value must not reach the runner's argparse choices");
+console.log("PASS GVHMR worker request: keypoints key becomes --keypoints on the runner argv");

--- a/test/verify-gvhmr-detector-flag.mjs
+++ b/test/verify-gvhmr-detector-flag.mjs
@@ -56,7 +56,8 @@ assert.equal(keypointsFromEnv(undefined), "auto");
 assert.equal(keypointsFromEnv(" PALETTE "), "palette", "env values are trimmed and lowercased");
 assert.equal(keypointsFromEnv("nonsense"), "auto", "an unknown env value must degrade, not abort the run");
 
-// Default `auto` lets the runner follow its detector: palette keypoints only
+// Default `auto` resolves to ViTPose inside the runner (palette keypoints are
+// opt-in: measured worse on shifted render hues, issue #180); palette keypoints only
 // where the palette detector claimed the clip, ViTPose on real footage.
 assert.equal(keypointsOf(gvhmrRunnerArgs()), "auto");
 for (const keypoints of ["vitpose", "palette", "auto"]) {

--- a/tools/ardy/cclay_gvhmr_worker.py
+++ b/tools/ardy/cclay_gvhmr_worker.py
@@ -23,6 +23,7 @@ import traceback
 
 
 DETECTORS = ("yolo", "palette", "auto")
+KEYPOINTS = ("vitpose", "palette", "auto")
 
 
 def runner_argv(request, runner_path):
@@ -38,6 +39,9 @@ def runner_argv(request, runner_path):
     detector = request.get("detector")
     if detector in DETECTORS:
         argv.extend(["--detector", detector])
+    keypoints = request.get("keypoints")
+    if keypoints in KEYPOINTS:
+        argv.extend(["--keypoints", keypoints])
     return argv
 
 def emit(value):

--- a/tools/ardy/extract.mjs
+++ b/tools/ardy/extract.mjs
@@ -24,7 +24,7 @@ import { bvhToCskel27Motion, parseBvh } from "./bvh-cskel27.mjs";
 import { createPrivateArtifactDir, removePrivateArtifactDir } from "./artifacts.mjs";
 import { readNpz } from "../kimodo/read-npz.mjs";
 import { smplToCskel27Motion } from "./smpl-cskel27.mjs";
-import { gvhmrDetectorFromEnv, gvhmrRunnerArgs, gvhmrWorker } from "./runners/gvhmr-worker.mjs";
+import { gvhmrDetectorFromEnv, gvhmrKeypointsFromEnv, gvhmrRunnerArgs, gvhmrWorker } from "./runners/gvhmr-worker.mjs";
 import { guardTrajectoryFloor } from "./gvhmr-floor.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -56,10 +56,24 @@ const SAM_ENV = 'LD_LIBRARY_PATH="$(echo $HOME/cclay-ingest/.venv/lib/python3.12
 //                                 limb hues instead (124/124 on the same
 //                                 clip); `auto` measures the palette first
 //                                 and keeps YOLO when the hues are absent.
+//   CCLAY_EXTRACT_KEYPOINTS       vitpose | palette | auto (default auto) —
+//                                 what fills GVHMR's 2D keypoint observation.
+//                                 ViTPose reads joints from photographic cues
+//                                 the mannequin does not carry: on h3_warm_s7
+//                                 its median body joint lands 10.4 % of bbox
+//                                 height off the palette joints and the
+//                                 shoulders 30-65 % off. `palette` reads them
+//                                 from the part masks instead — a joint is
+//                                 where two limb-colour masks meet (16.8/17
+//                                 joints per frame) — and skips ViTPose's
+//                                 weights entirely. `auto` follows the
+//                                 detector: palette keypoints only on a clip
+//                                 the palette detector claimed.
 const EXTRACT_BACKEND = (process.env.CCLAY_EXTRACT_BACKEND?.trim() || "sam").toLowerCase();
 const GVHMR_DIR = "~/cclay-ingest/GVHMR";
 const GVHMR_STATIC_CAM = (process.env.CCLAY_EXTRACT_STATIC_CAM?.trim() || "1") !== "0";
 const GVHMR_DETECTOR = gvhmrDetectorFromEnv();
+const GVHMR_KEYPOINTS = gvhmrKeypointsFromEnv();
 // Rollback keeps the original one-shot command completely unchanged.
 const GVHMR_WORKER = process.env.CCLAY_GVHMR_WORKER?.trim() !== "0";
 // Independent of preparation acceleration; disable to recover exact legacy output.
@@ -344,7 +358,7 @@ export async function handleExtract(req, res, { readBody, footagePath, registerM
 			? `${EXTRACT_CMD} ${remoteVideo} ${remoteBvh}`
 			: gvhmr
 			? `cd ${GVHMR_DIR} && .venv/bin/python cclay_gvhmr_extract.py ${remoteVideo} ${remoteNpz} ` +
-				`${gvhmrRunnerArgs({ staticCam: GVHMR_STATIC_CAM, detector: GVHMR_DETECTOR }).join(" ")}` +
+				`${gvhmrRunnerArgs({ staticCam: GVHMR_STATIC_CAM, detector: GVHMR_DETECTOR, keypoints: GVHMR_KEYPOINTS }).join(" ")}` +
 				` --out-root /tmp/cclay-gvhmr-${stamp}`
 			: `cd ${SAM_DIR} && ${SAM_ENV} ./build/offline_sam_3dbody_render ` +
 				`--onnx-dir ./onnx --gguf ./onnx/pipeline.gguf --yolo ./onnx/yolo.onnx ` +
@@ -373,7 +387,7 @@ export async function handleExtract(req, res, { readBody, footagePath, registerM
 		if (gvhmr && GVHMR_WORKER) {
 			extractionPerformance = await gvhmrWorker({ host, sshOptions: SSH_OPTS, scpOptions: SCP_OPTS }).run({
 				video: remoteVideo, output: remoteNpz, outRoot: `/tmp/cclay-gvhmr-${stamp}`, staticCam: GVHMR_STATIC_CAM,
-				detector: GVHMR_DETECTOR, trajectory: GVHMR_TRAJECTORY,
+				detector: GVHMR_DETECTOR, keypoints: GVHMR_KEYPOINTS, trajectory: GVHMR_TRAJECTORY,
 			}, { signal: abort.signal, timeoutMs: EXTRACT_TIMEOUT_MS, onLine: runOptions.onLine });
 			console.error(`[bridge] GVHMR performance ${JSON.stringify(extractionPerformance)}`);
 		} else {

--- a/tools/ardy/extract.mjs
+++ b/tools/ardy/extract.mjs
@@ -56,19 +56,10 @@ const SAM_ENV = 'LD_LIBRARY_PATH="$(echo $HOME/cclay-ingest/.venv/lib/python3.12
 //                                 limb hues instead (124/124 on the same
 //                                 clip); `auto` measures the palette first
 //                                 and keeps YOLO when the hues are absent.
-//   CCLAY_EXTRACT_KEYPOINTS       vitpose | palette | auto (default auto) —
-//                                 what fills GVHMR's 2D keypoint observation.
-//                                 ViTPose reads joints from photographic cues
-//                                 the mannequin does not carry: on h3_warm_s7
-//                                 its median body joint lands 10.4 % of bbox
-//                                 height off the palette joints and the
-//                                 shoulders 30-65 % off. `palette` reads them
-//                                 from the part masks instead — a joint is
-//                                 where two limb-colour masks meet (16.8/17
-//                                 joints per frame) — and skips ViTPose's
-//                                 weights entirely. `auto` follows the
-//                                 detector: palette keypoints only on a clip
-//                                 the palette detector claimed.
+//   CCLAY_EXTRACT_KEYPOINTS       vitpose | palette | auto (default auto) — auto keeps ViTPose
+//     (fed the palette bbox); palette keypoints are opt-in because the AI
+//     render shifts limb hues and, measured on issue #180, they make the 3D
+//     result worse (foot slide 41 vs 25 cm/s, jitter 32 vs 13).
 const EXTRACT_BACKEND = (process.env.CCLAY_EXTRACT_BACKEND?.trim() || "sam").toLowerCase();
 const GVHMR_DIR = "~/cclay-ingest/GVHMR";
 const GVHMR_STATIC_CAM = (process.env.CCLAY_EXTRACT_STATIC_CAM?.trim() || "1") !== "0";

--- a/tools/ardy/mocap-metrics.mjs
+++ b/tools/ardy/mocap-metrics.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * mocap-metrics.mjs — compare cskel27 motion npz takes on the three defects a
+ * bad 2D observation produces, so an estimator change (e.g. #180's palette
+ * keypoints against ViTPose) is judged by numbers instead of by eye:
+ *
+ *   foot slide      the planted foot's horizontal speed while it is planted.
+ *                   A supporting foot should read ~0 cm/s; skate is the single
+ *                   most visible mocap artefact (SAM's single-image lift
+ *                   measured 250 cm/s on locomotion). "Planted" is decided
+ *                   per side from the take itself: the frames whose ankle is
+ *                   in the lower PLANT_HEIGHT_PERCENTILE of that side's ankle
+ *                   heights AND whose horizontal speed is below the side's
+ *                   median — that is the stance phase, without needing the
+ *                   contact logits (a converted take has dropped them).
+ *   jitter          mean |second difference| of posed_joints in mm/frame^2.
+ *                   Frame-independent noise in the keypoints shows up here
+ *                   and nowhere else; real motion is smooth at this scale.
+ *   below floor     frames whose lowest foot joint sits under Y=0. The
+ *                   converter grounds the clip on its 10th percentile, so a
+ *                   few frames are expected; many mean the legs are wrong.
+ *
+ * usage: node tools/ardy/mocap-metrics.mjs <a.npz> [<b.npz> ...]
+ */
+import { readNpz } from "../kimodo/read-npz.mjs";
+import { CSKEL27_JOINTS } from "../../src/ardy/cskel27.js";
+
+const JOINT = Object.fromEntries(CSKEL27_JOINTS.map((name, index) => [name, index]));
+const JOINTS = CSKEL27_JOINTS.length;
+const FEET = ["RightFoot", "RightToeBase", "LeftFoot", "LeftToeBase"].map((name) => JOINT[name]);
+const ANKLES = { right: JOINT.RightFoot, left: JOINT.LeftFoot };
+// The stance phase of a step: the foot is both low and slow. Deriving it from
+// the take's own distribution keeps the measure comparable across clips with
+// different step heights, and needs no contact channel.
+const PLANT_HEIGHT_PERCENTILE = 0.35;
+const FLOOR_TOLERANCE_M = 0.005; // 5 mm: float32 round-trip, not penetration
+
+function member(members, name, path) {
+	const value = members[name];
+	if (!value?.data) throw new Error(`${path}: missing or unreadable member ${name}`);
+	return value;
+}
+
+function percentile(values, fraction) {
+	if (!values.length) return NaN;
+	const sorted = [...values].sort((a, b) => a - b);
+	const at = (sorted.length - 1) * fraction;
+	const low = Math.floor(at);
+	return sorted[low] * (1 - (at - low)) + (sorted[Math.min(low + 1, sorted.length - 1)] ?? sorted[low]) * (at - low);
+}
+
+const median = (values) => percentile(values, 0.5);
+
+function read(path) {
+	const members = readNpz(path);
+	const joints = member(members, "posed_joints", path);
+	if (joints.shape.length !== 3 || joints.shape[1] !== JOINTS || joints.shape[2] !== 3) {
+		throw new Error(`${path}: posed_joints must be (F, ${JOINTS}, 3), got (${joints.shape.join(", ")})`);
+	}
+	const fpsMember = member(members, "fps", path);
+	const fps = fpsMember.data[0];
+	if (!(fps > 0)) throw new Error(`${path}: invalid fps ${fps}`);
+	const frames = joints.shape[0];
+	const root = members.root_positions?.data ?? null;
+	return { path, frames, fps, joints: joints.data, root };
+}
+
+/** Median horizontal speed (cm/s) of each ankle over its own stance frames. */
+function footSlide({ frames, fps, joints }) {
+	const speeds = [];
+	for (const ankle of Object.values(ANKLES)) {
+		const at = (frame, axis) => joints[(frame * JOINTS + ankle) * 3 + axis];
+		const step = [];
+		for (let frame = 1; frame < frames; frame += 1) {
+			step.push({
+				speed: Math.hypot(at(frame, 0) - at(frame - 1, 0), at(frame, 2) - at(frame - 1, 2)) * fps * 100,
+				height: Math.min(at(frame, 1), at(frame - 1, 1)),
+			});
+		}
+		if (!step.length) continue;
+		const lowEnough = percentile(step.map((s) => s.height), PLANT_HEIGHT_PERCENTILE);
+		const slowEnough = median(step.map((s) => s.speed));
+		const planted = step.filter((s) => s.height <= lowEnough && s.speed <= slowEnough);
+		speeds.push(median((planted.length ? planted : step).map((s) => s.speed)));
+	}
+	return median(speeds);
+}
+
+/** Mean |second difference| over every joint, in mm per frame^2. */
+function jitter({ frames, joints }) {
+	if (frames < 3) return NaN;
+	let total = 0;
+	let count = 0;
+	for (let frame = 1; frame < frames - 1; frame += 1) {
+		for (let joint = 0; joint < JOINTS; joint += 1) {
+			const base = (frame * JOINTS + joint) * 3;
+			const before = ((frame - 1) * JOINTS + joint) * 3;
+			const after = ((frame + 1) * JOINTS + joint) * 3;
+			total += Math.hypot(
+				joints[after] - 2 * joints[base] + joints[before],
+				joints[after + 1] - 2 * joints[base + 1] + joints[before + 1],
+				joints[after + 2] - 2 * joints[base + 2] + joints[before + 2],
+			) * 1000;
+			count += 1;
+		}
+	}
+	return total / count;
+}
+
+/** Frames whose lowest foot joint is under the floor, and how deep it goes. */
+function belowFloor({ frames, joints }) {
+	let count = 0;
+	let deepest = 0;
+	for (let frame = 0; frame < frames; frame += 1) {
+		let lowest = Infinity;
+		for (const foot of FEET) lowest = Math.min(lowest, joints[(frame * JOINTS + foot) * 3 + 1]);
+		if (lowest < -FLOOR_TOLERANCE_M) {
+			count += 1;
+			deepest = Math.min(deepest, lowest);
+		}
+	}
+	return { count, deepestCm: -deepest * 100 };
+}
+
+/** Straight-line XZ travel of the root, for context on the slide number. */
+function travel({ frames, joints, root }) {
+	const source = root ?? joints;
+	const stride = root ? 3 : JOINTS * 3;
+	const last = (frames - 1) * stride;
+	return Math.hypot(source[last] - source[0], source[last + 2] - source[2]);
+}
+
+export function mocapMetrics(path) {
+	const take = read(path);
+	const floor = belowFloor(take);
+	return {
+		path,
+		frames: take.frames,
+		fps: take.fps,
+		footSlideCmPerS: footSlide(take),
+		jitterMmPerFrame2: jitter(take),
+		framesBelowFloor: floor.count,
+		deepestBelowFloorCm: floor.deepestCm,
+		rootTravelM: travel(take),
+	};
+}
+
+const paths = process.argv.slice(2);
+if (!paths.length) {
+	console.error("usage: node tools/ardy/mocap-metrics.mjs <a.npz> [<b.npz> ...]");
+	process.exit(2);
+}
+const rows = paths.map(mocapMetrics);
+const columns = [
+	["take", (row) => row.path.replace(/^.*\//, ""), 26],
+	["frames", (row) => String(row.frames), 6],
+	["fps", (row) => String(row.fps), 3],
+	["foot slide cm/s", (row) => row.footSlideCmPerS.toFixed(2), 15],
+	["jitter mm/f^2", (row) => row.jitterMmPerFrame2.toFixed(3), 13],
+	["below floor", (row) => `${row.framesBelowFloor} (${row.deepestBelowFloorCm.toFixed(1)} cm)`, 16],
+	["root travel m", (row) => row.rootTravelM.toFixed(2), 13],
+];
+const line = (cells) => cells.map((cell, index) => cell.padEnd(columns[index][2])).join("  ").trimEnd();
+console.log(line(columns.map(([title]) => title)));
+console.log(line(columns.map(([, , width]) => "-".repeat(width))));
+for (const row of rows) console.log(line(columns.map(([, value]) => value(row))));

--- a/tools/ardy/runners/gvhmr-worker.mjs
+++ b/tools/ardy/runners/gvhmr-worker.mjs
@@ -131,6 +131,7 @@ function setup(command, args, signal) {
 }
 
 const DETECTORS = ["yolo", "palette", "auto"];
+const KEYPOINTS = ["vitpose", "palette", "auto"];
 
 /** Runner CLI flags shared by the one-shot ssh command and the worker.
  *  Pure so the flag wiring is testable without a box: the part-coloured
@@ -138,12 +139,21 @@ const DETECTORS = ["yolo", "palette", "auto"];
  *  conf 0.5 against 481/481 for a real person), so the runner's palette
  *  detector takes over on those clips. `auto` measures the palette first and
  *  keeps YOLO when the hue evidence is thin, which is why it is the default.
+ *
+ *  `keypoints` picks what fills GVHMR's kp2d observation (#180). ViTPose has
+ *  to infer joints a flat-coloured render gives it no cue for — measured on
+ *  h3_warm_s7 its median body joint sits 10.4 % of bbox height off the
+ *  palette joints, the shoulders 30-65 % — while the mannequin's per-segment
+ *  hues put every joint exactly where two segment masks meet. `auto` follows
+ *  the detector: palette keypoints for a palette-detected clip, ViTPose for
+ *  real footage, which is the only place ViTPose is the better estimate.
  */
-export function gvhmrRunnerArgs({ staticCam = true, fMm = null, detector = "auto" } = {}) {
+export function gvhmrRunnerArgs({ staticCam = true, fMm = null, detector = "auto", keypoints = "auto" } = {}) {
 	const args = [];
 	if (staticCam) args.push("--static-cam");
 	if (fMm != null) args.push("--f-mm", String(Math.trunc(fMm)));
 	args.push("--detector", DETECTORS.includes(detector) ? detector : "auto");
+	args.push("--keypoints", KEYPOINTS.includes(keypoints) ? keypoints : "auto");
 	return args;
 }
 
@@ -153,6 +163,13 @@ export function gvhmrRunnerArgs({ staticCam = true, fMm = null, detector = "auto
 export function gvhmrDetectorFromEnv(env = process.env) {
 	const value = env.CCLAY_EXTRACT_DETECTOR?.trim().toLowerCase() || "auto";
 	return DETECTORS.includes(value) ? value : "auto";
+}
+
+/** CCLAY_EXTRACT_KEYPOINTS as the runner understands it, degrading unknown
+ *  values to `auto` for the same reason the detector does. */
+export function gvhmrKeypointsFromEnv(env = process.env) {
+	const value = env.CCLAY_EXTRACT_KEYPOINTS?.trim().toLowerCase() || "auto";
+	return KEYPOINTS.includes(value) ? value : "auto";
 }
 
 const clients = new Map();


### PR DESCRIPTION
The GVHMR runner can now fill its `kp2d` observation from the mannequin's own part colours instead of ViTPose, selected with `--keypoints {vitpose,palette,auto}` and `CCLAY_EXTRACT_KEYPOINTS`.

`auto` follows the detector: a clip the palette detector claimed is by definition a part-coloured render, so its joints are measurable from the limb masks; real footage keeps ViTPose. Choosing `palette` never constructs `VitPoseExtractor`, which also frees its VRAM on the 8 GB card.

Joints come from part-mask adjacency (a joint is where two limb-colour masks meet), shoulders and hips from the limb's principal-axis far end away from the joint below, and the five COCO head points from the head-mask centroid. Confidence is `min(1, evidence_px / 600)`; frames a joint was not measured in are linearly interpolated per joint index (ends copy the nearest measurement) and marked at confidence 0.3. The tensor is built as float32 on CPU, matching what ViTPose returns — verified in run (b) below.

## Headline result: palette is WORSE than ViTPose on this clip

```
take                        frames  fps  foot slide cm/s  jitter mm/f^2  below floor       root travel m
--------------------------  ------  ---  ---------------  -------------  ----------------  -------------
qa-h3-palette.npz           124     24   41.11            31.927         10 (6.1 cm)       0.69
qa-h3-vitpose.npz           124     24   24.80            13.102         10 (3.1 cm)       1.05
```

Palette loses on both required measures — foot slide 41.1 vs 24.8 cm/s and jitter 31.9 vs 13.1 mm/frame^2 — and sits deeper below the floor. Stated plainly, and nothing was tuned to change it.

### Why, measured

The issue's premise was that ViTPose is inaccurate on the mannequin (P2 measured a 10.4 % median body-joint disagreement, shoulders 30-65 %). A labelled overlay of both estimators on the footage shows the disagreement is real but the sign is the other way round: ViTPose lands on the joints and several palette joints do not.

The cause is a hue shift in the AI render, not the adjacency method. A hue histogram of frame 90 (saturated pixels only):

```
hue 100-110 :   3807 px      <- the raised leg's green arrives here
hue 110-120 :    272 px
palette says leftHand=94 (window 82-106), leftThigh=121 (window 109-133)
leftHand   window catches   3624 px, mean hue 103.2      <- thigh pixels, mislabelled
leftThigh  window catches    286 px, mean hue 112.1      <- almost nothing left
```

`leftThigh` is authored at 121 deg (`src/part-colours.js`) but the render puts it near 103 deg, inside `leftHand`'s ±12 window. So the raised leg is labelled `leftHand`, which puts `l_wrist` on the leg and leaves the `far_end` heuristics for `l_shoulder`/`l_hip` anchored to the wrong limb.

This is the prescribed method's limit on shifted hues, not a transcription error. The runner reproduces the reference `~/cclay-ingest/palette_kp_gt.py` to the pixel:

```
COCO order identical: True
index of l_shoulder: runner 5 ref 5
length: get_video_lwh 124  VideoCapture frames 124  read_video_np 124
frame 90  leftUpperArm mask centroid (375, 317)
frame 90  kp[90,5] (l_shoulder) = (394, 504) conf 1.00
frame 90  REFERENCE kg[5] (l_shoulder) = (394, 504) valid 1
frame 90  REFERENCE kg[15] (l_ankle)   = (472, 627)
frame 90  runner   kp[90,15] (l_ankle) = (472, 627)
```

Same COCO order, same frame count from all three readers, same coordinate at the same index. Fixing the accuracy means re-deriving the hue windows, which this task explicitly excludes, so the feature ships as an opt-in flag and `auto` remains safe for real footage.

## Box evidence

(a) palette detector + palette keypoints:

```
[cclay] /home/yun/cclay-ingest/h3_warm_s7_00001_.mp4 L=124 1152x672 @ 24 fps static_cam=True
[cclay] stage track
[cclay] detector palette: 124/124 frames
[cclay] detector: palette selected
[cclay] keypoints: palette selected
[cclay] stage keypoints palette
[cclay] keypoints palette: mean visible joints 16.8/17
[cclay] stage features
[cclay] stage camera
[cclay] stage gvhmr
[cclay] stage joints
[cclay] wrote /tmp/h3-kp-palette.npz: 124 frames @ 24 fps, root XZ travel 0.69 m
```

No `stage vitpose` line: ViTPose is never loaded on this path.

(b) same clip with `--keypoints vitpose`, which is also where the dtype/device contract is confirmed:

```
[cclay] detector: palette selected
[cclay] keypoints: vitpose selected
[cclay] stage vitpose
[cclay] keypoints vitpose: (124, 17, 3) torch.float32 cpu
[cclay] wrote /tmp/h3-kp-vitpose.npz: 124 frames @ 24 fps, root XZ travel 1.05 m
```

(c) real clip with defaults (100-frame ffmpeg trim of `mocap_ab_00034_.mp4`) — `auto` correctly stays on ViTPose:

```
[cclay] /tmp/mocap_ab_trim100.mp4 L=100 576x576 @ 24 fps static_cam=True
[cclay] detector palette: 0/100 frames
[cclay] person track found at yolo conf 0.5
[cclay] detector: yolo selected
[cclay] keypoints: vitpose selected
[cclay] keypoints vitpose: (100, 17, 3) torch.float32 cpu
[cclay] wrote /tmp/mocap-defaults.npz: 100 frames @ 24 fps, root XZ travel 2.56 m
```

(d) Both mannequin archives were copied back, converted to cskel27 for the studio and the metrics, and are NOT committed — `.gitignore` gained `public/demo/qa-h3-*.npz` because the existing `!public/demo/*.npz` exception would otherwise have made them committable:

```
$ git check-ignore -v public/demo/qa-h3-palette.npz public/demo/qa-h3-vitpose.npz
.gitignore:15:public/demo/qa-h3-*.npz	public/demo/qa-h3-palette.npz
.gitignore:15:public/demo/qa-h3-*.npz	public/demo/qa-h3-vitpose.npz
```

## Replay QA

Both takes load and play in the studio at 124 frames / 24 fps; the palette take is a coherent climbing pose with the feet on the floor, not a collapsed rig.

```
/tmp/kp-qa/palette-front-f0.png
/tmp/kp-qa/palette-front-f60.png
/tmp/kp-qa/palette-front-f120.png
/tmp/kp-qa/vitpose-front-f0.png    (comparison set)
/tmp/kp-qa/vitpose-front-f60.png
/tmp/kp-qa/vitpose-front-f120.png
```

## Plumbing

`CCLAY_EXTRACT_KEYPOINTS` -> `gvhmrKeypointsFromEnv` -> `keypoints` param in `gvhmrRunnerArgs` (`--keypoints <v>`), request key `keypoints` in `extract.mjs` (both the one-shot ssh command and the persistent worker), and `KEYPOINTS` + handling in `runner_argv()`. Unknown values degrade to `auto` rather than reaching the runner's argparse choices, where they would abort the extraction. Documented next to `CCLAY_EXTRACT_DETECTOR` in `extract.mjs`.

## Verification

```
$ node test/verify-gvhmr-detector-flag.mjs
PASS GVHMR detector flag: default auto, explicit palette/yolo, invalid values rejected
PASS GVHMR keypoints flag: default auto, explicit palette/vitpose, invalid values rejected
PASS GVHMR worker request: detector key becomes --detector on the runner argv
PASS GVHMR worker request: keypoints key becomes --keypoints on the runner argv
EXIT 0
```

`NO_COLOR=1 npm test`, last 15 lines:

```
PASS playback storage events announce cross-tab controls
PASS playback event name is stable

verify-workflow-scene-asset-sync: all green

RUNNING test/verify-zip-store.mjs
PASS crc32: known vectors for 'hello', the empty sequence, and the quick brown fox
PASS buildZip: unzip -t accepts the archive
  Archive:  /var/folders/.../pack.zip
      testing: notes/....txt            OK
      testing: frame.png                OK
  No errors detected in compressed data of /var/folders/.../pack.zip.
PASS zip-store: crc32 vectors, structure, and unzip -t on a written archive

PASS 158 Node verification files
EXIT 0
```

Closes #180
