### PR TITLE
feat(hierarchy): scene switcher lives on the tree root row; Projects… button removed (#192)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10166,7 +10166,6 @@ function resizePromptClip(id, edge, rawFrame) {
 					<span className="hierarchy-project-label">{ko("Project", "프로젝트")}</span>
 					<strong>{projectName ?? (projectStartupOpen ? ko("Choose Project", "프로젝트 선택") : ko("Untitled", "제목 없음"))}</strong>
 					{projectDirty && <i className="project-dirty-dot" aria-label={ko("Unsaved changes", "저장되지 않은 변경사항")} />}
-					<button type="button" onClick={() => { setProjectStartupOpen(false); setProjectBrowserOpen(true); }}>{ko("Projects…", "프로젝트…")}</button>
 				</div>
 				<HierarchyPanel
 					selectedId={selectedHierarchyId}

--- a/src/hierarchy-panel.jsx
+++ b/src/hierarchy-panel.jsx
@@ -3,6 +3,7 @@ import { ko, isKo } from "./locale.js";
 import { buildHierarchyNodes } from "./hierarchy-model.js";
 import { sceneObjectIdFromHierarchy } from "./scene-objects.js";
 import AddObjectMenu, { CatalogueEntries, displayObjectLabel } from "./object-catalog.jsx";
+import { Dropdown } from "./ui.jsx";
 
 const HIERARCHY_LABELS_KO = {
 	"SCENE 01": "장면 01",
@@ -37,6 +38,12 @@ const HIERARCHY_LABELS_KO = {
 };
 
 const FALLBACK_SCENES = [{ id: "current-scene", name: "SCENE 01" }];
+
+/** The tree root row IS the active scene document (hierarchy-model.js keeps
+ *  the legacy `shot` id for selection routing). */
+const SCENE_ROOT_ID = "shot";
+/** Sentinel option value: the scene list ends with "+ New scene". */
+const NEW_SCENE_OPTION = "__new-scene__";
 
 /**
  * The drag payload for a hierarchy ROW moved onto another row (attach a prop
@@ -149,101 +156,39 @@ function displaySceneName(name) {
  * - `scenes` contains lightweight `{ id, name }` records.
  * - callbacks request document changes; this panel never owns or mutates scenes.
  *
- * A compact document selector sits above the entity tree instead of mixing
- * every Scene into one tree. This keeps the current set readable and leaves
- * Shot authoring in the timeline, where directors expect to find it.
+ * The selector lives ON the tree root row, because the root row already IS the
+ * active scene document: one line of chrome instead of a separate Scenes block
+ * repeating the same name. The list is the portaled `Dropdown` — the hierarchy
+ * column clips its overflow, so an in-place menu would be cut off.
  */
-function SceneSwitcher({
-	scenes,
-	activeSceneId,
-	onSceneSelect,
-	onSceneCreate,
-	onSceneDuplicate,
-	onSceneRename,
-	onSceneDelete,
-}) {
-	const availableScenes = scenes?.length ? scenes : FALLBACK_SCENES;
-	const selectedId = availableScenes.some((scene) => scene.id === activeSceneId) ? activeSceneId : availableScenes[0].id;
-	const selectedScene = availableScenes.find((scene) => scene.id === selectedId);
-	const [editingId, setEditingId] = useState(null);
-	const [deleteArmed, setDeleteArmed] = useState(false);
-	useEffect(() => setDeleteArmed(false), [selectedId, availableScenes.length]);
-
-	const commitRename = (scene, value) => {
-		setEditingId(null);
-		const name = value.trim();
-		if (name && name !== scene.name) onSceneRename?.(scene.id, name);
-	};
-	const requestDelete = () => {
-		if (availableScenes.length <= 1 || !selectedScene) return;
-		if (!deleteArmed) {
-			setDeleteArmed(true);
-			return;
-		}
-		setDeleteArmed(false);
-		onSceneDelete?.(selectedScene.id);
-	};
-
+function ScenePill({ scenes, activeSceneId, onSceneSelect, onSceneCreate, onRenameStart }) {
+	const options = [
+		...scenes.map((scene) => ({ value: scene.id, label: displaySceneName(scene.name) })),
+		{ value: NEW_SCENE_OPTION, label: ko("+ New scene", "+ 새 장면") },
+	];
 	return (
-		<div className="scene-switcher" aria-label={ko("Scene documents", "장면 문서") }>
-			<div className="scene-switcher-heading">
-				<div>
-					<strong>{ko("Scenes", "장면")}</strong>
-					<span>{isKo ? `${availableScenes.length}개 장면` : `${availableScenes.length} scene${availableScenes.length === 1 ? "" : "s"}`}</span>
-				</div>
-				<button type="button" className="scene-create-button" onClick={() => onSceneCreate?.()}>
-					{ko("+ New Scene", "+ 새 장면")}
-				</button>
-			</div>
-			<div className="scene-list" role="listbox" aria-label={ko("Select scene", "장면 선택")}>
-				{availableScenes.map((scene) => {
-					const active = scene.id === selectedId;
-					return (
-						<div key={scene.id} className={`scene-list-item${active ? " active" : ""}`}>
-							{editingId === scene.id ? (
-								<input
-									className="scene-rename-input"
-									defaultValue={scene.name}
-									autoFocus
-									aria-label={ko("Rename scene", "장면 이름 바꾸기")}
-									onFocus={(event) => event.currentTarget.select()}
-									onBlur={(event) => commitRename(scene, event.currentTarget.value)}
-									onKeyDown={(event) => {
-										if (event.key === "Enter") event.currentTarget.blur();
-										else if (event.key === "Escape") setEditingId(null);
-									}}
-								/>
-							) : (
-								<button
-									type="button"
-									role="option"
-									aria-selected={active}
-									onClick={() => {
-										if (!active) onSceneSelect?.(scene.id);
-									}}
-									onDoubleClick={() => setEditingId(scene.id)}
-								>
-									<HierarchyIcon kind="scene" className="scene-document-icon" />
-									<span>{displaySceneName(scene.name)}</span>
-								</button>
-							)}
-						</div>
-					);
-				})}
-			</div>
-			{/* Scene housekeeping is a once-a-session errand, so it waits under one
-			    disclosure instead of holding three buttons open all day. */}
-			<details className="scene-actions-pop">
-				<summary title={ko("Scene actions", "장면 작업")}>{ko("Scene…", "장면…")}</summary>
-			<div className="scene-actions">
-				<button type="button" onClick={() => selectedScene && onSceneDuplicate?.(selectedScene.id)}>{ko("Duplicate", "복제")}</button>
-				<button type="button" onClick={() => selectedScene && setEditingId(selectedScene.id)}>{ko("Rename", "이름 바꾸기")}</button>
-				<button type="button" className={deleteArmed ? "danger" : undefined} disabled={availableScenes.length <= 1} onClick={requestDelete} title={availableScenes.length <= 1 ? ko("At least one scene is required", "장면은 최소 하나 필요합니다") : deleteArmed ? ko("Click again to permanently delete this scene", "한 번 더 누르면 이 장면을 완전히 삭제합니다") : undefined}>
-					{deleteArmed ? ko("Confirm delete", "삭제 확인") : ko("Delete", "삭제")}
-				</button>
-			</div>
-			</details>
-		</div>
+		// The pill sits beside the expand caret but is a different control: its
+		// clicks never reach the row, so picking a scene cannot fold the tree.
+		<span
+			className="hierarchy-scene-pill"
+			onClick={(event) => event.stopPropagation()}
+			// The pill carries the scene name, so a double-click on it renames the
+			// document — the same gesture the row label used to answer.
+			onDoubleClick={(event) => {
+				event.stopPropagation();
+				onRenameStart?.();
+			}}
+		>
+			<Dropdown
+				value={activeSceneId}
+				options={options}
+				ariaLabel={ko("Select scene", "장면 선택")}
+				onChange={(value) => {
+					if (value === NEW_SCENE_OPTION) onSceneCreate?.();
+					else if (value !== activeSceneId) onSceneSelect?.(value);
+				}}
+			/>
+		</span>
 	);
 }
 
@@ -267,6 +212,10 @@ function indexParents(nodes, parent = null, parents = new Map()) {
  * Closes on Escape, on any outside mousedown, and after a pick. */
 function RowContextMenu({ menu, onClose, onAction, onAddObject }) {
 	const rootRef = useRef(null);
+	// Deleting a scene document is not undoable, so Delete arms first and only
+	// the second click on the same item commits (the switcher behaved this way).
+	const [deleteArmed, setDeleteArmed] = useState(false);
+	useEffect(() => setDeleteArmed(false), [menu]);
 
 	useEffect(() => {
 		if (!menu) return undefined;
@@ -297,7 +246,36 @@ function RowContextMenu({ menu, onClose, onAction, onAddObject }) {
 	};
 	return (
 		<div className="hierarchy-context-menu" role="menu" style={style} ref={rootRef}>
-			{menu.kind === "object" ? (
+			{menu.kind === "scene" ? (
+				<>
+					<button type="button" role="menuitem" className="hierarchy-context-item" onClick={() => onAction("rename", menu.id)}>
+						{ko("Rename", "이름 바꾸기")}
+					</button>
+					<button type="button" role="menuitem" className="hierarchy-context-item" onClick={() => onAction("scene-duplicate", menu.id)}>
+						{ko("Duplicate", "복제")}
+					</button>
+					{menu.canDelete && (
+						<button
+							type="button"
+							role="menuitem"
+							className={"hierarchy-context-item" + (deleteArmed ? " danger" : "")}
+							title={deleteArmed ? ko("Click again to permanently delete this scene", "한 번 더 누르면 이 장면을 완전히 삭제합니다") : undefined}
+							onClick={() => {
+								if (!deleteArmed) {
+									setDeleteArmed(true);
+									return;
+								}
+								onAction("scene-delete", menu.id);
+							}}
+						>
+							{deleteArmed ? ko("Confirm delete", "삭제 확인") : ko("Delete", "삭제")}
+						</button>
+					)}
+					<button type="button" role="menuitem" className="hierarchy-context-item" onClick={() => onAction("scene-create", menu.id)}>
+						{ko("+ New scene", "+ 새 장면")}
+					</button>
+				</>
+			) : menu.kind === "object" ? (
 				<>
 					<button type="button" role="menuitem" className="hierarchy-context-item" onClick={() => onAction("rename", menu.id)}>
 						{ko("Rename", "이름 바꾸기")}
@@ -332,6 +310,11 @@ function TreeRow({
 	onRenameCommit,
 	onRenameCancel,
 	onRowContextMenu,
+	onRenameStart,
+	// The scene root row hands its name to the pill in `rowExtra`; printing it
+	// twice on one row is the duplication this panel just removed.
+	showLabel = true,
+	rowExtra,
 	dropHandlers,
 	reparent,
 	dragSourceId,
@@ -423,8 +406,13 @@ function TreeRow({
 	const rowWrapRef = useRef(null);
 	const inputRef = useRef(null);
 	// A commit/cancel may race the blur that follows the input unmounting;
-	// the flag ends the edit session exactly once.
+	// the flag ends the edit session exactly once. It is per SESSION, not per
+	// row: the row outlives its renames, and a flag left standing would make
+	// every later rename on that row uncommittable.
 	const doneRef = useRef(false);
+	useEffect(() => {
+		if (editing) doneRef.current = false;
+	}, [editing]);
 
 	const finish = () => {
 		if (doneRef.current) return;
@@ -494,13 +482,20 @@ function TreeRow({
 					/>
 				</div>
 			) : (
-				<button type="button" className="hierarchy-row" onClick={() => onSelect(node.id)}>
+				<button
+					type="button"
+					className={"hierarchy-row" + (showLabel ? "" : " icon-only")}
+					aria-label={showLabel ? undefined : label}
+					onClick={() => onSelect(node.id)}
+					onDoubleClick={onRenameStart ?? undefined}
+				>
 					<HierarchyIcon kind={node.kind} />
-					<span className="hierarchy-label">{label}</span>
+					{showLabel && <span className="hierarchy-label">{label}</span>}
 					{status && <span className="hierarchy-status">{status}</span>}
 					{badge !== null && badge !== undefined && badge !== 0 && <span className="hierarchy-badge">{badge}</span>}
 				</button>
 			)}
+			{rowExtra}
 		</div>
 	);
 }
@@ -544,10 +539,12 @@ export default function HierarchyPanel({
 	const lastTreeSelectRef = useRef(null);
 	const firstRenderRef = useRef(true);
 	const pendingScrollRef = useRef(false);
-	const activeSceneName = useMemo(() => {
-		const availableScenes = scenes?.length ? scenes : FALLBACK_SCENES;
-		return (availableScenes.find((scene) => scene.id === activeSceneId) ?? availableScenes[0]).name;
-	}, [activeSceneId, scenes]);
+	// Refused scene edits (the last scene cannot be deleted) explain themselves
+	// in the panel rather than failing silently.
+	const [sceneHint, setSceneHint] = useState(null);
+	const availableScenes = scenes?.length ? scenes : FALLBACK_SCENES;
+	const activeScene = availableScenes.find((scene) => scene.id === activeSceneId) ?? availableScenes[0];
+	const activeSceneName = activeScene.name;
 	const hierarchyNodes = useMemo(() => {
 		const nodes = buildHierarchyNodes(sceneObjects, characters);
 		const labelled = nodes.map((node) => node.kind === "scene" ? { ...node, label: activeSceneName } : node);
@@ -624,6 +621,17 @@ export default function HierarchyPanel({
 		event.stopPropagation(); // a row pick must not also open the create menu
 		if (sceneObjectIdFromHierarchy(id) !== null) {
 			setContextMenu({ x: event.clientX, y: event.clientY, height: 148, kind: "object", id });
+		} else if (id === SCENE_ROOT_ID) {
+			// The root row is the scene document: its own verbs, never the
+			// Add-Object catalogue.
+			setContextMenu({
+				x: event.clientX,
+				y: event.clientY,
+				height: availableScenes.length > 1 ? 148 : 116,
+				kind: "scene",
+				id,
+				canDelete: availableScenes.length > 1,
+			});
 		} else {
 			setContextMenu({ x: event.clientX, y: event.clientY, height: 344, kind: "create" });
 		}
@@ -634,10 +642,31 @@ export default function HierarchyPanel({
 		setContextMenu({ x: event.clientX, y: event.clientY, height: 344, kind: "create" });
 	};
 
+	const deleteActiveScene = () => {
+		if (availableScenes.length <= 1) {
+			setSceneHint(ko("At least one scene is required", "장면은 최소 하나 필요합니다"));
+			return;
+		}
+		setSceneHint(null);
+		onSceneDelete?.(activeScene.id);
+	};
+
 	const handleMenuAction = (action, hierarchyId) => {
 		setContextMenu(null);
 		if (action === "rename") {
 			setEditingId(hierarchyId);
+			return;
+		}
+		if (action === "scene-duplicate") {
+			onSceneDuplicate?.(activeScene.id);
+			return;
+		}
+		if (action === "scene-delete") {
+			deleteActiveScene();
+			return;
+		}
+		if (action === "scene-create") {
+			onSceneCreate?.();
 			return;
 		}
 		const objectId = sceneObjectIdFromHierarchy(hierarchyId);
@@ -649,6 +678,10 @@ export default function HierarchyPanel({
 
 	const commitRename = (hierarchyId, name) => {
 		setEditingId(null);
+		if (hierarchyId === SCENE_ROOT_ID) {
+			if (name !== activeScene.name) onSceneRename?.(activeScene.id, name);
+			return;
+		}
 		const objectId = sceneObjectIdFromHierarchy(hierarchyId);
 		if (objectId) onRenameObject?.(objectId, name);
 	};
@@ -663,7 +696,7 @@ export default function HierarchyPanel({
 	const onTreeKeyDown = (event) => {
 		if (editingId) return;
 		if (event.key !== "F2" && event.key !== "Enter") return;
-		if (sceneObjectIdFromHierarchy(selectedId) === null) return;
+		if (selectedId !== SCENE_ROOT_ID && sceneObjectIdFromHierarchy(selectedId) === null) return;
 		event.preventDefault();
 		setEditingId(selectedId);
 	};
@@ -672,6 +705,8 @@ export default function HierarchyPanel({
 		nodes.flatMap((node) => {
 			if (node.optional === "showB" && !showB) return [];
 			const open = expanded.has(node.id);
+			const sceneRoot = node.id === SCENE_ROOT_ID;
+			const editing = editingId === node.id;
 			return [
 				<TreeRow
 					key={node.id}
@@ -683,10 +718,25 @@ export default function HierarchyPanel({
 					onToggle={toggle}
 					badge={badgeFor(node.id)}
 					status={statusFor(node.id)}
-					editing={editingId === node.id}
+					editing={editing}
 					onRenameCommit={(name) => commitRename(node.id, name)}
 					onRenameCancel={cancelRename}
 					onRowContextMenu={openRowMenu}
+					// The root row names the scene document, and a double-click on a
+					// document name is where every file browser puts rename.
+					onRenameStart={sceneRoot ? () => setEditingId(node.id) : null}
+					// On the root row the pill IS the name: the row keeps its icon,
+					// and the rename input takes the pill's place while editing.
+					showLabel={!sceneRoot}
+					rowExtra={sceneRoot && !editing ? (
+						<ScenePill
+							scenes={availableScenes}
+							activeSceneId={activeScene.id}
+							onSceneSelect={onSceneSelect}
+							onSceneCreate={onSceneCreate}
+							onRenameStart={() => setEditingId(node.id)}
+						/>
+					) : null}
 					// A picture dropped on Props — or on any prop already in it —
 					// becomes a cutout in the set. Dropping ON an object is the
 					// same gesture as dropping on the group it lives in: people
@@ -709,15 +759,6 @@ export default function HierarchyPanel({
 				</div>
 				<span className="hierarchy-frame-status">{motionFrames ? (isKo ? `${motionFrames}프레임` : `${motionFrames} frames`) : ko("Blocking", "블로킹")}</span>
 			</div>
-			<SceneSwitcher
-				scenes={scenes}
-				activeSceneId={activeSceneId}
-				onSceneSelect={onSceneSelect}
-				onSceneCreate={onSceneCreate}
-				onSceneDuplicate={onSceneDuplicate}
-				onSceneRename={onSceneRename}
-				onSceneDelete={onSceneDelete}
-			/>
 			{onAddObject && (
 				<div className="hierarchy-toolbar">
 					<AddObjectMenu onAdd={onAddObject} />
@@ -727,6 +768,9 @@ export default function HierarchyPanel({
 			<div className="hierarchy-tree" role="tree" ref={treeRef} onKeyDown={onTreeKeyDown} onContextMenu={openCreateMenu}>
 				{renderNodes(hierarchyNodes)}
 			</div>
+			{sceneHint && (
+				<p className="hierarchy-scene-hint" role="status">{sceneHint}</p>
+			)}
 			<RowContextMenu
 				menu={contextMenu}
 				onClose={() => setContextMenu(null)}

--- a/src/styles.css
+++ b/src/styles.css
@@ -342,20 +342,6 @@ select {
 	text-overflow: ellipsis;
 }
 
-.hierarchy-project button {
-	padding: 3px 9px;
-	font-size: 11px;
-	border-radius: 6px;
-	border: 1px solid var(--line2);
-	background: var(--card2);
-	color: var(--fg);
-	cursor: pointer;
-}
-
-.hierarchy-project button:hover {
-	border-color: var(--accent);
-}
-
 /* Project browser modal */
 .project-browser-backdrop {
 	position: fixed;
@@ -2072,46 +2058,17 @@ select {
 	font-size: 8px;
 }
 
-.scene-switcher {
-	flex: none;
-	padding: 8px 9px 7px;
-	border-bottom: 1px solid rgba(255, 255, 255, .065);
-	background: rgba(8, 10, 14, .32);
-}
-
-.scene-switcher-heading,
-.scene-switcher-heading > div,
-.scene-actions {
-	display: flex;
-	align-items: center;
-}
-
 /* Disclosures that keep a once-in-a-while control out of the permanent
    furniture: a summary you can read, a panel that opens where it stands. */
-.scene-actions-pop > summary,
 .object-colors-pop > summary {
 	cursor: pointer;
 	list-style: none;
 }
 
-.scene-actions-pop > summary::-webkit-details-marker,
 .object-colors-pop > summary::-webkit-details-marker { display: none; }
-
-.scene-actions-pop > summary {
-	padding: 3px 8px;
-	border: 1px solid rgba(126, 154, 255, .2);
-	border-radius: 6px;
-	color: #9fb0d8;
-	font-size: 11px;
-	width: max-content;
-}
-
-.scene-actions-pop[open] > summary { color: #d7e2ff; }
-.scene-actions-pop .scene-actions { margin-top: 5px; }
 
 /* A closed <details> hides its children by display alone, so any child that
    sets its own display walks straight back out of the box. */
-.scene-actions-pop:not([open]) .scene-actions,
 .object-colors-pop:not([open]) .object-colors,
 .tl-camera-advanced:not([open]) > label,
 .tl-camera-advanced:not([open]) > button { display: none; }
@@ -2194,81 +2151,6 @@ select {
 	outline-offset: 0;
 }
 
-.scene-switcher-heading {
-	justify-content: space-between;
-	gap: 8px;
-	margin-bottom: 6px;
-}
-
-.scene-switcher-heading > div { gap: 6px; min-width: 0; }
-.scene-switcher-heading strong { color: var(--fg); font-size: 10px; }
-.scene-switcher-heading span { color: var(--muted); font-size: 8px; }
-
-.scene-create-button,
-.scene-actions button {
-	border: 1px solid rgba(126, 154, 255, .2);
-	border-radius: 5px;
-	background: rgba(87, 111, 221, .09);
-	color: #aebade;
-	font: inherit;
-	font-size: 9px;
-	cursor: pointer;
-}
-
-.scene-create-button { height: 24px; padding: 0 8px; }
-.scene-create-button:hover,
-.scene-actions button:hover:not(:disabled) { background: rgba(87, 111, 221, .18); color: var(--fg); }
-
-.scene-list {
-	max-height: 76px;
-	overflow: auto;
-	border: 1px solid rgba(255, 255, 255, .07);
-	border-radius: 6px;
-	background: rgba(0, 0, 0, .12);
-}
-
-.scene-list-item { height: 27px; padding: 2px; }
-.scene-list-item + .scene-list-item { border-top: 1px solid rgba(255, 255, 255, .045); }
-.scene-list-item > button {
-	display: flex;
-	align-items: center;
-	gap: 7px;
-	width: 100%;
-	height: 23px;
-	padding: 0 7px;
-	border: 0;
-	border-radius: 4px;
-	background: transparent;
-	color: var(--muted);
-	font: inherit;
-	font-size: 10px;
-	text-align: left;
-	cursor: pointer;
-}
-
-.scene-list-item.active > button { background: rgba(87, 111, 221, .16); color: var(--fg); }
-.scene-document-icon {
-	width: 15px;
-	height: 15px;
-	color: #8fa8ff;
-}
-.scene-rename-input {
-	width: 100%;
-	height: 23px;
-	padding: 0 7px;
-	border: 1px solid #627cd0;
-	border-radius: 4px;
-	outline: none;
-	background: #161b29;
-	color: var(--fg);
-	font: inherit;
-	font-size: 10px;
-}
-
-.scene-actions { justify-content: flex-end; gap: 4px; margin-top: 5px; }
-.scene-actions button { height: 21px; padding: 0 7px; }
-.scene-actions button:disabled { opacity: .35; cursor: not-allowed; }
-
 .hierarchy-tree {
 	flex: 1;
 	min-height: 0;
@@ -2334,6 +2216,13 @@ select {
 	cursor: default;
 }
 
+/* The scene root row: its name lives in the pill beside it, so the row itself
+   shrinks to its icon instead of holding an empty stretch of label. */
+.hierarchy-row.icon-only {
+	flex: none;
+	padding-right: 0;
+}
+
 .hierarchy-icon {
 	flex: none;
 	width: 15px;
@@ -2382,6 +2271,69 @@ select {
 	color: #8f97a9;
 	font-size: 7px;
 	text-align: center;
+}
+
+/* Scene selector on the tree root row (#192). The root row already IS the
+   active scene document, so its name carries the document switcher instead of
+   a second Scenes block above the tree. The pill is its own box, right of the
+   label and far from the expand caret, so the two never read as one control.
+   Selectors are row-scoped so the panel's compact sizing wins over the shared
+   `.dropdown .trigger` field styling further down the sheet. */
+.hierarchy-row-wrap .hierarchy-scene-pill {
+	/* Wide enough that the portaled list it sizes still fits a scene name and
+	   its tick mark (the menu takes the trigger's width), but never more than
+	   half the row: on a narrowed column the row's own name keeps its space. */
+	flex: 0 1 122px;
+	max-width: calc(100% - 52px);
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	margin: 0 4px 0 6px;
+}
+
+.hierarchy-row-wrap .hierarchy-scene-pill .dropdown { width: 100%; }
+
+.hierarchy-row-wrap .hierarchy-scene-pill .trigger {
+	width: 100%;
+	min-width: 0;
+	height: 19px;
+	gap: 4px;
+	padding: 0 7px;
+	border: 1px solid var(--line2);
+	border-radius: 999px;
+	background: var(--card2);
+	color: var(--muted);
+	font-size: 10px;
+}
+
+.hierarchy-row-wrap .hierarchy-scene-pill .trigger:hover {
+	border-color: var(--accent);
+	color: var(--fg);
+}
+
+.hierarchy-row-wrap .hierarchy-scene-pill .dropdown.open .trigger {
+	border-color: var(--accent);
+	background: var(--hover);
+	color: var(--fg);
+	box-shadow: 0 0 0 1px var(--accent);
+}
+
+.hierarchy-row-wrap .hierarchy-scene-pill .dd-caret {
+	width: 10px;
+	height: 10px;
+}
+
+.hierarchy-row-wrap.selected .hierarchy-scene-pill .trigger { color: var(--fg); }
+
+/* Why a scene edit was refused (the last scene cannot be deleted), said in
+   the panel that refused it. */
+.hierarchy-scene-hint {
+	flex: none;
+	margin: 0;
+	padding: 0 10px 8px;
+	color: var(--muted);
+	font-size: 10px;
+	line-height: 1.4;
 }
 
 .inspector-heading {

--- a/test/qa-scene-switcher-browser.mjs
+++ b/test/qa-scene-switcher-browser.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// Browser QA for the scene switcher on the tree root row (#192). Drives the
+// real studio over CDP through the whole scene-document life cycle from the
+// row itself: create two more scenes from the pill, switch between the three,
+// rename the active one with F2, duplicate it from the root-row context menu,
+// delete back down to one, and prove Delete is not offered when one scene is
+// all that is left. Screenshots the pill list and the root menu, because "the
+// state is right" and "the operator can see the control" are two claims.
+//
+//   QA_URL=http://127.0.0.1:5180/app/ CDP_PORT=9254 node tools/qa-browser.mjs \
+//     -- node test/qa-scene-switcher-browser.mjs
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const out = process.env.QA_OUT || "/tmp/scene-switcher-qa";
+mkdirSync(out, { recursive: true });
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params.exceptionDetails.exception?.description ?? message.params.exceptionDetails.text);
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true, timeout: 120_000 });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+// Every wait is on the state the step produces, never on a fixed delay: React
+// commits when it commits, and a sleep would only decide how flaky this is.
+const waitFor = async (expression, timeoutMs = 20_000) => {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		if (Date.now() >= deadline) return false;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+/* --- helpers that speak in the panel's own controls -------------------------- */
+
+const PILL = ".hierarchy-scene-pill .trigger";
+const ROOT_ROW = "[data-node-id='shot']";
+
+const pillLabel = () => evaluate(`document.querySelector("${PILL}")?.querySelector("span")?.textContent.trim() ?? null`);
+// The root row hands its name to the pill, so the row button carries the name
+// as its accessible label instead of a second copy of the text.
+const rootLabel = () => evaluate(`document.querySelector("${ROOT_ROW} .hierarchy-row")?.getAttribute("aria-label") ?? null`);
+const rootRowNameCount = (name) => evaluate(`(document.querySelector("${ROOT_ROW}").innerText.match(/${name}/g) ?? []).length`);
+// The list ends with "+ New scene", which is an action rather than a document:
+// the scene names are everything before it.
+const sceneNames = () => evaluate(`[...document.querySelectorAll(".dropdown-menu [role=option]")].map((node) => node.textContent.trim()).filter((label) => !label.includes("New scene"))`);
+const menuItems = () => evaluate(`[...document.querySelectorAll(".hierarchy-context-menu [role=menuitem]")].map((node) => node.textContent.trim())`);
+
+const openPill = async () => {
+	await evaluate(`document.querySelector("${PILL}").click()`);
+	return waitFor(`!!document.querySelector(".dropdown-menu [role=option]")`);
+};
+const closePopovers = async () => {
+	await evaluate(`document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }))`);
+	return waitFor(`!document.querySelector(".dropdown-menu") && !document.querySelector(".hierarchy-context-menu")`);
+};
+const pickPillItem = async (pattern) => {
+	await evaluate(`[...document.querySelectorAll(".dropdown-menu [role=option]")].find((node) => /${pattern}/.test(node.textContent))?.click()`);
+	return waitFor(`!document.querySelector(".dropdown-menu")`);
+};
+const openRootMenu = async () => {
+	await evaluate(`(() => {
+		const row = document.querySelector("${ROOT_ROW}");
+		const box = row.getBoundingClientRect();
+		row.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, clientX: Math.round(box.x + 40), clientY: Math.round(box.y + 12) }));
+	})()`);
+	return waitFor(`!!document.querySelector(".hierarchy-context-menu")`);
+};
+const clickMenuItem = async (pattern) => evaluate(`[...document.querySelectorAll(".hierarchy-context-menu [role=menuitem]")].find((node) => /${pattern}/.test(node.textContent))?.click()`);
+const shot = async (name) => {
+	const clip = await evaluate(`(() => { const node = document.querySelector(".hierarchy-left"); const box = node.getBoundingClientRect(); return { x: 0, y: 0, width: Math.round(box.right + 220), height: 640 }; })()`);
+	const image = await send("Page.captureScreenshot", { format: "png", clip: { ...clip, scale: 2 } });
+	writeFileSync(`${out}/${name}.png`, Buffer.from(image.data, "base64"));
+	return Buffer.from(image.data, "base64").byteLength;
+};
+
+/* --- a one-scene project to start from -------------------------------------- */
+
+await send("Runtime.enable");
+await send("Page.enable");
+await send("Emulation.setDeviceMetricsOverride", { width: 1600, height: 1000, deviceScaleFactor: 1, mobile: false });
+await send("Page.navigate", { url: process.env.QA_URL ?? "http://127.0.0.1:5180/app/" });
+await waitFor("location.href.startsWith('http')");
+await evaluate(`(() => {
+	localStorage.clear();
+	localStorage.setItem("cozyclay.locale", "en");
+	localStorage.setItem("cozyclay.project-session.v1", JSON.stringify({ name: "QA", updatedAt: Date.now() }));
+})()`);
+await send("Page.reload");
+expect("the studio comes up", await waitFor("!!window.__cozyclay?.rigA", 60_000));
+expect("the hierarchy column carries no second Projects… button", await evaluate(`![...document.querySelectorAll(".hierarchy-project button")].length`));
+expect("the tree root row carries the scene pill", await waitFor(`!!document.querySelector("${PILL}")`));
+expect("the pill says which scene is open", await pillLabel() === "SCENE 01", String(await pillLabel()));
+expect("the pill announces itself as the scene selector", await evaluate(`document.querySelector("${PILL}").getAttribute("aria-label")`) === "Select scene");
+expect("the pill carries its own caret, apart from the row's expand caret", await evaluate(`!!document.querySelector(".hierarchy-scene-pill .dd-caret") && !!document.querySelector("${ROOT_ROW} .hierarchy-toggle")`));
+expect("the root row prints the scene name once, in the pill", await rootRowNameCount("SCENE 01") === 1 && await evaluate(`!document.querySelector("${ROOT_ROW} .hierarchy-label")`), String(await rootRowNameCount("SCENE 01")));
+expect("the row still names itself for assistive tech", await rootLabel() === "SCENE 01", String(await rootLabel()));
+
+/* --- create two more scenes from the pill ------------------------------------ */
+
+for (const expected of ["SCENE 02", "SCENE 03"]) {
+	expect(`the pill opens before creating ${expected}`, await openPill());
+	await pickPillItem("New scene");
+	expect(`+ New scene opens ${expected}`, await waitFor(`document.querySelector("${PILL}").textContent.includes("${expected}")`), String(await pillLabel()));
+}
+expect("the root row name follows the active scene", await rootLabel() === "SCENE 03", String(await rootLabel()));
+expect("the new scene name is still printed once", await rootRowNameCount("SCENE 03") === 1);
+
+expect("the pill lists every scene", await openPill());
+const listed = await sceneNames();
+expect("all three scenes are listed", listed.length === 3, JSON.stringify(listed));
+expect("the active scene is marked in the list", await evaluate(`[...document.querySelectorAll('.dropdown-menu [role=option]')].filter((node) => node.getAttribute("aria-selected") === "true").map((node) => node.textContent.trim()).join()`) === "SCENE 03");
+expect("the list offers a create item after the scenes", await evaluate(`/New scene/.test([...document.querySelectorAll(".dropdown-menu [role=option]")].at(-1).textContent)`));
+expect("the pill list is portaled clear of the panel that clips it", await evaluate(`document.querySelector(".dropdown-menu")?.parentElement === document.body`));
+expect("opening the pill does not fold the tree", await evaluate(`document.querySelector("${ROOT_ROW}").getAttribute("aria-expanded")`) === "true");
+expect("the pill screenshot has bytes", (await shot("pill-open-three-scenes")) > 2000);
+
+/* --- switch between the three ------------------------------------------------ */
+
+await pickPillItem("SCENE 01");
+expect("picking a scene from the pill switches document", await waitFor(`document.querySelector("${PILL}").textContent.includes("SCENE 01")`), String(await pillLabel()));
+expect("the tree root follows the switch", await rootLabel() === "SCENE 01", String(await rootLabel()));
+await openPill();
+await pickPillItem("SCENE 02");
+expect("switching again lands on the third scene", await waitFor(`document.querySelector("${PILL}").textContent.includes("SCENE 02")`), String(await pillLabel()));
+
+/* --- rename the active scene with F2 ----------------------------------------- */
+
+await evaluate(`document.querySelector("${ROOT_ROW} .hierarchy-row").click()`);
+await evaluate(`document.querySelector("${ROOT_ROW}").dispatchEvent(new KeyboardEvent("keydown", { key: "F2", bubbles: true }))`);
+expect("F2 on the root row opens an inline rename", await waitFor(`!!document.querySelector("${ROOT_ROW} .hierarchy-rename-input")`));
+await evaluate(`(() => {
+	const input = document.querySelector("${ROOT_ROW} .hierarchy-rename-input");
+	input.value = "REHEARSAL";
+	input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+})()`);
+expect("the rename reaches the scene document", await waitFor(`document.querySelector("${PILL}").textContent.includes("REHEARSAL")`), String(await pillLabel()));
+expect("the renamed scene is what the tree root shows", await rootLabel() === "REHEARSAL", String(await rootLabel()));
+await openPill();
+expect("the renamed scene keeps its place in the list", (await sceneNames()).includes("REHEARSAL"), JSON.stringify(await sceneNames()));
+await closePopovers();
+
+// The pill carries the name, so it answers the double-click that used to land
+// on the row label; the input takes the pill's place while editing.
+await evaluate(`(() => {
+	const pill = document.querySelector("${PILL}");
+	for (const type of ["click", "click", "dblclick"]) pill.dispatchEvent(new MouseEvent(type, { bubbles: true, detail: type === "dblclick" ? 2 : 1 }));
+})()`);
+expect("double-clicking the pill opens the inline rename in its place", await waitFor(`!!document.querySelector("${ROOT_ROW} .hierarchy-rename-input") && !document.querySelector("${PILL}")`));
+await evaluate(`document.querySelector("${ROOT_ROW} .hierarchy-rename-input").dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }))`);
+expect("Escape puts the pill back, name unchanged", await waitFor(`!!document.querySelector("${PILL}")`) && (await rootLabel()) === "REHEARSAL", String(await rootLabel()));
+
+/* --- the root-row context menu ------------------------------------------------ */
+
+expect("right-clicking the root row opens the scene menu", await openRootMenu());
+const sceneMenu = await menuItems();
+expect("the root menu offers the scene verbs", sceneMenu.join("|") === "Rename|Duplicate|Delete|+ New scene", JSON.stringify(sceneMenu));
+expect("the root menu is not the Add-Object catalogue", await evaluate(`!document.querySelector(".hierarchy-context-menu .catalogue-entry, .hierarchy-context-menu .object-catalogue")`));
+expect("the root menu screenshot has bytes", (await shot("root-context-menu")) > 2000);
+
+await clickMenuItem("Duplicate");
+expect("Duplicate opens the copy", await waitFor(`document.querySelector("${PILL}").textContent.includes("REHEARSAL 2")`), String(await pillLabel()));
+await openPill();
+expect("the duplicate joins the list", (await sceneNames()).length === 4, JSON.stringify(await sceneNames()));
+await closePopovers();
+
+/* --- delete back down to one -------------------------------------------------- */
+
+for (let remaining = 4; remaining > 1; remaining -= 1) {
+	expect(`the root menu opens with ${remaining} scenes`, await openRootMenu());
+	await clickMenuItem("^Delete$");
+	expect("Delete arms before it commits", await waitFor(`[...document.querySelectorAll(".hierarchy-context-menu [role=menuitem]")].some((node) => node.textContent.trim() === "Confirm delete")`));
+	await clickMenuItem("Confirm delete");
+	await waitFor(`!document.querySelector(".hierarchy-context-menu")`);
+	await openPill();
+	expect(`deleting leaves ${remaining - 1} scenes`, (await sceneNames()).length === remaining - 1, JSON.stringify(await sceneNames()));
+	await closePopovers();
+}
+
+expect("the last scene still opens its menu", await openRootMenu());
+const lastMenu = await menuItems();
+expect("Delete is not offered when one scene is all there is", !lastMenu.includes("Delete"), JSON.stringify(lastMenu));
+expect("the other scene verbs stay available", lastMenu.join("|") === "Rename|Duplicate|+ New scene", JSON.stringify(lastMenu));
+await closePopovers();
+await openPill();
+const finalScenes = await sceneNames();
+expect("one scene is left, and the pill names it", finalScenes.length === 1 && (await pillLabel()) === finalScenes[0], JSON.stringify(finalScenes));
+await closePopovers();
+
+writeFileSync(`${out}/summary.json`, JSON.stringify({ finalScenes, lastMenu, sceneMenu }, null, 2));
+expect("browser run has no uncaught page errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+ws.close();
+if (failures) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log(`PASS scene switcher — created, switched, renamed, duplicated and deleted from the tree root row; evidence in ${out}`);

--- a/test/verify-hierarchy.mjs
+++ b/test/verify-hierarchy.mjs
@@ -177,11 +177,35 @@ expect("row handlers never swallow a picture drop", panelSource.includes("if (ca
 for (const callback of ["onSceneSelect", "onSceneCreate", "onSceneDuplicate", "onSceneRename", "onSceneDelete"]) {
 	expect(`panel exposes ${callback}`, panelSource.includes(callback));
 }
-expect("scene selector is separate from entity tree", panelSource.includes('className="scene-switcher"') && panelSource.includes('className="hierarchy-tree"'));
-expect("scene rename supports double-click", panelSource.includes("onDoubleClick={() => setEditingId(scene.id)}"));
+expect(
+	"the scene selector rides the tree root row",
+	panelSource.includes('className="hierarchy-scene-pill"') &&
+		panelSource.includes("const sceneRoot = node.id === SCENE_ROOT_ID;") &&
+		panelSource.includes('ariaLabel={ko("Select scene", "장면 선택")}'),
+);
+expect("the scene list is the portaled Dropdown, so the panel cannot clip it", panelSource.includes('import { Dropdown } from "./ui.jsx"'));
+expect("the scene list ends with a create item", panelSource.includes('{ value: NEW_SCENE_OPTION, label: ko("+ New scene", "+ 새 장면") }'));
+expect("the pill's clicks never reach the row, so picking a scene cannot fold the tree", panelSource.includes("onClick={(event) => event.stopPropagation()}"));
+expect("the root row right-click opens scene verbs, not the object catalogue", panelSource.includes("} else if (id === SCENE_ROOT_ID) {") && panelSource.includes('kind: "scene",'));
+expect(
+	"the root row prints the scene name once: the pill is the name",
+	panelSource.includes("showLabel={!sceneRoot}") &&
+		panelSource.includes("{showLabel && <span className=\"hierarchy-label\">{label}</span>}") &&
+		panelSource.includes("rowExtra={sceneRoot && !editing ? ("),
+);
+// The row outlives its renames: a second rename on the same row must not be
+// blocked by the first session's "already finished" flag.
+expect("the once-only rename flag is per edit session", panelSource.includes("if (editing) doneRef.current = false;"));
+expect("scene rename supports double-click, on the row icon and on the pill", panelSource.includes("onRenameStart={sceneRoot ? () => setEditingId(node.id) : null}") && panelSource.includes("onRenameStart={() => setEditingId(node.id)}"));
+expect("F2 on the root row renames the scene document", panelSource.includes("if (selectedId !== SCENE_ROOT_ID && sceneObjectIdFromHierarchy(selectedId) === null) return;") && panelSource.includes("if (hierarchyId === SCENE_ROOT_ID) {"));
 expect("scene deletion requires a second deliberate click", panelSource.includes("deleteArmed") && panelSource.includes('ko("Confirm delete", "삭제 확인")'));
-expect("active scene clicks do not repeat selection callbacks", panelSource.includes("if (!active) onSceneSelect?.(scene.id)"));
-expect("last scene deletion is protected", panelSource.includes("disabled={availableScenes.length <= 1}"));
+expect("active scene clicks do not repeat selection callbacks", panelSource.includes("else if (value !== activeSceneId) onSceneSelect?.(value)"));
+expect(
+	"last scene deletion is protected, with a reason",
+	panelSource.includes("{menu.canDelete && (") &&
+		panelSource.includes("canDelete: availableScenes.length > 1,") &&
+		panelSource.includes('setSceneHint(ko("At least one scene is required", "장면은 최소 하나 필요합니다"))'),
+);
 expect("entity tree root follows the active scene name", panelSource.includes('node.kind === "scene" ? { ...node, label: activeSceneName } : node'));
 
 // The studio source spans App.jsx and app-stage.jsx (module-level extraction); pin against both.
@@ -199,6 +223,10 @@ expect(
 for (const prop of ["scenes={scenes}", "activeSceneId={activeSceneId}", "onSceneSelect={selectSceneDocument}", "onSceneCreate={createSceneDocumentFromUi}", "onSceneDuplicate={duplicateSceneDocumentFromUi}", "onSceneRename={renameSceneDocumentFromUi}", "onSceneDelete={deleteSceneDocumentFromUi}"]) {
 	expect(`App wires ${prop.split("=")[0]}`, appSource.includes(prop));
 }
+// The project row keeps the name and the dirty dot; opening a project is the
+// Project menu's "Open Project…", not a second button in the hierarchy column.
+expect("the hierarchy column has no duplicate Projects… button", !appSource.includes('ko("Projects…", "프로젝트…")'));
+expect("the Project menu still opens the project browser", appSource.includes('ko("Open Project…", "프로젝트 열기…")'));
 expect("App seals shots inside the active Scene", appSource.includes("shotDocument: shotDocumentRef.current"));
 expect("App persists the unified Scene document", appSource.includes("serializeSceneDocument({"));
 expect("Scene switch snapshots outgoing work first", appSource.indexOf("const savedScenes = snapshotActiveScene();", appSource.indexOf("function selectSceneDocument")) < appSource.indexOf("openScene(target, savedScenes);", appSource.indexOf("function selectSceneDocument")));

--- a/test/verify-korean-ui.mjs
+++ b/test/verify-korean-ui.mjs
@@ -122,7 +122,7 @@ includesAll("src/locale-toggle.jsx", ["한국어로 전환", "한국어", "Switc
 includesAll("src/result-modal.jsx", ["장면이 준비됐어요", "프롬프트 복사", "프레임 다운로드", "AI에 넣는 순서", "AI에 이미지 첨부"]);
 includesAll("src/App.jsx", ["장면", "재생 보기", "속성", "모션 생성", "변환", "카메라 레일 완성", "연결 중…"]);
 includesAll("src/ardy/client.js", ["브리지 상태가 좋지 않아요", "브리지에 연결할 수 없어요", "생성 응답에 본문 스트림이 없어요"]);
-includesAll("src/hierarchy-panel.jsx", ["이름 바꾸기", "장면 구조", "장면 계층", "프레임 맞추기", "장면 문서", "+ 새 장면", "장면은 최소 하나 필요합니다"]);
+includesAll("src/hierarchy-panel.jsx", ["이름 바꾸기", "장면 구조", "장면 계층", "프레임 맞추기", "장면 선택", "+ 새 장면", "장면은 최소 하나 필요합니다"]);
 includesAll("src/ardy/timeline.jsx", ["애니메이션 타임라인", "프롬프트", "타임라인 펼치기"]);
 includesAll("src/posestudio.jsx", ["포즈 스튜디오", "포즈 적용", "포즈 저장"]);
 includesAll("src/ardy/waypoints.js", ["핀 사이에는 최소", "자연스럽게 걷기엔 너무 느려요", "이전 구간보다 속도가"]);

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -179,13 +179,14 @@ const BROWSER_FILES = [
 	"test/verify-project-menu-browser.mjs",
 	"test/qa-keyframe-pack-browser.mjs",
 	"test/qa-reference-slots-browser.mjs",
+	"test/qa-scene-switcher-browser.mjs",
 	"test/qa-send-to-ai-browser.mjs",
 ];
 
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-send-to-ai-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
## What changed

The hierarchy column stacked three layers above the tree — a Project row, a Scenes block, and the tree whose root row already **is** the active scene document. Two of them said the same thing twice. Now it is two layers, with every scene-document verb kept (R1, discussion rounds 3 & 6).

The root row reads `▾ [scene icon] ( SCENE 01 ▾ )` — **the pill is the row's name**, not a second copy of it (review round 2).

- **src/App.jsx** — deleted the `Projects…` button in `.hierarchy-project` (the Project menu's `Open Project…` already does exactly this; c95d478 removed it once and 3fa3006 put it back). The row keeps the project name and the dirty dot.
- **src/hierarchy-panel.jsx**
  - deleted `SceneSwitcher` (list + `+ New Scene` + the `Scene…` `<details>` with Duplicate/Rename/Delete) and its mount;
  - the tree **root row** carries a **scene pill** in place of its label text: active scene name + caret, `aria-label={ko("Select scene","장면 선택")}`. Clicking it opens `ui.jsx`'s portaled `Dropdown` listing every scene (the active one `aria-selected` + ticked) plus a final `+ New scene`. Portaled on purpose: `.hierarchy-left { overflow: hidden }` would clip an in-place menu. Keyboard nav (Esc / ↑↓ / Enter) comes with `Dropdown`;
  - the row keeps its scene icon and its expand caret as separate controls, and still names itself for assistive tech (`aria-label` on the row button). The pill's clicks `stopPropagation`, so picking a scene never folds the tree (QA asserts `aria-expanded` stays `true`);
  - **root-row right-click** is a scene-document menu — `Rename` / `Duplicate` / `Delete` / `+ New scene` — routed to the `onScene*` callbacks; `openRowMenu` no longer falls through to the Add-Object catalogue for the root;
  - **Delete** keeps the switcher's two-click arm (`Delete` → `Confirm delete`; a scene delete is not undoable), is **not rendered at all** when one scene is left, and if that path is reached anyway the panel says why: `ko("At least one scene is required","장면은 최소 하나 필요합니다")` as an inline `role="status"` hint. `scenes.js:339-367`'s guard is untouched;
  - **F2 / Enter** from the tree and a **double-click on the pill** (or on the row icon) open the same inline input **in the pill's place**, committed through `onSceneRename`; the object rename path is unchanged;
  - **bug found while wiring the second rename**: `TreeRow`'s once-only rename flag (`doneRef`) was per ROW, not per edit session, so a second rename on the same row could neither commit nor cancel — the input just sat there. It now resets when an edit session opens. This also fixes renaming the same object row twice.
- **src/styles.css** — removed the dead `.scene-switcher*`, `.scene-list*`, `.scene-create-button`, `.scene-rename-input`, `.scene-actions*`, `.scene-actions-pop` (the shared `<details>` rules stay for `.object-colors-pop`) and `.hierarchy-project button` rules; added `.hierarchy-scene-pill` and `.hierarchy-row.icon-only` on existing tokens (`--card2`, `--line2`, `--accent`, `--muted`, 10px row type, 999px pill like `.hierarchy-badge`/`.hierarchy-frame-status`). The pill is `flex: 0 1 122px; max-width: calc(100% - 52px)`, so a narrowed hierarchy column shrinks it instead of overflowing.

## Control count

`git show origin/chore/studio-ui-ia:tools/qa/studio-control-count.mjs`, `QA_URL=http://127.0.0.1:5192/app/`:

| | hierarchy region |
|---|---|
| before (385d340) | **16** — `Projects…`, `+ New Scene`, scene-list `SCENE 01`, `＋Add object`, 8 tree rows, 4 carets |
| after | **14** — `＋Add object`, `Select scene` (the pill), 8 tree rows, 4 carets |

Totals per state: scene-none 45→43, scene-char 45→43, camera 50→48, motion 57→55. Unchanged by the review fix (one fewer text span, same buttons).

Note on the doc's `16 → 12`: `docs/studio-ui-ia.md` budgets "트리 행 8 + 캐럿 3" = 11, but the tree renders **4** carets (`SCENE 01`, `Characters`, `Character 1`, `Rig`), and the new pill is itself a counted button. Keeping every tree row and caret — which this issue does — the floor is 14, not 12. Three controls removed, one added; the switcher's Duplicate/Rename/Delete never counted because a closed `<details>` hides them.

## Browser QA

New: **`test/qa-scene-switcher-browser.mjs`** (same shape as the other `qa-*-browser.mjs` suites, driven by `tools/qa-browser.mjs` + CDP; every wait is on a state condition — no sleeps). It creates two scenes from the pill's `+ New scene`, switches between all three via the pill, renames the active one with F2, renames again by double-clicking the pill (Escape reverts), duplicates from the root-row context menu, deletes back down to one, and asserts `Delete` is absent at one scene while `Rename`/`Duplicate`/`+ New scene` remain. Registered in `tools/run-tests.mjs` (`BROWSER_FILES` + `EXTRA_INVENTORY`).

```
QA_URL=http://127.0.0.1:5192/app/ CDP_PORT=9271 node tools/qa-browser.mjs -- node test/qa-scene-switcher-browser.mjs
51 PASS, 0 FAIL, including:
PASS the hierarchy column carries no second Projects… button
PASS the root row prints the scene name once, in the pill
PASS the row still names itself for assistive tech
PASS the pill announces itself as the scene selector
PASS + New scene opens SCENE 02 / SCENE 03
PASS all three scenes are listed
PASS the active scene is marked in the list
PASS the pill list is portaled clear of the panel that clips it
PASS opening the pill does not fold the tree
PASS picking a scene from the pill switches document
PASS F2 on the root row opens an inline rename
PASS the rename reaches the scene document
PASS double-clicking the pill opens the inline rename in its place
PASS Escape puts the pill back, name unchanged
PASS the root menu offers the scene verbs
PASS the root menu is not the Add-Object catalogue
PASS Duplicate opens the copy
PASS Delete arms before it commits  (×3)
PASS Delete is not offered when one scene is all there is
PASS browser run has no uncaught page errors
```

Also re-ran `test/qa-multichar-rig-browser.mjs` (touches the same rows): all checks passed.

## Screenshots

Pill open with three scenes — the name appears once, in the pill; the active scene is ticked and `+ New scene` is last:

![pill open](/tmp/pr192-qa/pill-open-three-scenes.png)

Root-row context menu (scene verbs, not the Add-Object catalogue):

![root context menu](/tmp/pr192-qa/root-context-menu.png)

Korean locale, default column width, pill closed:

![ko default](/tmp/look192g/ko-default-width.png)

Korean locale, hierarchy column narrowed to 190 px, pill open:

![ko narrow](/tmp/look192g/ko-narrow-open.png)

Files: `/tmp/pr192-qa/pill-open-three-scenes.png`, `/tmp/pr192-qa/root-context-menu.png`, `/tmp/look192g/ko-default-width.png`, `/tmp/look192g/ko-narrow-open.png`

## Tests

```
node tools/run-tests.mjs
TEST MANIFEST scope=all runnable=158 total=177
PASS 158 Node verification files
```

Updated: `test/verify-hierarchy.mjs` (switcher assertions → pill / icon-only root row / root-menu / F2 / hint / per-session rename-flag assertions, plus two pinning the `Projects…` removal and the surviving `Open Project…`), `test/verify-korean-ui.mjs` (`장면 문서` → `장면 선택`, the pill's aria-label). `test/verify-project.mjs`, `test/verify-beginner-screen.mjs` and `test/qa-multichar-rig-browser.mjs` needed no change (`rg -n 'scene-switcher|SceneSwitcher|New Scene|Scene…|scene-actions|Projects…' test/` now returns only the new QA suite).

Rebased on `edbd9cf` (#198); earlier on `8be6473` (#196) — no `beginnerMode` anywhere on this branch, no conflict with the timeline `workflowMode` work.

## Noticed, not fixed (out of scope)

- The `Blocking` frame-status chip renders twice in the hierarchy column — once in `.hierarchy-heading`, once in `.hierarchy-toolbar` (`hierarchy-panel.jsx`, pre-existing).
- `test/process/verify-bridge-launch.mjs` flaked once on a bridge-port collision with the dev server this PR's QA ran against (`64604 !== 64602`); it passes standalone and on every later full run.

Closes #192.
