### PR TITLE
feat(viewport): View menu for grid, Auto Color and part colours; character Transform becomes a Placement row in Motion (#194)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1172,7 +1172,10 @@ globalThis.playMode = centerTab === "play";
 		setCenterTab("scene");
 		if (next === "camera") setSelectedHierarchyId("camera");
 		else if (next === "motion") {
-			setSelectedHierarchyId("characters");
+			// The active character's ROW, not the group: the placement gizmo only
+			// renders for a specific cast member, so selecting the group used to
+			// drop the operator into Motion with nothing to drag.
+			setSelectedHierarchyId(rowIdForCharIndex(activeCharIndex));
 			// Selecting Motion should land on its first useful control rather than
 			// leaving the operator to hunt through a long inspector column.
 			setPromptBlocksReveal((signal) => signal + 1);
@@ -3023,6 +3026,31 @@ globalThis.playMode = centerTab === "play";
 			window.removeEventListener("keydown", onKeyDown);
 		};
 	}, [exportMenuOpen]);
+	// `View ▾` on the viewport bar (#194): one home for the display-only
+	// toggles that used to be scattered across the topbar, the scene bar and
+	// the inspector. Same dismissal as the two menus above, plus focus
+	// returning to the trigger on Escape — the bar is a keyboard stop.
+	const [viewMenuOpen, setViewMenuOpen] = useState(false);
+	const [viewMenuAnchor, setViewMenuAnchor] = useState({ top: 0, right: 0 });
+	const viewMenuTriggerRef = useRef(null);
+	useEffect(() => {
+		if (!viewMenuOpen) return undefined;
+		const onPointerDown = (event) => {
+			if (event.target instanceof Element && event.target.closest(".view-menu-wrap")) return;
+			setViewMenuOpen(false);
+		};
+		const onKeyDown = (event) => {
+			if (event.key !== "Escape") return;
+			setViewMenuOpen(false);
+			viewMenuTriggerRef.current?.focus();
+		};
+		document.addEventListener("pointerdown", onPointerDown);
+		window.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("pointerdown", onPointerDown);
+			window.removeEventListener("keydown", onKeyDown);
+		};
+	}, [viewMenuOpen]);
 	const projectHandleRef = useRef(null);
 	const projectSnapshotRef = useRef("");
 	const projectStateRef = useRef(null);
@@ -5001,6 +5029,11 @@ globalThis.playMode = centerTab === "play";
 		|| selectedHierarchyId === "characterA"
 		|| selectedHierarchyId === "characterB"
 		|| selectedHierarchyId.startsWith("character:");
+	// The View menu's three toggles, as the menu reads them: one radio choice
+	// for the part colours, and a dot on the trigger whenever the viewport is
+	// showing something other than the plain stage.
+	const partColoursChoice = partColoursEnabled ? partColoursMode : "off";
+	const viewLooksActive = gridView || autoColor || partColoursEnabled;
 	const rigSelection = parseRigNodeId(selectedHierarchyId);
 	const isRigSelection = rigSelection !== null;
 	const inspectorHasContent = isSceneSelection || isCameraSelection || isCharacterSelection || isRigSelection
