### PR TITLE
test(gizmo): select the scene root by aria-label after the scene pill (#192 follow-up)

### DIFF
--- a/test/verify-object-gizmo.mjs
+++ b/test/verify-object-gizmo.mjs
@@ -353,7 +353,7 @@ globalThis.objectCentre = await evaluate(
 	" const x = Math.round(c.x + r * Math.cos(a * Math.PI / 180)); const y = Math.round(c.y + r * Math.sin(a * Math.PI / 180));" +
 	" if (window.__objectPick(x, y) && !window.__gizmoPick(x, y) && document.elementFromPoint(x, y)?.tagName === \"CANVAS\") return { x, y }; } } return { x: Math.round(c.x), y: Math.round(c.y) }; })()",
 );
-await click("[...document.querySelectorAll('.hierarchy-row')].find(b => b.textContent.includes('SCENE 01'))");
+await click("[...document.querySelectorAll('.hierarchy-row')].find(b => (b.getAttribute('aria-label') || b.textContent).includes('SCENE 01'))");
 // the deselection commit unmounts the gizmo; poll for it
 await waitFor("window.__gizmoHandles().length === 0");
 expect("selecting something else drops the gizmo", await evaluate("window.__gizmoHandles().length === 0"));


### PR DESCRIPTION
## Cause
#197 moved the scene name out of the root `.hierarchy-row` (now icon-only with `aria-label`) into a sibling `.hierarchy-scene-pill`, so the test's `textContent.includes('SCENE 01')` lookup at test/verify-object-gizmo.mjs:356 returned `undefined` and the suite aborted. The click now matches the root row by `aria-label` (falling back to `textContent`), which works for both label and icon-only rows.

## Diff
```diff
-await click("[...document.querySelectorAll('.hierarchy-row')].find(b => b.textContent.includes('SCENE 01'))");
+await click("[...document.querySelectorAll('.hierarchy-row')].find(b => (b.getAttribute('aria-label') || b.textContent).includes('SCENE 01'))");
```

## Suite result (QA browser, dev :5197)
The abort at :356 is fixed — the suite now runs far past the scene-root click (68-69 PASS per run, including all gizmo move/rotate/scale, selection, navigation, plane-handle, snap, and persistence-flush checks).

However, the full suite does NOT reach 0 FAIL on this branch. Every run shows pre-existing failures in the localStorage storage/normalization section (cases 4, 6-9), unrelated to this change (this PR touches exactly one selector line; those cases seed `cozyclay.scene.v1`, which src/scenes.js now treats as `LEGACY_SCENE_STORAGE_KEY` since the multi-scene persistence migration — live key is `cozyclay.scenes.v4`). Verbatim FAIL tail from the last run:

```
FAIL the corrupt payload is quarantined — null
FAIL a failing setItem surfaces a visible error — 
FAIL the error line stays visible while an object is selected — 
FAIL a successful write persists the scene — 
FAIL a stale but valid payload reports dropped records — 
FAIL a stale but valid payload restores only the normalized record — ["Camera","Light","Characters","Character 1","Rig","Environment","Props","Chair","Cube","Cube 2"]
FAIL the normalized record fans a legacy scale into all three axes — [1,1,1]
FAIL the normalized payload is what gets written back — {"version":1,"count":3,"hasScale":true,"scales":[null,null,null]}
FAIL the second reload restores exactly one object — ["Camera","Light","Characters","Character 1","Rig","Environment","Props","Chair","Cube","Cube 2"]
FAIL the second reload keeps the normalized scale — [1,1,1]
FAIL typing a Y value raises the object above the support — {"Position":[0.55,0,0.7],"Rotation":[0,0,0],"Scale":[1,1,1]}
FAIL End rests the object exactly on the support's top — {"Position":[0.55,0,0.7],"Rotation":[0,0,0],"Scale":[1,1,1]}
FAIL a drop is exactly one history entry — 
FAIL a second End adds no history entry — {"past":2,"future":0,"settled":true}
FAIL undo after a drop restores the previous height — {"Position":[0.55,0,0.7]... -> {"Position":[0,0,0]}
FAIL the lifecycle section starts with the Chair back on the Cube — {"Position":[0,0,0]}
TypeError: Cannot read properties of null (reading 'x') at dragHeld (test/verify-object-gizmo.mjs:878)
```
(The downstream TypeError at :878 follows from the lifecycle section starting from a default project instead of the seeded payload.)

`node tools/run-tests.mjs`: **PASS — 158 Node verification files** (after `npm run build`; note `test/verify-agent-routes.mjs` requires `ws`, which is not in the lockfile and had to be installed ad hoc into `mcp/`).
