### PR TITLE
feat(studio): add shared agent chat panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,6 +61,7 @@ import Timeline from "./ardy/timeline.jsx";
 import { alignArdyPath, judgeAuthoredPath, judgeNextWaypoint } from "./ardy/waypoints.js";
 import { FlyControls, aimAt, forwardFrom } from "./controls.jsx";
 import { createLiveControl } from "./live-control.js";
+import AgentPanel from "./workflow/AgentPanel.jsx";
 import HierarchyPanel from "./hierarchy-panel.jsx";
 import { PlanBoard } from "./planview.jsx";
 import { autoColorHex, loadAutoColor, saveAutoColor } from "./auto-color.js";
@@ -3073,6 +3074,11 @@ export default function App() {
 			window.removeEventListener("keydown", onKeyDown);
 		};
 	}, [viewMenuOpen]);
+	// The agent panel keeps owning its own collapsed flag (the rail button and
+	// Cmd/Ctrl+B both live inside it); the studio only mirrors the flag so the
+	// View ▾ item can render a checkmark. It boots collapsed here: the studio
+	// opens on the stage, not on a chat column.
+	const [agentCollapsed, setAgentCollapsed] = useState(true);
 	const projectHandleRef = useRef(null);
 	const projectSnapshotRef = useRef("");
 	const projectStateRef = useRef(null);
@@ -10626,6 +10632,26 @@ function resizePromptClip(id, edge, rawFrame) {
 											})}
 										</div>
 									)}
+									{/* Panel visibility belongs to the same menu (R4): the
+									    agent column is something you show, not a mode, so it
+									    gets a checkmark here instead of a topbar button. */}
+									{!embedMode && (
+										<div className="view-menu-group" role="group" aria-label={ko("Panels", "패널")}>
+											<span className="view-menu-label" aria-hidden="true">{ko("Panels", "패널")}</span>
+											<button
+												type="button"
+												role="menuitemcheckbox"
+												className={"view-menu-item agent-panel-toggle" + (agentCollapsed ? "" : " active")}
+												aria-checked={!agentCollapsed}
+												aria-pressed={!agentCollapsed}
+												title={ko("Show the agent chat column (Cmd/Ctrl+B)", "에이전트 채팅 열 표시 (Cmd/Ctrl+B)")}
+												onClick={() => window.dispatchEvent(new CustomEvent("cozyclay:agent-panel-toggle"))}
+											>
+												<span className="view-menu-mark" aria-hidden="true">{agentCollapsed ? "" : "✓"}</span>
+												{ko("Agent panel", "에이전트 패널")}
+											</button>
+										</div>
+									)}
 								</div>
 							)}
 						</div>
@@ -12974,6 +13000,13 @@ function resizePromptClip(id, edge, rawFrame) {
 						/>
 					)}
 				</aside>
+				{!embedMode && (
+					<AgentPanel
+						sceneName={scenes.find((entry) => entry.id === activeSceneId)?.name ?? ko("Untitled Scene", "제목 없는 씬")}
+						defaultCollapsed
+						onCollapsedChange={setAgentCollapsed}
+					/>
+				)}
 			</div>
 
 			<div