@@ -10272,24 +10305,6 @@ function resizePromptClip(id, edge, rawFrame) {
 							{projectStatus}
 						</span>
 					</div>
-					<button
-						type="button"
-						className="auto-color-toggle"
-						aria-pressed={autoColor}
-						title={ko(
-							"Distinct display colors per object — captures include them while on",
-							"오브젝트별 구분 색 — 켜둔 동안 캡처에도 포함됩니다",
-						)}
-						 onClick={() => {
-							setAutoColor((on) => {
-								saveAutoColor(!on);
-								trackFeature("auto_color");
-								return !on;
-							});
-						}}
-					>
-						{ko("Auto Color", "자동 색")}
-					</button>
 					{liveWorkspaceHandle && (
 						<span className="live-workspace-handle" data-live-workspace={liveWorkspaceHandle} title={liveWorkspaceHandle}>
 							{ko("Live workspace", "라이브 작업공간")} {liveWorkspaceHandle}
@@ -10435,15 +10450,6 @@ function resizePromptClip(id, edge, rawFrame) {
 						>
 							{ko("Snap", "스냅")}
 						</button>
-						<button
-							type="button"
-							className={"snap-switch grid-view-switch workflow-scene-context" + (gridView ? " active" : "")}
-							title={ko("Blender-style viewport — dark void with a reference grid instead of the deck", "Blender식 뷰포트 — 데크 대신 어두운 배경과 기준 그리드")}
-							aria-pressed={gridView}
-							onClick={() => setGridView((v) => !v)}
-						>
-							{ko("Grid", "그리드")}
-						</button>
 						<span className="viewport-toolbar-separator settings-separator workflow-camera-context" aria-hidden="true" />
 						<label className="viewport-toolbar-field shot-field workflow-camera-context">
 							<span>{ko("Shot", "샷")}</span>
@@ -10520,6 +10526,108 @@ function resizePromptClip(id, edge, rawFrame) {
 						>
 							{ko("Top", "탑")} {workspaceLayout.insetCollapsed ? "▸" : "▾"}
 						</button>
+						{/* One menu for every viewport-look toggle (R4), in every mode:
+						    what the stage LOOKS like is not a mode's business. The 27px
+						    bar clips its own overflow, so the panel is fixed to the
+						    viewport and anchored to the trigger, like the export menu.
+						    Items keep the menu open: these are toggles you compare, not
+						    commands you fire. */}
+						<div className="view-menu-wrap">
+							<button
+								type="button"
+								className="view-menu-trigger"
+								data-testid="view-menu-trigger"
+								ref={viewMenuTriggerRef}
+								aria-haspopup="menu"
+								aria-expanded={viewMenuOpen}
+								title={ko("Viewport display toggles", "뷰포트 표시 토글")}
+								onClick={(event) => {
+									const box = event.currentTarget.getBoundingClientRect();
+									setViewMenuAnchor({ top: box.bottom + 6, right: Math.max(8, window.innerWidth - box.right) });
+									setViewMenuOpen((open) => !open);
+								}}
+							>
+								{ko("View", "보기")}
+								<span className="caret">▾</span>
+								{viewLooksActive && <span className="view-menu-dot" data-testid="view-menu-dot" aria-hidden="true" />}
+							</button>
+							{viewMenuOpen && (
+								<div
+									className="project-menu view-menu"
+									role="menu"
+									aria-label={ko("Viewport display", "뷰포트 표시")}
+									style={{ top: `${viewMenuAnchor.top}px`, right: `${viewMenuAnchor.right}px` }}
+								>
+									{/* aria-pressed rides along with aria-checked: the toggles
+									    published that state contract in their old homes and QA
+									    still reads it, so the move keeps the signpost (R9). */}
+									<button
+										type="button"
+										role="menuitemcheckbox"
+										className={"view-menu-item grid-view-switch" + (gridView ? " active" : "")}
+										aria-checked={gridView}
+										aria-pressed={gridView}
+										title={ko("Blender-style viewport — dark void with a reference grid instead of the deck", "Blender식 뷰포트 — 데크 대신 어두운 배경과 기준 그리드")}
+										onClick={() => setGridView((v) => !v)}
+									>
+										<span className="view-menu-mark" aria-hidden="true">{gridView ? "✓" : ""}</span>
+										{ko("Reference grid", "기준 그리드")}
+									</button>
+									<button
+										type="button"
+										role="menuitemcheckbox"
+										className={"view-menu-item auto-color-toggle" + (autoColor ? " active" : "")}
+										aria-checked={autoColor}
+										aria-pressed={autoColor}
+										title={ko(
+											"Distinct display colors per object — captures include them while on",
+											"오브젝트별 구분 색 — 켜둔 동안 캡처에도 포함됩니다",
+										)}
+										onClick={() => {
+											setAutoColor((on) => {
+												saveAutoColor(!on);
+												trackFeature("auto_color");
+												return !on;
+											});
+										}}
+									>
+										<span className="view-menu-mark" aria-hidden="true">{autoColor ? "✓" : ""}</span>
+										{ko("Auto Color", "자동 색")}
+									</button>
+									{/* Part colours repaint a BODY, so the section only exists
+									    while a character is selected (R2). */}
+									{isCharacterSelection && (
+										<div className="view-menu-group" role="group" aria-label={ko("Body part colours", "부위 색상")}>
+											<span className="view-menu-label" aria-hidden="true">{ko("Body part colours", "부위 색상")}</span>
+											{[
+												{ value: "off", label: ko("Off", "끕") },
+												{ value: "shaded", label: ko("Shaded", "음영") },
+												{ value: "flat", label: ko("Flat", "평면") },
+											].map((option) => {
+												const checked = option.value === partColoursChoice;
+												return (
+													<button
+														type="button"
+														key={option.value}
+														role="menuitemradio"
+														className={"view-menu-item part-colour-option" + (checked ? " active" : "")}
+														data-part-colours={option.value}
+														aria-checked={checked}
+														onClick={() => {
+															setPartColoursEnabled(option.value !== "off");
+															if (option.value !== "off") setPartColoursMode(option.value);
+														}}
+													>
+														<span className="view-menu-mark" aria-hidden="true">{checked ? "✓" : ""}</span>
+														{option.label}
+													</button>
+												);
+											})}
+										</div>
+									)}
+								</div>
+							)}
+						</div>
 					</div>
 				) : (
 					<div className="editor-toolbar play-tools" aria-label={ko("PlayView tools", "재생 보기 도구")}>
@@ -11314,10 +11422,6 @@ function resizePromptClip(id, edge, rawFrame) {
 						</Field>
 					</Foldout>
 
-				<Foldout hidden={!isCharacterSelection} title={ko("Part colours", "부위 색상")}>
-					<label className="check snap-toggle"><input type="checkbox" checked={partColoursEnabled} onChange={(e) => setPartColoursEnabled(e.target.checked)} /> {ko("Render body parts by colour", "신체 부위를 색상으로 렌더링")}</label>
-					{partColoursEnabled && <div className="move-ab"><button type="button" className={"btn ghost" + (partColoursMode === "shaded" ? " primary" : "")} onClick={() => setPartColoursMode("shaded")}>{ko("Shaded", "음영")}</button><button type="button" className={"btn ghost" + (partColoursMode === "flat" ? " primary" : "")} onClick={() => setPartColoursMode("flat")}>{ko("Flat", "평면")}</button></div>}
-				</Foldout>
 				<Foldout hidden={!isCharacterSelection} title={showB ? ko("Subjects", "인물들") : ko("Subject", "인물")}>
 						<div className={"subjects-row" + (showB ? "" : " single")}>
 							{characters.map((entry, index) => entry.hidden ? null : (
@@ -11345,20 +11449,48 @@ function resizePromptClip(id, edge, rawFrame) {
 						)}
 					</Foldout>
 
-				<Foldout hidden={!isCharacterSelection} title={ko("Transform", "변환")}>
-					<p className="inspector-hint">
-						{ko("Edit the selected subject's placement, turn and size. Drag the Transform tool in the viewport for direct manipulation.", "선택한 인물의 위치·회전·크기를 편집합니다. 뷰포트의 변환 도구를 드래그해 바로 조작할 수도 있어요.")}
-					</p>
-					<Vector3Row
-						label={ko("Position", "위치")}
-						fields={[
-							{ axis: "X", value: activeChar.x, step: 0.05, precision: 2, scrubRange: 5, onChange: (x) => updateCharacterAt(activeCharIndex, { x }) },
-							{ axis: "Y", value: activeChar.y ?? 0, step: 0.05, precision: 2, scrubRange: 5, onChange: (y) => updateCharacterAt(activeCharIndex, { y: Math.max(0, y) }) },
-							{ axis: "Z", value: activeChar.z, step: 0.05, precision: 2, scrubRange: 5, onChange: (z) => updateCharacterAt(activeCharIndex, { z }) },
-						]}
-					/>
-					<Slider compact label={ko("Rotation", "회전")} min={-180} max={180} step={1} value={activeChar.rot ?? 0} unit="°" onChange={(rot) => updateCharacterAt(activeCharIndex, { rot })} />
-					<Slider compact label={ko("Scale", "크기")} min={0.2} max={3} step={0.05} value={activeChar.scale ?? 1} unit="×" onChange={(scale) => updateCharacterAt(activeCharIndex, { scale })} />
+				{/* Scene mode: the viewport gizmo and Move/Rotate/Scale are the primary
+				    path, so the numeric form starts folded (R5). Motion mode hides
+				    those tools, so the same foldout becomes the open Placement row —
+				    where the body stands on stage, which is all Motion can restage.
+				    Foldout reads defaultOpen once, so the key remounts it per mode. */}
+				<Foldout
+					key={workflowMode === "motion" ? "placement" : "transform"}
+					hidden={!isCharacterSelection}
+					defaultOpen={workflowMode === "motion"}
+					title={workflowMode === "motion" ? ko("Placement", "배치") : ko("Transform", "변환")}
+				>
+					{workflowMode === "motion" ? (
+						<div className="placement-fields">
+							<p className="inspector-hint">
+								{ko("Stage position — does not change the take", "무대 위치 — 테이크는 바꾸지 않습니다")}
+							</p>
+							<Vector3Row
+								label={ko("Position", "위치")}
+								fields={[
+									{ axis: "X", value: activeChar.x, step: 0.05, precision: 2, scrubRange: 5, onChange: (x) => updateCharacterAt(activeCharIndex, { x }) },
+									{ axis: "Z", value: activeChar.z, step: 0.05, precision: 2, scrubRange: 5, onChange: (z) => updateCharacterAt(activeCharIndex, { z }) },
+								]}
+							/>
+							<Slider compact label={ko("Rotation", "회전")} min={-180} max={180} step={1} value={activeChar.rot ?? 0} unit="°" onChange={(rot) => updateCharacterAt(activeCharIndex, { rot })} />
+						</div>
+					) : (
+						<>
+							<p className="inspector-hint">
+								{ko("Edit the selected subject's placement, turn and size. Drag the Transform tool in the viewport for direct manipulation.", "선택한 인물의 위치·회전·크기를 편집합니다. 뷰포트의 변환 도구를 드래그해 바로 조작할 수도 있어요.")}
+							</p>
+							<Vector3Row
+								label={ko("Position", "위치")}
+								fields={[
+									{ axis: "X", value: activeChar.x, step: 0.05, precision: 2, scrubRange: 5, onChange: (x) => updateCharacterAt(activeCharIndex, { x }) },
+									{ axis: "Y", value: activeChar.y ?? 0, step: 0.05, precision: 2, scrubRange: 5, onChange: (y) => updateCharacterAt(activeCharIndex, { y: Math.max(0, y) }) },
+									{ axis: "Z", value: activeChar.z, step: 0.05, precision: 2, scrubRange: 5, onChange: (z) => updateCharacterAt(activeCharIndex, { z }) },
+								]}
+							/>
+							<Slider compact label={ko("Rotation", "회전")} min={-180} max={180} step={1} value={activeChar.rot ?? 0} unit="°" onChange={(rot) => updateCharacterAt(activeCharIndex, { rot })} />
+							<Slider compact label={ko("Scale", "크기")} min={0.2} max={3} step={0.05} value={activeChar.scale ?? 1} unit="×" onChange={(scale) => updateCharacterAt(activeCharIndex, { scale })} />
+						</>
+					)}
 				</Foldout>
 
 				{/* Rig and Pose are chosen once when a character is cast and then left

--- a/src/styles.css
+++ b/src/styles.css
@@ -821,34 +821,6 @@ select {
 	flex: 1;
 }
 
-/* Auto color: compact topbar chrome; the pressed state carries the accent so
-   "the viewport is recolored right now" is visible at a glance. */
-.auto-color-toggle {
-	display: inline-flex;
-	align-items: center;
-	height: 28px;
-	padding: 0 10px;
-	border: 1px solid var(--line2);
-	border-radius: 2px;
-	background: #2c2c2c;
-	color: var(--fg);
-	font-size: 10px;
-	font-weight: 620;
-	cursor: pointer;
-}
-
-.auto-color-toggle:hover,
-.auto-color-toggle:focus-visible {
-	border-color: var(--accent);
-	background: var(--accent-soft);
-	outline: none;
-}
-
-.auto-color-toggle[aria-pressed="true"] {
-	border-color: var(--accent);
-	background: var(--accent-soft);
-}
-
 .auto-color-hex {
 	align-self: center;
 	font-size: 10px;
@@ -8912,6 +8884,19 @@ input[type=range] {
 	align-items: center;
 }
 
+/* View ▾ (#194): the viewport bar's own menu of look toggles. It borrows the
+   export menu's trigger and the project menu's popover so the studio keeps one
+   dropdown language; the wrap's auto margin parks it at the bar's right end in
+   every mode, and the dot says a toggle is on without opening the menu. */
+.view-menu-wrap {
+	position: relative;
+	flex: none;
+	margin-left: auto;
+	align-self: stretch;
+	display: flex;
+	align-items: center;
+}
+
 /* The live-workspace handle can fill the row; a settings label that wrapped to
    one glyph per line is how the topbar used to squeeze the language button. */
 .settings-menu-trigger {
@@ -8958,6 +8943,93 @@ input[type=range] {
 .settings-menu button[aria-pressed="true"] .mark {
 	color: var(--cyan);
 }
+
+.view-menu-trigger {
+	position: relative;
+	flex: none;
+	height: 26px;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 0 8px;
+	border: 0;
+	border-left: 1px solid var(--line);
+	background: transparent;
+	color: #bdbdbd;
+	font: inherit;
+	font-size: 9px;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.view-menu-trigger:hover,
+.view-menu-trigger[aria-expanded="true"] {
+	background: #363636;
+	color: #fff;
+}
+
+.view-menu-trigger .caret {
+	color: var(--muted2);
+	font-size: 8px;
+}
+
+.view-menu-dot {
+	width: 5px;
+	height: 5px;
+	border-radius: 50%;
+	background: var(--accent);
+	flex: none;
+}
+
+.view-menu {
+	position: fixed;
+	left: auto;
+	min-width: 200px;
+	z-index: 80;
+}
+
+.view-menu .view-menu-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.view-menu .view-menu-item.active {
+	background: var(--accent-soft);
+}
+
+.view-menu-mark {
+	width: 12px;
+	flex: none;
+	color: var(--accent);
+	font-size: 11px;
+	text-align: center;
+}
+
+.view-menu-group {
+	display: flex;
+	flex-direction: column;
+	margin-top: 4px;
+	padding-top: 4px;
+	border-top: 1px solid var(--line);
+}
+
+.view-menu-label {
+	padding: 4px 10px;
+	color: var(--muted);
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: .04em;
+	text-transform: uppercase;
+}
+
+/* Placement (Motion mode) drops the Y axis: the row is two fields wide, not a
+   truncated XYZ, and the second field is Z — Unity's blue, not the Y green. */
+.placement-fields .vec3-row {
+	grid-template-columns: 56px 1fr 1fr;
+}
+
+.placement-fields .vec3-row .number-field:nth-of-type(2) .axis { color: #79c0ff; }
 
 /* ----------------------------------------------------- Unity axis colors --- */
 /* X red / Y green / Z blue — Unity's axis colour-coding (class-Transform). */
@@ -10309,9 +10381,6 @@ input[type=range] {
 		height: 23px;
 		border: 1px solid var(--line2);
 		border-radius: 3px;
-	}
-	.editor-toolbar.scene-tools > .grid-view-switch {
-		margin-left: 4px;
 	}
 	.editor-toolbar.scene-tools .viewport-toolbar-field,
 	.editor-toolbar.scene-tools .viewport-fov-control {

--- a/test/qa-auto-color-browser.mjs
+++ b/test/qa-auto-color-browser.mjs
@@ -67,8 +67,19 @@ const GREY_BOX = "#c2c6c8"; // src/scene-objects.js:65 — asserted below before
 expect("GREY_BOX constant matches the source", await evaluate(`(${JSON.stringify(GREY_BOX)}).length === 7`) && (await import("node:fs")).readFileSync(new URL("../src/scene-objects.js", import.meta.url), "utf8").includes(`GREY_BOX = "${GREY_BOX}"`));
 expect("mode OFF renders both cubes grey-box", await evaluate(`${sceneColors}.filter(h => h === "${GREY_BOX}").length >= 2`));
 
+// The toggle moved out of the topbar into the viewport bar's View ▾ menu
+// (#194). It kept its class and its aria-pressed contract, so every
+// assertion below is the same one, driven through the menu.
 const toggle = "document.querySelector('.auto-color-toggle')";
-expect("the topbar offers the Auto Color toggle", await evaluate(`!!${toggle}`));
+const openViewMenu = async () => {
+	if (!(await evaluate("!!document.querySelector('.view-menu')"))) {
+		await evaluate("document.querySelector('.view-menu-trigger').click()");
+	}
+	return waitFor("!!document.querySelector('.view-menu')", 8000);
+};
+expect("the viewport bar offers the View menu", await waitFor("!!document.querySelector('.view-menu-trigger')", 15000));
+expect("the View menu opens", await openViewMenu());
+expect("the View menu offers the Auto Color toggle", await evaluate(`!!${toggle}`));
 expect("the toggle starts unpressed", await evaluate(`${toggle}.getAttribute("aria-pressed") === "false"`));
 await evaluate(`${toggle}.click()`);
 await sleep(400);
@@ -91,7 +102,8 @@ expect("the toggle survives the undo", await evaluate(`${toggle}.getAttribute("a
 await send("Page.enable");
 await send("Page.reload", { ignoreCache: false });
 await sleep(1000);
-expect("app returns after reload", await waitFor("!!document.querySelector('.auto-color-toggle')", 30000));
+expect("app returns after reload", await waitFor("!!document.querySelector('.view-menu-trigger')", 30000));
+expect("the View menu reopens after the reload", await openViewMenu());
 expect("the mode survives the reload", await evaluate(`${toggle}.getAttribute("aria-pressed") === "true"`));
 expect("the surviving cube keeps #66b8d6 after reload", await waitFor(`${sceneColors}.includes("#66b8d6")`, 15000));
 

--- a/test/qa-grid-view-browser.mjs
+++ b/test/qa-grid-view-browser.mjs
@@ -53,8 +53,18 @@ const deckPresent = `(() => { let found = false; ${sceneRoot}.traverse((c) => { 
 
 expect("app becomes ready", await waitFor("!!document.querySelector('.add-object-trigger')", 30000));
 expect("the scene graph hook is live", await waitFor("!!window.__cozyclay?.editorCam?.parent", 30000));
+// The toggle folded into the viewport bar's View ▾ menu (#194), keeping its
+// class and aria-pressed contract; the menu is opened before each use.
 const toggle = "document.querySelector('.grid-view-switch')";
-expect("the toolbar offers the Grid toggle", await evaluate(`!!${toggle}`));
+const openViewMenu = async () => {
+	if (!(await evaluate("!!document.querySelector('.view-menu')"))) {
+		await evaluate("document.querySelector('.view-menu-trigger').click()");
+	}
+	return waitFor("!!document.querySelector('.view-menu')", 8000);
+};
+expect("the viewport bar offers the View menu", await waitFor("!!document.querySelector('.view-menu-trigger')", 15000));
+expect("the View menu opens", await openViewMenu());
+expect("the View menu offers the Reference grid toggle", await evaluate(`!!${toggle}`));
 expect("mode OFF shows the clay stage background", await evaluate(`${backgroundHex} === "eef4f3"`));
 expect("mode OFF has the floor deck", await evaluate(deckPresent));
 expect("mode OFF has no grid mesh", await evaluate(`${gridMesh} === null`));
@@ -73,7 +83,8 @@ expect("the preference is stored under its own key", await evaluate(`localStorag
 await send("Page.enable");
 await send("Page.reload", { ignoreCache: false });
 await sleep(1000);
-expect("app returns after reload", await waitFor(`!!${toggle}`, 30000));
+expect("app returns after reload", await waitFor("!!document.querySelector('.view-menu-trigger')", 30000));
+expect("the View menu reopens after the reload", await openViewMenu());
 expect("the mode survives the reload", await waitFor(`${toggle}.getAttribute("aria-pressed") === "true"`, 8000));
 expect("the void background survives the reload", await waitFor(`${backgroundHex} === "2c2e33"`, 8000));
 

--- a/test/qa-view-menu-browser.mjs
+++ b/test/qa-view-menu-browser.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// Browser QA for the viewport bar's View ▾ menu and the mode-aware character
+// Transform foldout (#194), over CDP through the QA browser wrapper:
+//
+//   QA_URL=http://127.0.0.1:5180/app/ node tools/qa-browser.mjs -- \
+//     node test/qa-view-menu-browser.mjs
+//
+// It drives the REAL studio: the menu's open/close behaviour, the three look
+// toggles it now owns (part colours only while a character is selected), the
+// trigger's "something is on" dot, and the foldout that is a folded Transform
+// in Scene mode and an open Placement row in Motion — with the character
+// gizmo mounted, which is the whole point of entering Motion on a character
+// row instead of the group. Evidence script; not part of the manifest.
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+/** poll a page condition — every wait in this file is a state condition, never a delay */
+const waitFor = async (expression, timeoutMs = 15000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 60));
+	}
+	return false;
+};
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+/* ---------------------------------------------------------- page setup --- */
+
+// The QA browser inherits the host locale; pin English so label matching is
+// deterministic, then let the studio boot from that storage.
+await waitFor("location.href.startsWith('http')", 30000);
+await evaluate("localStorage.setItem('cozyclay.locale', 'en')");
+await send("Page.enable");
+await send("Page.reload", { ignoreCache: false });
+expect("the studio comes back up", await waitFor("!!document.querySelector('.add-object-trigger')", 40000));
+expect("the scene-graph hook is live", await waitFor("!!window.__cozyclay?.editorCam?.parent", 30000));
+expect("the hierarchy has rendered", await waitFor("document.querySelectorAll('.hierarchy-row-wrap').length > 0", 15000));
+
+const trigger = "document.querySelector('.view-menu-trigger')";
+const menu = "document.querySelector('.view-menu')";
+const selectRow = async (nodeId) => {
+	await evaluate(`document.querySelector('[data-node-id="${nodeId}"] .hierarchy-row').click()`);
+	return waitFor(`document.querySelector('[data-node-id="${nodeId}"]').getAttribute('aria-selected') === 'true'`, 8000);
+};
+const clickMode = async (label) => {
+	await evaluate(`[...document.querySelectorAll('.workflow-mode-switch button')].find((b) => b.textContent.trim() === ${JSON.stringify(label)}).click()`);
+	return waitFor(`document.querySelector('.app').dataset.workflowMode === ${JSON.stringify(label.toLowerCase())}`, 8000);
+};
+const openMenu = async () => {
+	if (!(await evaluate(`!!${menu}`))) await evaluate(`${trigger}.click()`);
+	return waitFor(`!!${menu}`, 8000);
+};
+/** the one visible foldout with this title, read as its shipped control set */
+const foldout = (title) => evaluate(`(() => {
+	const head = [...document.querySelectorAll('.card.foldout:not([hidden]) .foldout-head')]
+		.find((b) => b.querySelector('.foldout-title')?.textContent.trim() === ${JSON.stringify(title)});
+	if (!head) return null;
+	const card = head.closest('.card.foldout');
+	return {
+		open: head.getAttribute('aria-expanded') === 'true',
+		axes: [...card.querySelectorAll('.foldout-body .vec3-row .axis')].map((s) => s.textContent.trim()),
+		sliders: [...card.querySelectorAll('.foldout-body .cslider-head > span:first-child')].map((s) => s.textContent.trim()),
+	};
+})()`);
+/** gizmo pick proxies live in the scene graph (src/gizmo-claim.js HANDLE_PROXY_FLAG) */
+const gizmoProxies = `(() => {
+	let node = window.__cozyclay.editorCam; while (node.parent) node = node.parent;
+	let count = 0;
+	node.traverse((child) => { if (child.userData?.gizmoHandleProxy) count += 1; });
+	return count;
+})()`;
+
+/* ------------------------------------------------- the menu itself ------- */
+
+expect("Scene mode is the entry state", await clickMode("Scene"));
+expect("a character is selected", await selectRow("characterA"));
+expect("the viewport bar carries the View trigger", await evaluate(`!!${trigger}`));
+expect("the trigger reads as a menu button", await evaluate(`${trigger}.getAttribute('aria-haspopup') === 'menu'`));
+expect("the menu starts closed", await evaluate(`${trigger}.getAttribute('aria-expanded') === 'false' && !${menu}`));
+
+expect("clicking opens the menu", await openMenu());
+expect("the trigger reports expanded", await evaluate(`${trigger}.getAttribute('aria-expanded') === 'true'`));
+expect("Reference grid is an item", await evaluate(`!!document.querySelector('.view-menu .grid-view-switch')`));
+expect("Auto Color is an item", await evaluate(`!!document.querySelector('.view-menu .auto-color-toggle')`));
+expect(
+	"Auto Color keeps its capture warning",
+	await evaluate(`/captures include them/.test(document.querySelector('.view-menu .auto-color-toggle').title)`),
+);
+expect(
+	"body part colours offer off/shaded/flat while a character is selected",
+	await evaluate(`JSON.stringify([...document.querySelectorAll('.view-menu [data-part-colours]')].map((b) => b.dataset.partColours)) === '["off","shaded","flat"]'`),
+);
+expect(
+	"the part colours start on off",
+	await evaluate(`document.querySelector('.view-menu [data-part-colours="off"]').getAttribute('aria-checked') === 'true'`),
+);
+
+// Escape closes and hands focus back to the trigger.
+await send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+await send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+expect("Escape closes the menu", await waitFor(`!${menu}`, 8000));
+expect("focus returns to the trigger", await evaluate(`document.activeElement === ${trigger}`));
+
+// A second click on the trigger closes it again (the trigger is a toggle).
+expect("clicking reopens the menu", await openMenu());
+await evaluate(`${trigger}.click()`);
+expect("clicking the trigger again closes it", await waitFor(`!${menu}`, 8000));
+
+/* --------------------------------------- the toggles the menu now owns --- */
+
+expect("the trigger has no dot while every look toggle is off", await evaluate("!document.querySelector('.view-menu-dot')"));
+expect("the menu opens for the grid toggle", await openMenu());
+const gridItem = "document.querySelector('.view-menu .grid-view-switch')";
+expect("the grid toggle starts unpressed", await evaluate(`${gridItem}.getAttribute('aria-pressed') === 'false'`));
+await evaluate(`${gridItem}.click()`);
+expect("toggling the grid flips aria-pressed", await waitFor(`${gridItem}.getAttribute('aria-pressed') === 'true'`, 8000));
+expect("the item stays in the open menu after a toggle", await evaluate(`!!${menu}`));
+expect("the trigger grows its dot", await waitFor("!!document.querySelector('.view-menu-dot')", 8000));
+await evaluate(`${gridItem}.click()`);
+expect("toggling back clears aria-pressed", await waitFor(`${gridItem}.getAttribute('aria-pressed') === 'false'`, 8000));
+expect("the dot goes with it", await waitFor("!document.querySelector('.view-menu-dot')", 8000));
+
+// Part colours belong to a body: with the camera selected the section is gone
+// while the two viewport toggles stay.
+await evaluate(`${trigger}.click()`);
+await waitFor(`!${menu}`, 8000);
+expect("the camera row can be selected", await selectRow("camera"));
+expect("the menu opens with the camera selected", await openMenu());
+expect(
+	"body part colours are not offered without a character",
+	await evaluate("document.querySelectorAll('.view-menu [data-part-colours]').length === 0"),
+);
+expect(
+	"the viewport toggles stay",
+	await evaluate("!!document.querySelector('.view-menu .grid-view-switch') && !!document.querySelector('.view-menu .auto-color-toggle')"),
+);
+await evaluate(`${trigger}.click()`);
+await waitFor(`!${menu}`, 8000);
+expect("the character row can be reselected", await selectRow("characterA"));
+
+/* ------------------------------------- Transform (Scene) / Placement ----- */
+
+const sceneTransform = await foldout("Transform");
+expect("Scene mode still offers the character Transform", !!sceneTransform, JSON.stringify(sceneTransform));
+expect("it is folded by default — the gizmo is the primary path", sceneTransform?.open === false, JSON.stringify(sceneTransform));
+
+expect("Motion mode is reachable", await clickMode("Motion"));
+expect(
+	"entering Motion selects a character row, not the group",
+	await waitFor("document.querySelector('.hierarchy-row-wrap.selected')?.dataset.nodeId?.startsWith('character') && document.querySelector('.hierarchy-row-wrap.selected').dataset.nodeId !== 'characters'", 8000),
+);
+expect("the character gizmo is mounted", await waitFor(`${gizmoProxies} > 0`, 10000));
+expect("Motion has no Transform foldout", (await foldout("Transform")) === null);
+const placement = await foldout("Placement");
+expect("Motion shows the Placement foldout", !!placement, JSON.stringify(placement));
+expect("Placement is open on arrival", placement?.open === true, JSON.stringify(placement));
+expect(
+	"Placement is exactly Position X/Z plus Rotation",
+	JSON.stringify(placement?.axes) === '["X","Z"]' && JSON.stringify(placement?.sliders) === '["Rotation"]',
+	JSON.stringify(placement),
+);
+expect(
+	"the stage-position hint says the take is untouched",
+	await evaluate("/does not change the take/.test(document.querySelector('.placement-fields .inspector-hint')?.textContent || '')"),
+);
+expect("the View menu is still reachable in Motion mode", await evaluate(`!!${trigger}`));
+expect("the menu opens in Motion mode too", await openMenu());
+expect(
+	"and it still offers the part colours for the selected character",
+	await evaluate("document.querySelectorAll('.view-menu [data-part-colours]').length === 3"),
+);
+
+// Back to Scene: the foldout remounts as the folded full Transform. Scene
+// mode selects the shot, so the character has to be picked again first.
+await evaluate(`${trigger}.click()`);
+await waitFor(`!${menu}`, 8000);
+expect("Scene mode is reachable again", await clickMode("Scene"));
+expect("the character is selectable again", await selectRow("characterA"));
+expect("Motion's Placement row is gone", (await foldout("Placement")) === null);
+const backToScene = await foldout("Transform");
+expect("Scene mode restores the character Transform", !!backToScene, JSON.stringify(backToScene));
+expect("and it comes back folded", backToScene?.open === false, JSON.stringify(backToScene));
+// Opened by hand, it is the full nine-input form again (X/Y/Z + turn + size).
+await evaluate(`[...document.querySelectorAll('.card.foldout:not([hidden]) .foldout-head')].find((b) => b.querySelector('.foldout-title')?.textContent.trim() === 'Transform').click()`);
+expect("opening it shows the full transform", await waitFor(`(() => {
+	const head = [...document.querySelectorAll('.card.foldout:not([hidden]) .foldout-head')].find((b) => b.querySelector('.foldout-title')?.textContent.trim() === 'Transform');
+	const card = head?.closest('.card.foldout');
+	if (!card) return false;
+	const axes = [...card.querySelectorAll('.foldout-body .vec3-row .axis')].map((s) => s.textContent.trim()).join(',');
+	const sliders = [...card.querySelectorAll('.foldout-body .cslider-head > span:first-child')].map((s) => s.textContent.trim()).join(',');
+	return axes === 'X,Y,Z' && sliders === 'Rotation,Scale';
+})()`, 8000));
+
+if (failures > 0) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log("qa-view-menu-browser: all checks passed");
+process.exit(0);

--- a/test/verify-auto-color.mjs
+++ b/test/verify-auto-color.mjs
@@ -55,7 +55,13 @@ expect(
 	app.includes("object.renderer === CUTOUT_KIND ? object : { ...object, autoColor:"),
 );
 expect("the toggle persists under its own key", app.includes("saveAutoColor(") && AUTO_COLOR_KEY === "cozyclay.auto-color.v1");
-expect("the toggle reports its state", app.includes('className="auto-color-toggle"') && app.includes("aria-pressed={autoColor}"));
+// The toggle lives in the viewport bar's View menu (#194); it kept its class
+// and its aria-pressed contract through the move.
+expect(
+	"the toggle reports its state",
+	app.includes('className={"view-menu-item auto-color-toggle" + (autoColor ? " active" : "")}') &&
+	app.includes("aria-pressed={autoColor}"),
+);
 expect(
 	"the viewport renderers consume the marker with authored fallback",
 	props.includes("autoColor ?? color"),

--- a/test/verify-grid-view.mjs
+++ b/test/verify-grid-view.mjs
@@ -47,6 +47,10 @@ const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
 assert.ok(app.includes("{gridView ? <GridFloor layer={GIZMO_LAYER} /> : <Room />}"), "grid replaces the deck on the export-stripped gizmo layer");
 assert.ok(app.includes('args={[gridView ? GRID_BACKGROUND : "#eef4f3"]}'), "the background swaps to the void colour");
 assert.ok(app.includes("writeStoredGridView(globalThis.localStorage, gridView)"), "the preference persists per browser");
-assert.ok(app.includes('ko("Grid", "그리드")'), "the toolbar offers a bilingual toggle");
+assert.ok(app.includes('ko("Reference grid", "기준 그리드")'), "the View menu offers a bilingual toggle");
+assert.ok(
+	app.includes('className={"view-menu-item grid-view-switch" + (gridView ? " active" : "")}'),
+	"the toggle kept its class and moved into the viewport bar's View menu",
+);
 
 console.log("verify-grid-view: all checks passed");

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -262,13 +262,28 @@ expect(
 // scrub, viewport gizmo) agree on max(0, y).
 expect(
 	"Subject transforms have one inspector home with the direct tools",
-	app.includes('<Foldout hidden={!isCharacterSelection} title={ko("Transform", "변환")}>') &&
+	app.includes('title={workflowMode === "motion" ? ko("Placement", "배치") : ko("Transform", "변환")}') &&
 	app.includes('{ axis: "X", value: activeChar.x, step: 0.05') &&
 	app.includes('{ axis: "Y", value: activeChar.y ?? 0, step: 0.05') &&
 	app.includes('{ axis: "Z", value: activeChar.z, step: 0.05') &&
 	app.includes('label={ko("Rotation", "회전")}') &&
 	app.includes('label={ko("Scale", "크기")}') &&
 	app.includes('data-transform-controls'),
+);
+// Motion mode hides Move/Rotate/Scale, so the same foldout becomes the open
+// Placement row (stage X/Z + turn) and Scene mode folds the full form away
+// behind the gizmo (#194). Foldout reads defaultOpen once, hence the key.
+expect(
+	"the character transform is mode-aware",
+	app.includes('key={workflowMode === "motion" ? "placement" : "transform"}') &&
+	app.includes('defaultOpen={workflowMode === "motion"}') &&
+	app.includes('ko("Stage position — does not change the take", "무대 위치 — 테이크는 바꾸지 않습니다")'),
+);
+// Entering Motion selects the active character's ROW: the placement gizmo only
+// renders for a specific cast member, never for the group.
+expect(
+	"Motion mode lands on a character the gizmo can draw",
+	app.includes("setSelectedHierarchyId(rowIdForCharIndex(activeCharIndex));"),
 );
 expect(
 	"the character gizmo no longer caps lift at 4 m",

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -184,12 +184,13 @@ const BROWSER_FILES = [
 	"test/qa-reference-slots-browser.mjs",
 	"test/qa-scene-switcher-browser.mjs",
 	"test/qa-send-to-ai-browser.mjs",
+	"test/qa-view-menu-browser.mjs",
 ];
 
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
## What changed

The three toggles that decide what the viewport **looks like** lived in three different rooms: Auto Color in the topbar beside Save/Export, Grid on the scene toolbar behind a Scene-mode gate, and Part colours in a character inspector foldout. None of them edits the document and none of them belongs to a mode — so they move into one `View ▾` at the right end of the viewport bar, visible in **every** mode (`docs/studio-ui-ia.md` §3 뷰포트 바/인스펙터, §4 `View ▾`, R4).

- **`src/App.jsx`**
  - **new `View ▾`** as the last child of `.editor-toolbar.scene-tools` (no `.workflow-*-context` class, `margin-left: auto` parks it at the bar's right end in all three modes). `aria-haspopup="menu"`, `aria-expanded`, `data-testid="view-menu-trigger"`. The panel is `position: fixed` and anchored to the trigger rect in JS — the same treatment the PlayView export menu gets, because the 27px title bar clips its own overflow. Dismissal mirrors the project/export menus: outside `pointerdown` or Escape, and Escape returns focus to the trigger. Measured live: trigger `[1174, 48.5, 46×26]`, menu `[1020, 80.5, 200×72]` in a 1600px window — right-aligned to the trigger, hanging below the bar, nothing clipped.
  - Items keep the contracts of their old homes (R9): `☐ Reference grid` keeps `className="…grid-view-switch"` + `aria-pressed`; `☐ Auto Color` keeps `className="…auto-color-toggle"`, `aria-pressed` and its "captures include them while on" warning in `title`; both also carry `role="menuitemcheckbox"` + `aria-checked`. **Body part colours** is an off/shaded/flat `menuitemradio` group rendered **only while a character is selected** (R2). A `.view-menu-dot` on the trigger appears whenever grid, Auto Color or part colours is on. Items leave the menu **open** — these are toggles you compare, not commands you fire.
  - **deleted**: the topbar Auto Color button, the scene-bar Grid button, the inspector `Part colours` foldout. No empty containers left behind.
  - **character Transform is mode-aware** (R5). Scene mode has the gizmo and Move/Rotate/Scale, so the nine-input form now mounts with `defaultOpen={false}`. Motion mode hides those tools, so the same foldout becomes an **open `Placement` / `배치`** row: `Position X` / `Position Z` + `Rotation`, under the hint *"Stage position — does not change the take" / "무대 위치 — 테이크는 바꾸지 않습니다"*. Y and Scale stay reachable in Scene mode. `Foldout` reads `defaultOpen` once on mount, so the foldout is keyed by mode (`key={workflowMode === "motion" ? "placement" : "transform"}`) and remounts with the right default on a mode switch. **The object Transform (`hidden={!selectedSceneObject}`) is untouched** — `verify-object-gizmo.mjs:133` still reads it.
  - `selectWorkflowMode("motion")` selects **`rowIdForCharIndex(activeCharIndex)`** instead of the `characters` group: the placement gizmo only renders for a specific cast member (`gizmoView` → `charIdFromHierarchyId`), so entering Motion used to leave nothing to drag. `setPromptBlocksReveal` is unchanged.
- **`src/styles.css`** — removed the dead `.auto-color-toggle` block (topbar chrome) and `.editor-toolbar.scene-tools > .grid-view-switch`. Added `.view-menu-wrap/-trigger/-dot/-mark/-group/-label` and `.view-menu` on existing tokens only (`--panel`, `--line`, `--line2`, `--accent`, `--accent-soft`, `--muted`, `--muted2`), reusing `.project-menu`'s popover and the export trigger's flat toolbar treatment so the studio keeps one dropdown language. `.placement-fields .vec3-row` narrows the axis grid from `56px 1fr 1fr 1fr` to `56px 1fr 1fr` (a two-axis row, not a truncated XYZ) and keeps Unity's blue on the second field because it is Z, not Y.

## Control count

`git show origin/chore/studio-ui-ia:tools/qa/studio-control-count.mjs`, 1600×1000, one character + the 432-frame demo take, no shots — §1's scenario. Both columns measured on the same server (`npx vite`), main at `140bfea` vs this branch rebased on it:

| state | `main` 140bfea | this branch |
|---|---|---|
| scene-none | 41 | **40** |
| scene-char | 41 | **40** |
| camera | 43 | **43** |
| motion | 60 | **57** |

Per-control diff from the same run (nothing else moved):

- **scene-char** — removed `topbar | Auto Color`, `viewport-bar | Grid`; added `viewport-bar | View ▾`.
- **camera** — removed `topbar | Auto Color`; added `viewport-bar | View ▾`.
- **motion** — removed `topbar | Auto Color`, the `Part colours` foldout (head + its checkbox) and the `Transform` foldout (head + the Scale slider, Rotation staying as Placement's); added `Placement` (head) and `View ▾`.

Region detail: the viewport bar is Scene **10** (`Scene/Camera/Motion` + `Scene/PlayView` + `Move/Rotate/Scale` + `Snap` + `View ▾`; PiP's 2 counted separately), Camera **11**, Motion **6**. The Motion inspector's two panels go from 5 controls (Part colours 2 + Transform 3) to **2** (Placement head + Rotation).

With no take loaded — the state PR #195 will measure once the centre tabs go — the same run reads scene 40 / camera 43 / **motion 49**. The doc's ≤52 Motion budget is met in that state; with a take loaded the remaining 5 over budget are the take-bar and segment controls that PR #195/#196 own, not this PR's.

## Browser QA

Dev server `npm run dev -- --port 5194`, Chrome over CDP through `tools/qa-browser.mjs`.

**New: `test/qa-view-menu-browser.mjs`** — same shape as the sibling `qa-*-browser.mjs` suites, every wait is a state condition (no sleeps). Registered in `tools/run-tests.mjs` (`BROWSER_FILES` + `EXTRA_INVENTORY`).

```
43 PASS, 0 FAIL — qa-view-menu-browser: all checks passed
PASS the trigger reads as a menu button
PASS the menu starts closed / clicking opens the menu / the trigger reports expanded
PASS Reference grid is an item
PASS Auto Color is an item
PASS Auto Color keeps its capture warning
PASS body part colours offer off/shaded/flat while a character is selected
PASS the part colours start on off
PASS Escape closes the menu
PASS focus returns to the trigger
PASS clicking the trigger again closes it
PASS the trigger has no dot while every look toggle is off
PASS toggling the grid flips aria-pressed
PASS the item stays in the open menu after a toggle
PASS the trigger grows its dot / the dot goes with it
PASS body part colours are not offered without a character
PASS the viewport toggles stay
PASS Scene mode still offers the character Transform
PASS it is folded by default — the gizmo is the primary path
PASS entering Motion selects a character row, not the group
PASS the character gizmo is mounted
PASS Motion shows the Placement foldout / Placement is open on arrival
PASS Placement is exactly Position X/Z plus Rotation
PASS the stage-position hint says the take is untouched
PASS the menu opens in Motion mode too
PASS Scene mode restores the character Transform / and it comes back folded
PASS opening it shows the full transform
```

**Updated (every assertion kept, plus a step that opens `View ▾` first):**

```
qa-grid-view-browser: all checks passed   (23 PASS — background/deck/grid mesh/layer/fog/persistence/reload)
qa-auto-color-browser: all checks passed  (22 PASS — derived hexes, undo, reload, OFF restores the authored world)
```

### Screenshots

Captured at 1600×1000 @2× by the QA run (`/tmp/pr194-scene-view-menu.png`, `/tmp/pr194-motion-placement.png`):

1. **Scene mode, character selected, `View ▾` open** — the menu hangs from the trigger at the bar's right end: `Reference grid`, `Auto Color`, then the `BODY PART COLOURS` group with `✓ Off` / `Shaded` / `Flat`. The character gizmo is on stage and the inspector shows `Transform` folded. The topbar is #200's `Export ▾` + `Settings` with **no** Auto Color button beside them.
2. **Motion mode**, 432-frame take loaded — the inspector shows `Placement` open with `Position X` / `Position Z` (blue Z chip) and the `Rotation` slider under the stage-position hint; `Transform` and `Part colours` are gone; the character gizmo is mounted on Character 1, because Motion now enters on the character row instead of the `characters` group.

## Tests

```
node tools/run-tests.mjs
TEST MANIFEST scope=all runnable=158 total=…
PASS 158 Node verification files
```

Source-contract tests followed the moved markup instead of being deleted: `verify-auto-color.mjs` (the toggle's class + `aria-pressed` in its new item), `verify-grid-view.mjs` (`ko("Reference grid","기준 그리드")` + the item's class), `verify-layout.mjs` (mode-aware foldout title, the `key`/`defaultOpen` pair, the Placement hint, and the Motion row selection). `verify-object-gizmo.mjs:133` needed no change — the object Transform is untouched.

## Noted, not fixed

While reading the placement path: with a take loaded, a placement drag (gizmo or the Placement fields) writes `entry.x` / `entry.z`, but the character renders from `clip.anchorX` / `clip.anchorZ` (`App.jsx` ~4184-4214 vs ~1045-1054), so the body does not move until the take is cleared. Out of scope here (this PR only moves and re-frames controls); worth its own issue.

Rebased onto `140bfea` (#200); the diff against `main` touches only this PR's files.

Closes #194
