### PR TITLE
fix: open Studio at the dev root

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ npm install
 npm run dev
 ```
 
-Open `http://127.0.0.1:5180/` for the Workflow canvas. The full Studio remains available at `http://127.0.0.1:5180/app/` through the Workflow `Open Studio` handoff. `npm run dev` starts the studio together with its local Kimodo bridge once `CCLAY_KIMODO_HOST` points at a GPU box; without that variable it starts the studio alone and says so, and Block Generation stays unavailable until you set it. `npm run dev:ui` starts the browser UI alone in every case. The bridge listens on loopback only; Kimodo host variables are documented in [`tools/kimodo/setup-on-box.sh`](tools/kimodo/setup-on-box.sh).
+Open `http://127.0.0.1:5180/` for the Studio. The Workflow canvas remains available at `http://127.0.0.1:5180/workflow/` when you need its node editor. `npm run dev` starts the studio together with its local Kimodo bridge once `CCLAY_KIMODO_HOST` points at a GPU box; without that variable it starts the studio alone and says so, and Block Generation stays unavailable until you set it. `npm run dev:ui` starts the browser UI alone in every case. The bridge listens on loopback only; Kimodo host variables are documented in [`tools/kimodo/setup-on-box.sh`](tools/kimodo/setup-on-box.sh).
 
 ### Workflow canvas
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -60,15 +60,15 @@ export default defineConfig({
 			configureServer(server) {
 				server.middlewares.use((req, res, next) => {
 					const path = (req.url || "").split("?")[0];
-					// Dev only: the root opens the Workflow canvas so local authoring
-					// starts there. The production root stays the crawlable landing
+					// Dev only: the root opens the Studio so a fresh checkout starts in
+					// the complete authoring surface. The production root stays the crawlable landing
 					// page at cozyclay.org; a redirect baked into index.html would
 					// hide it from every visitor and from search. /index.html still
 					// serves the landing so it can be previewed locally.
 					if (path === "/") {
 						const query = (req.url || "").slice(path.length);
 						res.statusCode = 302;
-						res.setHeader("location", `/workflow/${query}`);
+						res.setHeader("location", `/app/${query}`);
 						res.end();
 						return;
 					}


### PR DESCRIPTION
## Problem
A fresh clone opened the incomplete Workflow canvas at `/`, while the complete Studio lived at `/app/`.

## Change
- Redirect the Vite dev root from `/` to `/app/`.
- Keep `/workflow/` available as the explicit Workflow canvas route.
- Update clone quick-start documentation to match the new first screen.

## Validation
- `npm test` — PASS (158 Node verification files)
- `npm run test:analytics` — PASS
- Dev server: `GET /` returns `302 location: /app/`; `GET /app/` returns `200`
- Browser visual QA: Studio first-shot chooser rendered at `/app/`
- Production PostHog QA: SDK hook initialized; `$pageview` and `motion:backend_state` batches reached `https://t.cozyclay.org/e/` with HTTP 200