--- a/src/styles.css
+++ b/src/styles.css
@@ -1075,6 +1075,9 @@ select {
 .app[data-embed-mode="playview"] .bottom-window {
 	display: none;
 }
+.app[data-embed-mode="playview"] .agent-panel {
+	display: none;
+}
 .app[data-embed-mode="playview"] .main,
 .app[data-embed-mode="playview"] .workspace,
 .app[data-embed-mode="playview"] .viewport {

--- a/src/workflow/AgentPanel.jsx
+++ b/src/workflow/AgentPanel.jsx
@@ -101,11 +101,15 @@ function PausedCard({ resetAt, onRetry, onSwitchModel }) {
 	</div>;
 }
 
-export default function AgentPanel({ transport: injectedTransport = null, sceneName = "CozyClay Scene" }) {
+// `defaultCollapsed` + `onCollapsedChange` let a host mirror the panel's
+// visibility in its own chrome (the studio's View ▾ menu) without taking the
+// flag away from the panel: the rail button, Cmd/Ctrl+B and the toggle event
+// all still flip it here, and the host is told after every flip.
+export default function AgentPanel({ transport: injectedTransport = null, sceneName = "CozyClay Scene", defaultCollapsed = false, onCollapsedChange = null }) {
 	const transport = useMemo(() => injectedTransport || createAgentTransport(), [injectedTransport]);
 	const mockState = transport.mock ? transport.state : null;
 
-	const [collapsed, setCollapsed] = useState(false);
+	const [collapsed, setCollapsed] = useState(defaultCollapsed);
 	const [width, setWidth] = useState(readStoredPanelWidth);
 	const [resizing, setResizing] = useState(false);
 	const [menuOpen, setMenuOpen] = useState(false);
@@ -190,6 +194,10 @@ export default function AgentPanel({ transport: injectedTransport = null, sceneN
 		window.addEventListener("cozyclay:agent-panel-toggle", onToggle);
 		return () => window.removeEventListener("cozyclay:agent-panel-toggle", onToggle);
 	}, []);
+
+	useEffect(() => {
+		onCollapsedChange?.(collapsed);
+	}, [collapsed, onCollapsedChange]);
 
 	// Focus moves to the composer whenever the panel opens. The composer only
 	// mounts once the session resolves, so authState is a dependency too:

--- a/src/workflow/agent-panel.css
+++ b/src/workflow/agent-panel.css
@@ -8,11 +8,14 @@
  * as one surface. No component rule may hardcode a colour, radius or spacing
  * value: extend the token block instead. */
 
-.workflow-app {
+.workflow-app,
+.app {
 	--agent-width-default: 360px;
 	--agent-width-min: 300px;
 	--agent-width-max: 560px;
 	--agent-rail-width: 36px;
+	/* Top of the overlay drawer: the host's top bar height. */
+	--agent-drawer-top: 58px;
 
 	--agent-bg: #14161d;
 	--agent-bg-raised: #1a1d26;
@@ -54,6 +57,20 @@
 	--agent-dot: 6px;
 	--agent-shadow: 0 12px 34px #0006;
 	--agent-motion: 140ms ease;
+}
+
+/* The studio top bar is 48px where the workflow one is 58px, so the drawer
+ * hangs from a different line in the same rules. */
+.app {
+	--agent-drawer-top: 48px;
+}
+
+/* The studio keeps no collapsed rail. The builder can afford a permanent strip
+ * next to a canvas; the studio cannot — a rail button would spend one of the
+ * mode's visible controls (docs/studio-ui-ia.md R6) on chrome nobody asked
+ * for. View ▾ (and Cmd/Ctrl+B) is the way in, like every other panel. */
+.app .agent-panel.collapsed {
+	display: none;
 }
 
 /* --- shell ------------------------------------------------------------- */
@@ -673,7 +690,7 @@
 @media (max-width: 1100px) {
 	.agent-panel:not(.collapsed) {
 		position: fixed;
-		top: 58px;
+		top: var(--agent-drawer-top);
 		right: 0;
 		bottom: 0;
 		z-index: 20;
@@ -682,7 +699,7 @@
 
 	.agent-panel.collapsed {
 		position: fixed;
-		top: 58px;
+		top: var(--agent-drawer-top);
 		right: 0;
 		bottom: 0;
 		z-index: 20;

--- a/test/qa-agent-view-toggle-browser.mjs
+++ b/test/qa-agent-view-toggle-browser.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Browser QA for the studio's agent panel toggle (#184), driven over CDP
+// through tools/qa-browser.mjs:
+//
+//   QA_URL=http://127.0.0.1:5306/app/ CDP_PORT=9316 \
+//     node tools/qa-browser.mjs -- node test/qa-agent-view-toggle-browser.mjs
+//
+// The studio has no room for another top bar button (IA rule R4), so the panel
+// is shown from View ▾ like every other "what is on screen" toggle. This suite
+// proves the three things that contract is made of: the studio boots with the
+// panel collapsed and NO .agent-topbar-toggle in the top bar, the View ▾ item
+// expands it, and Cmd/Ctrl+B collapses it again with the menu's checkmark
+// following along. Screenshots land in QA_SHOT_DIR for the PR body.
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const port = Number(process.env.CDP_PORT || 9222);
+const shotDir = process.env.QA_SHOT_DIR || "/tmp/agent-view-toggle-qa";
+mkdirSync(shotDir, { recursive: true });
+
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+/** poll a page condition — every wait in this file is a state condition, never a delay */
+const waitFor = async (expression, timeoutMs = 15000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 60));
+	}
+	return false;
+};
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+async function shot(name) {
+	const { data } = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: false });
+	const file = `${shotDir}/${name}.png`;
+	writeFileSync(file, Buffer.from(data, "base64"));
+	console.log(`     screenshot ${file}`);
+	return file;
+}
+
+/* ---------------------------------------------------------- page setup --- */
+
+await waitFor("location.href.startsWith('http')", 30000);
+await evaluate("localStorage.setItem('cozyclay.locale', 'en')");
+await send("Page.enable");
+await send("Emulation.setDeviceMetricsOverride", { width: 1600, height: 950, deviceScaleFactor: 1, mobile: false });
+await send("Page.reload", { ignoreCache: false });
+expect("the studio comes back up", await waitFor("!!document.querySelector('.add-object-trigger')", 40000));
+expect("the hierarchy has rendered", await waitFor("document.querySelectorAll('.hierarchy-row-wrap').length > 0", 15000));
+
+const trigger = "document.querySelector('.view-menu-trigger')";
+const menu = "document.querySelector('.view-menu')";
+const item = "document.querySelector('.view-menu .agent-panel-toggle')";
+const panel = "document.querySelector('.agent-panel')";
+const collapsedFlag = `${panel}?.getAttribute('data-agent-collapsed')`;
+const openMenu = async () => {
+	if (!(await evaluate(`!!${menu}`))) await evaluate(`${trigger}.click()`);
+	return waitFor(`!!${menu}`, 8000);
+};
+const pressToggleShortcut = async () => {
+	// Ctrl+B: the panel's own shortcut listener accepts either modifier.
+	const key = { key: "b", code: "KeyB", windowsVirtualKeyCode: 66, nativeVirtualKeyCode: 66, modifiers: 2 };
+	await send("Input.dispatchKeyEvent", { type: "keyDown", ...key });
+	await send("Input.dispatchKeyEvent", { type: "keyUp", ...key });
+};
+
+/* ------------------------------------------------------ R4: no button ---- */
+
+expect("the top bar carries no agent button", await evaluate("document.querySelectorAll('.agent-topbar-toggle').length === 0"));
+expect(
+	"nothing agent-shaped was added to .topbar-actions",
+	await evaluate("![...document.querySelectorAll('.topbar-actions button, .topbar-actions a')].some((el) => /agent/i.test(el.className + ' ' + el.textContent))"),
+);
+
+/* ---------------------------------------------- the panel boots collapsed - */
+
+expect("the agent panel is mounted", await waitFor(`!!${panel}`, 15000));
+expect("it boots collapsed", await evaluate(`${collapsedFlag} === 'true'`), await evaluate(`${collapsedFlag}`));
+expect("collapsed, it takes no room at all — no rail, no control spent", await evaluate(`${panel}.getBoundingClientRect().width === 0 && getComputedStyle(${panel}).display === 'none'`));
+
+/* ------------------------------------------------------ the View ▾ item -- */
+
+expect("the View menu opens", await openMenu());
+expect("it offers an Agent panel item", await evaluate(`!!${item}`));
+expect("the item reads as a checkbox", await evaluate(`${item}.getAttribute('role') === 'menuitemcheckbox'`));
+expect("the item is labelled Agent panel", await evaluate(`${item}.textContent.trim() === 'Agent panel'`), await evaluate(`${item}?.textContent`));
+expect("it is unchecked while the panel is collapsed", await evaluate(`${item}.getAttribute('aria-checked') === 'false' && ${item}.getAttribute('aria-pressed') === 'false'`));
+expect("the checkmark slot is empty", await evaluate(`${item}.querySelector('.view-menu-mark').textContent.trim() === ''`));
+await shot("view-menu-agent-item");
+
+await evaluate(`${item}.click()`);
+expect("clicking it expands the panel", await waitFor(`!${collapsedFlag}`, 8000));
+expect("the expanded panel is the full column", await evaluate(`${panel}.getBoundingClientRect().width > 200`));
+expect("the menu stays open — this is a toggle, not a command", await evaluate(`!!${menu}`));
+expect("the item now reports checked", await waitFor(`${item}.getAttribute('aria-checked') === 'true' && ${item}.getAttribute('aria-pressed') === 'true'`, 8000));
+expect("the checkmark is drawn", await evaluate(`${item}.querySelector('.view-menu-mark').textContent.trim() === '✓'`));
+expect("it sits beside the inspector, not over it", await evaluate(`(() => {
+	const inspector = document.querySelector('.inspector-sidebar');
+	if (!inspector) return false;
+	const a = inspector.getBoundingClientRect();
+	const b = ${panel}.getBoundingClientRect();
+	return b.left >= a.right - 1;
+})()`));
+
+// Close the menu so the screenshot shows the panel itself.
+await evaluate(`${trigger}.click()`);
+expect("the menu closes again", await waitFor(`!${menu}`, 8000));
+await shot("agent-panel-expanded");
+
+/* ------------------------------------------------------- Cmd/Ctrl+B ------ */
+
+await pressToggleShortcut();
+expect("Cmd/Ctrl+B collapses the panel", await waitFor(`${collapsedFlag} === 'true'`, 8000));
+expect("the View item follows the shortcut", await openMenu() && await waitFor(`${item}.getAttribute('aria-checked') === 'false'`, 8000));
+await evaluate(`${trigger}.click()`);
+await waitFor(`!${menu}`, 8000);
+
+await pressToggleShortcut();
+expect("the shortcut expands it again", await waitFor(`!${collapsedFlag}`, 8000));
+expect("and the item checks itself back on", await openMenu() && await waitFor(`${item}.getAttribute('aria-checked') === 'true'`, 8000));
+await evaluate(`${item}.click()`);
+expect("the item collapses the panel exactly like the shortcut", await waitFor(`${collapsedFlag} === 'true'`, 8000));
+expect("the top bar is still free of an agent button", await evaluate("document.querySelectorAll('.agent-topbar-toggle').length === 0"));
+
+if (failures > 0) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log("qa-agent-view-toggle-browser: all checks passed");
+process.exit(0);

--- a/test/verify-agent-panel.mjs
+++ b/test/verify-agent-panel.mjs
@@ -10,6 +10,8 @@ const panel = readFileSync(new URL("../src/workflow/AgentPanel.jsx", import.meta
 const client = readFileSync(new URL("../src/workflow/agent-client.js", import.meta.url), "utf8");
 const css = readFileSync(new URL("../src/workflow/agent-panel.css", import.meta.url), "utf8");
 const builder = readFileSync(new URL("../src/workflow/WorkflowBuilder.jsx", import.meta.url), "utf8");
+const studio = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+const studioCss = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
 
 let failures = 0;
 function expect(name, condition, detail = "") {
@@ -33,6 +35,27 @@ expect("the panel lives inside .workflow-main", (() => {
 })());
 expect("the top bar carries a panel toggle", builder.includes("workflow-agent-toggle") && builder.includes("cozyclay:agent-panel-toggle"));
 expect("AgentPanel imports its own stylesheet", panel.includes('import "./agent-panel.css"'));
+
+// --- Studio mount -------------------------------------------------------
+// The studio has no room for another top bar button (IA rule R4): the panel is
+// shown from the View ▾ menu, exactly like every other "what is on screen"
+// toggle, and it boots collapsed so the studio still opens on the stage.
+expect("Studio imports the shared AgentPanel", studio.includes('import AgentPanel from "./workflow/AgentPanel.jsx"'));
+expect("Studio mounts AgentPanel beside the authoring workspace", studio.includes("<AgentPanel") && studio.includes("sceneName={scenes.find((entry) => entry.id === activeSceneId)?.name"));
+expect("Studio boots the panel collapsed and mirrors the flag", studio.includes("defaultCollapsed") && studio.includes("onCollapsedChange={setAgentCollapsed}") && studio.includes("useState(true)"));
+expect("AgentPanel accepts the host's default/notify pair", panel.includes("defaultCollapsed = false") && panel.includes("onCollapsedChange?.(collapsed)") && panel.includes("useState(defaultCollapsed)"));
+expect("Studio adds NO agent button to the top bar", !studio.includes("agent-topbar-toggle") && !/topbar-action[^"]*agent/i.test(studio));
+expect("the View menu owns the panel toggle", (() => {
+	const menu = studio.indexOf('<div className="view-menu-wrap">');
+	const item = studio.indexOf('"view-menu-item agent-panel-toggle"');
+	return menu !== -1 && item > menu && studio.includes('cozyclay:agent-panel-toggle');
+})(), "the toggle must sit inside the View ▾ menu");
+expect("the item is a checkbox that reflects the panel state", /role="menuitemcheckbox"\s*\n\s*className=\{"view-menu-item agent-panel-toggle"[^]*?aria-checked=\{!agentCollapsed\}[^]*?aria-pressed=\{!agentCollapsed\}/.test(studio));
+expect("the item is labelled Agent panel in both locales", studio.includes('ko("Agent panel", "에이전트 패널")'));
+expect("Studio tokens share the panel host scope", /\.workflow-app,\s*\.app\s*\{/.test(css));
+expect("the studio shows no collapsed rail — the mode budget stays as it was", /\.app \.agent-panel\.collapsed\s*\{[^}]*display:\s*none/.test(css));
+expect("the overlay drawer hangs from a host-sized token", /--agent-drawer-top:\s*58px/.test(css) && /\.app\s*\{\s*--agent-drawer-top:\s*48px;?\s*\}/.test(css) && !/[^-]top:\s*58px/.test(css));
+expect("embedded Studio hides the authoring panel", studioCss.includes('.app[data-embed-mode="playview"] .agent-panel'));
 
 // --- width contract -----------------------------------------------------
 expect("css defines the default width token as 360px", /--agent-width-default:\s*360px/.test(css));

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -180,6 +180,7 @@ const BROWSER_FILES = [
 	"test/verify-project-menu-browser.mjs",
 	"test/verify-settings-menu-browser.mjs",
 	"test/verify-static-shot-export-browser.mjs",
+	"test/qa-agent-view-toggle-browser.mjs",
 	"test/qa-ia-tail-browser.mjs",
 	"test/qa-keyframe-pack-browser.mjs",
 	"test/qa-preview-browser.mjs",
@@ -192,7 +193,7 @@ const BROWSER_FILES = [
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-agent-view-toggle-browser.mjs", "test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
## What changed

The Studio now mounts the same Agent chat panel that Workflow already has, beside the inspector — but it is turned on from the **View ▾** menu, not from a new top bar button. IA rule R4 keeps panel visibility in that menu, next to the other "what is on screen" toggles, and the top bar is left exactly as `main` has it.

- **View ▾ → Panels → Agent panel** is a `menuitemcheckbox`; its `aria-checked`/`aria-pressed` and its ✓ follow the panel however it was toggled — the menu item, the panel's own header control, or **Cmd/Ctrl+B**. Clicking it does exactly what the shortcut does, and the menu stays open, like every other toggle in it.
- `AgentPanel` gained one optional prop pair, `defaultCollapsed` / `onCollapsedChange`. The panel still owns its collapsed flag; the host only mirrors it for the checkmark, so the Workflow builder is untouched.
- The Studio boots the panel **collapsed** and hides the collapsed rail there: a permanent 36px rail would spend one of the mode's visible controls. The control-count audit is therefore unchanged — Scene 35 / Scene+character 35 / Camera 38 / Motion 51, identical to `main`.
- The overlay drawer (<1100px) hangs from a `--agent-drawer-top` token (58px in Workflow, 48px in the Studio) instead of a duplicated media query with a hardcoded offset.
- Embedded Studio (`data-embed-mode="playview"`) never mounts the panel.

Rebased onto `main` @ 0989fbc.

## Screenshots

View ▾ open, showing the Agent panel item (unchecked while the panel is off):

![View menu with the Agent panel item](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/agent-185/view-menu-agent-item.png)

The panel expanded beside the inspector:

![Agent panel expanded beside the inspector](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/agent-185/agent-panel-expanded.png)

## Validation

- `npm run build` — exit 0.
- `node tools/run-tests.mjs` — `PASS 158 Node verification files` (exit 0), including the reworked `test/verify-agent-panel.mjs`: the View ▾ item, its checkbox contract, the collapsed boot, and the *absence* of any `.agent-topbar-toggle` in the top bar.
- New `test/qa-agent-view-toggle-browser.mjs` (registered in `tools/run-tests.mjs` as a browser suite), run over CDP against a local Vite server:
  `QA_URL=http://127.0.0.1:5306/app/ CDP_PORT=9316 node tools/qa-browser.mjs -- node test/qa-agent-view-toggle-browser.mjs`
  → **28 PASS / 0 FAIL** — no agent button anywhere in the top bar, the panel boots collapsed and takes no room, View ▾ → Agent panel expands it beside the inspector, Cmd/Ctrl+B collapses and re-expands it, and the menu's checkmark tracks every path.
- `tools/qa/studio-control-count.mjs` on this branch: 35 / 35 / 38 / 51 — byte-for-byte the same numbers as `main` @ 0989fbc.
