### PR TITLE
feat(timeline): motion-layer track tools render only in Motion mode; Foot snap and Body contact live under IK (#191)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13051,6 +13051,7 @@ function resizePromptClip(id, edge, rawFrame) {
 				ghostLayers={ghostLayers}
 				pathSpeed={pathSpeed}
 				playing={tlPlaying}
+				workflowMode={workflowMode}
 				waypointMode={waypointMode}
 				waypoints={waypoints}
 				pathSpeed={pathSpeed}

--- a/src/ardy/timeline.jsx
+++ b/src/ardy/timeline.jsx
@@ -953,6 +953,12 @@ export default function Timeline({
 	// cast's schedule is visible while only the active layer is editable.
 	ghostLayers = [], // [{ owner, promptClips: [], waypointFrames: [] }]
 	waypointMode,
+	// Which department the studio is in ("scene" | "camera" | "motion"). The
+	// motion-layer track tools — Prompts +, the Full-Body Cut, the trim and
+	// retime grips — only mean something while motion is the job, so they are
+	// not rendered anywhere else. The Root path (Waypoint) toggle stays in
+	// every mode: blocking uses it to stage where a subject walks.
+	workflowMode = "motion",
 	waypoints = [],
 	pathSpeed = null, // { min, max, warn } in m/s, shown on the 2D Root label
 	badge,
@@ -1709,6 +1715,13 @@ export default function Timeline({
 			return shift === 0 ? segment : { ...segment, timelineStart: segment.timelineStart + shift, timelineEnd: segment.timelineEnd + shift };
 		});
 	})();
+	// The motion-layer track tools (Prompts +, the Full-Body Cut, the trim and
+	// retime grips) edit the take, so Scene and Camera never render them.
+	const motionTools = workflowMode === "motion";
+	// A trim or retime grip edits ONE segment: it belongs to the segment the
+	// playhead selects. The trim preview clip carries the live gesture, so it
+	// keeps its grips while the pointer is down.
+	const segmentTools = (segment) => motionTools && (segment.preview === true || selectedMotionSegment?.id === segment.id);
 	const changeSelectedMotionSpeed = (speed) => {
 		if (!selectedMotionSegment || !Number.isFinite(speed)) return;
 		handlers.current.onMotionSpeedChange?.(selectedMotionSegment.id, Math.max(0.1, Math.min(4, speed)));
@@ -1773,37 +1786,47 @@ export default function Timeline({
 							</button>
 						</div>
 						<div className="tl-head-group tl-pose-tools" role="group" aria-label={ko("Pose correction tools", "포즈 보정 도구")} style={TL_HEAD_GROUP_STYLE}>
-							<button
-								type="button"
-								className={"tl-btn ik" + (ikMode ? " on" : "")}
-								aria-pressed={ikMode}
-								disabled={ikDisabled && !ikMode}
-								aria-label={ko("Inverse kinematics", "역운동학")}
-								title={ikDisabled && !ikMode ? ko("IK needs Subject 1's rig loaded", "IK를 사용하려면 인물 1의 리그를 먼저 불러와야 해요") : ko("IK mode — drag a wrist / ankle handle; keys land on the Full-Body lane. With a motion loaded, keys correct it layer-style", "IK 모드 — 손목이나 발목 핸들을 드래그하세요. 키는 전신 레인에 찍히며, 모션을 불러온 뒤에는 레이어 방식으로 보정합니다")}
-								onClick={() => handlers.current.onIkToggle?.()}
-							>
-								{isKo ? `IK ${ikMode ? "켜짐" : "꺼짐"}` : `IK ${ikMode ? "on" : "off"}`}
-							</button>
-							<button
-								type="button"
-								className={"tl-btn ik snap" + (footSnap ? " on" : "")}
-								aria-pressed={footSnap}
-								aria-label={ko("Foot snap", "발 스냅")}
-								title={ko("Foot snap — keep the feet planted while you move the body (hips); the knees bend instead of the feet sinking through the floor", "발 스냅 — 몸(엉덩이)을 움직여도 발을 바닥에 고정합니다. 발이 바닥으로 가라앉는 대신 무릎이 구부러집니다")}
-								onClick={() => handlers.current.onFootSnapToggle?.()}
-							>
-								{isKo ? `스냅 ${footSnap ? "켜짐" : "꺼짐"}` : `Snap ${footSnap ? "on" : "off"}`}
-							</button>
-							<button
-								type="button"
-								className={"tl-btn ik contact" + (bodyContact ? " on" : "")}
-								aria-pressed={bodyContact}
-								aria-label={ko("Body contact", "바닥 접촉")}
-								title={ko("Body contact — keep hands, knees, feet, head, and hips above the floor", "바닥 접촉 — 손, 무릎, 발, 머리, 엉덩이가 바닥 아래로 내려가지 않게 합니다")}
-								onClick={() => handlers.current.onBodyContactToggle?.()}
-							>
-								{isKo ? `바닥 접촉 ${bodyContact ? "켜짐" : "꺼짐"}` : `Body contact ${bodyContact ? "on" : "off"}`}
-							</button>
+							{/* No rig, no pose editing: the group says why instead of
+							    offering a button that cannot do anything (R3). */}
+							{ikDisabled && !ikMode ? (
+								<span className="tl-pose-hint">{ko("Load a rig to edit poses", "리그를 로드하면 포즈를 편집할 수 있어요")}</span>
+							) : (<>
+								<button
+									type="button"
+									className={"tl-btn ik" + (ikMode ? " on" : "")}
+									aria-pressed={ikMode}
+									aria-label={ko("Inverse kinematics", "역운동학")}
+									title={ko("IK mode — drag a wrist / ankle handle; keys land on the Full-Body lane. With a motion loaded, keys correct it layer-style", "IK 모드 — 손목이나 발목 핸들을 드래그하세요. 키는 전신 레인에 찍히며, 모션을 불러온 뒤에는 레이어 방식으로 보정합니다")}
+									onClick={() => handlers.current.onIkToggle?.()}
+								>
+									{isKo ? `IK ${ikMode ? "켜짐" : "꺼짐"}` : `IK ${ikMode ? "on" : "off"}`}
+								</button>
+								{/* Foot snap and Body contact only reinterpret an IK drag, so
+								    they live for exactly as long as IK does (R7). Two
+								    independent bits, two toggles. */}
+								{ikMode && (<>
+									<button
+										type="button"
+										className={"tl-btn ik snap" + (footSnap ? " on" : "")}
+										aria-pressed={footSnap}
+										aria-label={ko("Foot snap", "발 스냅")}
+										title={ko("Foot snap — keep the feet planted while you move the body (hips); the knees bend instead of the feet sinking through the floor", "발 스냅 — 몸(엉덩이)을 움직여도 발을 바닥에 고정합니다. 발이 바닥으로 가라앉는 대신 무릎이 구부러집니다")}
+										onClick={() => handlers.current.onFootSnapToggle?.()}
+									>
+										{isKo ? `스냅 ${footSnap ? "켜짐" : "꺼짐"}` : `Snap ${footSnap ? "on" : "off"}`}
+									</button>
+									<button
+										type="button"
+										className={"tl-btn ik contact" + (bodyContact ? " on" : "")}
+										aria-pressed={bodyContact}
+										aria-label={ko("Body contact", "바닥 접촉")}
+										title={ko("Body contact — keep hands, knees, feet, head, and hips above the floor", "바닥 접촉 — 손, 무릎, 발, 머리, 엉덩이가 바닥 아래로 내려가지 않게 합니다")}
+										onClick={() => handlers.current.onBodyContactToggle?.()}
+									>
+										{isKo ? `바닥 접촉 ${bodyContact ? "켜짐" : "꺼짐"}` : `Body contact ${bodyContact ? "on" : "off"}`}
+									</button>
+								</>)}
+							</>)}
 						</div>
 						{(selectedMotionSegment || onClearMotion) && (
 							<div className="tl-head-group tl-motion-tools" role="group" aria-label={ko("Motion controls", "모션 컨트롤")} style={TL_HEAD_GROUP_STYLE}>
@@ -1962,7 +1985,7 @@ export default function Timeline({
 												: `${pathSpeed.min.toFixed(1)}–${pathSpeed.max.toFixed(1)} m/s`}
 										</em>
 									)}
-									{name === "Prompts" && <button className="tl-track-add" type="button" title={ko("Add a 2–4 second prompt clip — one action per block", "2–4초 프롬프트 클립 추가 — 한 블록에 한 동작")} onClick={() => handlers.current.onPromptAdd?.(frame)}>+</button>}
+									{motionTools && name === "Prompts" && <button className="tl-track-add" type="button" title={ko("Add a 2–4 second prompt clip — one action per block", "2–4초 프롬프트 클립 추가 — 한 블록에 한 동작")} onClick={() => handlers.current.onPromptAdd?.(frame)}>+</button>}
 									{name === SHOTS_LANE && (
 										<button
 											type="button"
@@ -1984,7 +2007,9 @@ export default function Timeline({
 											+
 										</button>
 									)}
-									{name === IK_LANE && motion && (
+									{/* Cutting the take addresses the selected segment, so it is
+									    offered only where that selection means something (R2). */}
+									{name === IK_LANE && motion && motionTools && selectedMotionSegment && (
 										<button
 											className="tl-track-add motion-cut"
 											type="button"
@@ -2224,7 +2249,7 @@ export default function Timeline({
 												handlers.current.onMotionSegmentRemove?.(segment.id);
 											}}
 										>
-											{index === 0 && <button
+											{index === 0 && segmentTools(segment) && <button
 												className="tl-motion-clip-handle start"
 												type="button"
 												aria-label={ko("Trim take start", "테이크 시작점 자르기")}
@@ -2239,7 +2264,7 @@ export default function Timeline({
 													? `${trimPreview.start}–${trimPreview.end} (${trimPreview.end - trimPreview.start + 1}f)`
 													: `${index + 1} · ${segment.previewSpeed ?? segment.speed}×`}
 											</span>
-											{!segment.preview && <button
+											{!segment.preview && segmentTools(segment) && <button
 												className="tl-motion-clip-handle speed"
 												type="button"
 												aria-label={ko("Retime segment by stretch", "드래그로 구간 배속 조절")}
@@ -2249,7 +2274,7 @@ export default function Timeline({
 												onPointerUp={endMotionSpeed}
 												onPointerCancel={endMotionSpeed}
 											/>}
-											{index === displayMotionSegments.length - 1 && <button
+											{index === displayMotionSegments.length - 1 && segmentTools(segment) && <button
 												className="tl-motion-clip-handle end"
 												type="button"
 												aria-label={ko("Trim take end", "테이크 끝점 자르기")}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5210,6 +5210,14 @@ input[type=range]::-moz-range-thumb {
 	color: #ffd166;
 }
 
+/* A tool group with nothing to offer yet says why, in the same quiet voice
+   the timeline head uses for its other hints. */
+.tl-pose-hint {
+	font-size: 10.5px;
+	color: var(--muted);
+	white-space: nowrap;
+}
+
 .tl-playhead {
 	position: absolute;
 	top: 0;

--- a/test/verify-ik-browser.mjs
+++ b/test/verify-ik-browser.mjs
@@ -102,6 +102,16 @@ const contactTable = async (label) => {
 	console.log(`${label} skinned-mesh min Y`, JSON.stringify(values));
 	return values;
 };
+// Foot snap and Body contact are IK drag modifiers, so they only exist while
+// IK does (#191). Every fresh navigation lands with IK off: enter it before
+// reading or driving the contact toggle.
+const ikButton = (state) => `[...document.querySelectorAll("button")].find((item) => item.textContent.trim() === "IK ${state}")`;
+const enterIk = async () => {
+	expect("IK rig resolves", await waitFor("!!window.__cozyclay?.ikChains", 10000));
+	if (!(await evaluate("window.__cozyclay?.ikMode === true"))) await evaluate(`(${ikButton("off")})?.click()`);
+	expect("IK mode is on before the contact toggle", await waitFor("window.__cozyclay?.ikMode === true", 4000));
+	expect("Body contact appears with IK on", await waitFor(`!!(${contactButton})`, 4000));
+};
 const toggleContact = async (on) => {
 	const pressed = await evaluate(`${contactButton}?.getAttribute("aria-pressed") === "true"`);
 	if (pressed !== on) await evaluate(`(${contactButton})?.click()`);
@@ -111,6 +121,8 @@ const toggleContact = async (on) => {
 await send("Page.navigate", { url: `${baseUrl}?motion=/demo/qa-lying.npz` });
 expect("app becomes ready", await waitFor("!!window.__cozyclay?.rigA && !window.__cozyclay?.ikMode", 10000));
 expect("lying QA motion becomes ready", await waitFor("!!window.__cozyclay?.motion", 10000));
+expect("body contact stays hidden while IK is off", await evaluate(`!(${contactButton})`));
+await enterIk();
 expect("body contact toggle exists", await evaluate(`!!(${contactButton})`));
 const radii = await evaluate("window.__cozyclay.contactRadii");
 console.log("measured contact radii", JSON.stringify(radii));
@@ -126,6 +138,7 @@ await toggleContact(true);
 
 await send("Page.navigate", { url: `${baseUrl}?motion=/demo/walk-then-stop.npz` });
 expect("walk motion resets after contact regression", await waitFor("!!window.__cozyclay?.rigA && !!window.__cozyclay?.motion", 10000));
+await enterIk();
 const walkOn = await contactTable("walk-then-stop ON");
 await toggleContact(false);
 const walkOff = await contactTable("walk-then-stop OFF");
@@ -136,6 +149,7 @@ await toggleContact(true);
 // world matrix at fixed frames with the toggle in both states.
 await send("Page.navigate", { url: `${baseUrl}?motion=/demo/qa-lying.npz` });
 expect("playback identity fixture loads", await waitFor("!!window.__cozyclay?.rigA && !!window.__cozyclay?.motion", 10000));
+await enterIk();
 await toggleContact(true);
 const playbackOn = {};
 for (const frame of [0, 23, 47, 71]) { await evaluate(`window.__cozyclay.scrub(${frame})`); await waitFor(`window.__cozyclay.tlFrame === ${frame}`, 2000); playbackOn[frame] = await boneSnapshot(); }

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -349,12 +349,30 @@ expect(
 	(app.match(/motionFullRef\.current\.set\(/g) ?? []).length >= 4,
 );
 expect(
-	"the timeline receives the active take and both trim handlers",
+	"the timeline receives the active take, both trim handlers, and the department it draws for",
 	app.includes("onMotionTrim={applyMotionTrim}") &&
 	app.includes("onMotionTrimReset={resetMotionTrim}") &&
 	app.includes("motion={motion ? {") &&
 	app.includes("frames: motion.frames,") &&
-	app.includes("segments: motionEditLayout("),
+	app.includes("segments: motionEditLayout(") &&
+	app.includes("workflowMode={workflowMode}"),
+);
+// Trim, retime and Cut edit the take: Scene and Camera never draw them, and
+// inside Motion they belong to the segment the playhead selects (#191).
+expect(
+	"take trim, retime and Cut render only in Motion mode on the selected segment",
+	timeline.includes('const motionTools = workflowMode === "motion";') &&
+	timeline.includes("segmentTools = (segment) => motionTools && (segment.preview === true || selectedMotionSegment?.id === segment.id)") &&
+	timeline.includes("segmentTools(segment) && <button") &&
+	timeline.includes("name === IK_LANE && motion && motionTools && selectedMotionSegment && ("),
+);
+// Foot snap and Body contact only reinterpret an IK drag (R7).
+expect(
+	"foot snap and body contact stay under IK, as two independent toggles",
+	timeline.includes("{ikMode && (<>") &&
+	timeline.includes('"tl-btn ik snap"') &&
+	timeline.includes('"tl-btn ik contact"') &&
+	timeline.includes('ko("Load a rig to edit poses"'),
 );
 expect("a deleted character takes its full take with it", app.includes("motionFullRef.current.delete(charId);"));
 

--- a/test/verify-motion-edit-browser.mjs
+++ b/test/verify-motion-edit-browser.mjs
@@ -57,6 +57,15 @@ await send("Page.enable");
 await send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-motion", value: "reduce" }] });
 await send("Page.navigate", { url: process.env.QA_URL ?? "http://127.0.0.1:5180/app/" });
 expect("app becomes ready", await waitFor("!!window.__cozyclay?.rigA"));
+// The Full-Body track tools (Cut, trim, retime) and the segment-speed editor
+// belong to Motion mode (#191): pick the department before editing the take.
+expect("Motion mode is selectable", await evaluate(`(() => {
+	const tab = [...document.querySelectorAll('.workflow-mode-switch button')].find((item) => ['Motion', '\ubaa8\uc158'].includes(item.textContent.trim()));
+	if (!tab) return false;
+	tab.click();
+	return true;
+})()`));
+expect("the studio switches to Motion mode", await waitFor("document.querySelector('.app')?.dataset.workflowMode === 'motion'"));
 expect("the demo take draws one Full-Body segment", await waitFor("document.querySelectorAll('.tl-motion-clip').length === 1"));
 
 const initial = await evaluate(`(() => {


### PR DESCRIPTION
Closes #191

`styles.css` already hides the timeline's motion **header** groups (`.tl-pose-tools`, `.tl-motion-tools`, `.take-bar`) outside Motion mode, but the **track** level leaked: with a take loaded, Scene and Camera still drew the Prompts lane `+`, the Full-Body `Cut`, both trim handles and the retime grip. This closes those leaks by conditional render (R2), and folds the IK drag modifiers under IK (R3/R7).

Rebased on `origin/main` 8be6473 (#196): no `advancedMode` reference remains — the Prompts `+` is gated on `workflowMode === "motion"` alone.

## Changes

- `src/App.jsx` — one line: `workflowMode={workflowMode}` on `<Timeline>`.
- `src/ardy/timeline.jsx`
  - accepts `workflowMode` (default `"motion"`), derives `motionTools` and a per-segment `segmentTools(segment)`;
  - **Prompts lane `+`** — Motion mode only;
  - **Full-Body `Cut`** — Motion mode + a selected segment;
  - **trim start/end handles, retime grip** — Motion mode + *that* segment selected. The trim preview clip keeps its grips for the length of the gesture, so a drag still completes;
  - **IK button** — not rendered at all without `ikChains`; the group header says `ko("Load a rig to edit poses", "리그를 로드하면 포즈를 편집할 수 있어요")` instead of a disabled button. Button text stays exactly `IK on` / `IK off`;
  - **Foot snap / Body contact** — rendered only while `ikMode`. Still **two** toggles with the verbatim labels `Snap on/off` and `Body contact on/off`, because they are two independent bits;
  - Segment speed / Clear motion were already conditional (`selectedMotionSegment` / `onClearMotion`) — left as they are.
- `src/styles.css` — one new rule, `.tl-pose-hint` (same 10.5px / `var(--muted)` tokens the timeline head already uses for hints). No mode rule touched.
- **Waypoint (Root path) stays in every mode on purpose**: it is how an author stages where a subject walks while blocking a scene, so it is not a motion-only tool. Shot `Cut`/`Split`, the shot boundary handles and the camera bar are untouched (already selection-gated).

## Control counts — `tools/qa/studio-control-count.mjs`

Same script, same 1600×1000 viewport, a take loaded (`?motion=/demo/walk-then-stop.npz`), before = `origin/main` 8be6473:

| state | before | after |
| --- | --- | --- |
| scene-none | 49 | **44** |
| scene-char | 49 | **44** |
| camera | 54 | **49** |
| motion | 65 | **63** |

Scene target (≤44) met. Timeline region, Scene mode:

- before: `… Root path mode, Collapse timeline, +, Cut, Trim take start, Retime segment by stretch, Trim take end, + Add shot`
- after: `… Root path mode, Collapse timeline, + Add shot`

Motion mode loses exactly `Foot snap` and `Body contact` while IK is off (65 → 63); with IK on they are both back.

Artifacts (local run): `/tmp/pr191-counts.json`, `/tmp/pr191-motion.png` (Motion + take, IK off), `/tmp/pr191-motion-ik-on.png` (Snap + Body contact present), `/tmp/pr191-scene-take.png` (Scene with the same take: no Cut / trim / retime / Prompts +), `/tmp/pr191-dom.json`.

## DOM evidence (same CDP session, take loaded)

| mode | Full-Body `Cut` | trim handles | retime grips | Prompts `+` | `Snap` | `Body contact` | Waypoint |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Scene | 0 | 0 | 0 | 0 | 0 | 0 | 1 |
| Camera | 0 | 0 | 0 | 0 | 0 | 0 | 1 |
| Motion, IK off | 1 | 2 | 1 | 1 | 0 | 0 | 1 |
| Motion, IK on | 1 | 2 | 1 | 1 | 1 | 1 | 1 |

Counted with `document.querySelectorAll` inside `.tl-track.ik` / `.tl-motion-clip-handle.*` / `.tl-track.prompts .tl-track-add` and by exact button text — these are DOM absences, not `display: none`.

## Tests

`node tools/run-tests.mjs` (after the rebase, after `npm run build`):

```
TEST MANIFEST scope=all runnable=158 total=176
…
PASS 158 Node verification files
```

Browser suites, against `npm run dev -- --port 5291` on this branch:

- `QA_URL='http://127.0.0.1:5291/app/?motion=/demo/walk-then-stop.npz' node tools/qa-browser.mjs -- node test/verify-motion-edit-browser.mjs` → **all motion edit browser checks PASS** (28/28). It now picks Motion mode before editing the take; that also fixes its pre-existing failure `speed editor lives outside the segment and is visible`, which the mode CSS had been failing on `origin/main`.
- `QA_URL=http://127.0.0.1:5291/app/ node tools/qa-browser.mjs -- node test/verify-ik-browser.mjs` → **all IK browser checks PASS** (82/82). It enters IK (clicking the button whose text is `IK off`) before every `Body contact` interaction, and asserts the toggle is absent while IK is off. The `IK on`/`IK off` exact-text steps are unchanged.

Updated tests:

- `test/verify-ik-browser.mjs` — `enterIk()` helper before each contact section; new check `body contact stays hidden while IK is off`.
- `test/verify-motion-edit-browser.mjs` — switches to Motion mode after the app is ready.
- `test/verify-layout.mjs` — the motion-trim source contract now also pins `workflowMode={workflowMode}` on the Timeline mount, the `motionTools` / `segmentTools` gating and the IK-only Snap/Body-contact block.

## Noted, not fixed (out of scope for #191)

- One IK browser run showed a flaky `front view exposes <control>` block (visibility raycast right after the app reset); two subsequent runs of the same commit passed 82/82. That section is untouched by this PR.
- The Full-Body lane's IK **key** `+` (`name === IK_LANE && ikMode`) still renders in Scene/Camera if IK was left on. It is not in this issue's list; reporting only.
