### PR TITLE
release: v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.1
+
+- Open the complete Studio at the development server root; the unfinished
+  Workflow canvas remains available at `/workflow/`.
+
 ## 1.7.0
 
 Kimodo becomes the default motion-generation backend, and a full edit-and-refine

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cozyclay",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cozyclay",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "AGPL-3.0-or-later",
       "bin": {
         "cclay": "bin/cozyclay.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozyclay",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Open source previs software in the browser: block a scene, pose characters, author camera moves and cuts, then take the same shots to an AI video model.",
   "scripts": {
     "dev": "node tools/dev-full.mjs --host 127.0.0.1 --port 5180",


### PR DESCRIPTION
Release CozyClay v1.7.1.

- Studio opens at the development server root.
- Workflow remains available at /workflow/.
- npm package metadata and changelog updated.

Validation: npm test (158 verification files), package tarball signature check.
