### PR TITLE
refactor(studio): drop the Scene/PlayView tabs; look-through enters an explicit preview state (#195)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -634,6 +634,11 @@ export default function App() {
 	const embedMode = ["scene", "playview"].includes(new URLSearchParams(globalThis.location?.search || "").get("embed"));
 	useEffect(() => {
 		if (!embedMode) return undefined;
+		// The Workflow page's Scene node embeds the studio as its preview, so the
+		// embed enters the player through the same door the look-through button
+		// uses. The states are seeded from embedMode as well, so the first painted
+		// frame is already the shot view rather than a flash of editor chrome.
+		enterPreview();
 		const capture = () => {
 			try {
 				const live = liveStateRef.current;
@@ -736,12 +741,17 @@ export default function App() {
 	// The Top-View is always the inset: the old double-click swap that let the
 	// plan own the big pane is gone, so there is no view mode to toggle.
 	const planIsMain = false;
-	// Unity Scene/Game tabs: PlayView is the framed output only — no editing
-	// chrome (gizmo, inset, fly navigation) reaches it.
-	const [centerTab, setCenterTab] = useState(embedMode ? "play" : "scene");
-globalThis.playMode = centerTab === "play";
-	// PlayView is the player for the finished motion: entering starts playback,
-	// leaving pauses it. Scene stays the manipulation surface.
+	// The framed output only — no editing chrome (gizmo, inset, fly navigation)
+	// reaches it. The Scene/PlayView centre tabs are gone (#195): this is an
+	// internal state with two entry points (the shot PiP's look-through button
+	// and the Workflow embed) and one exit (Esc / the exit pill).
+	const [preview, setPreview] = useState(embedMode);
+	// The name stays `playMode`: window.__cozyclay QA hooks and the MCP live
+	// bridge read this global, and the render path is still PlayView's.
+	globalThis.playMode = preview;
+	const playMode = preview;
+	// Preview is the player for the finished motion: entering starts playback,
+	// leaving pauses it. The editor view stays the manipulation surface.
 	const [tlPlaying, setTlPlaying] = useState(false);
 	const cameraPreviewEndRef = useRef(null);
 	// Once the operator touches the viewport, the physical camera stays in
@@ -758,19 +768,29 @@ globalThis.playMode = centerTab === "play";
 	useEffect(() => {
 		if (!lookThroughShot || embedMode) return undefined;
 		const onKey = (event) => {
-			if (event.key === "Escape") setLookThroughShot(false);
+			if (event.key === "Escape") exitPreview();
 		};
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
-	}, [lookThroughShot, embedMode]);
-	useEffect(() => {
-		// The player always starts the finished piece from frame 0; auto-play
-		// only exists once there is a motion to play.
-		if (centerTab === "play") setTlFrame(0);
-		if (centerTab === "play" && motion) setTlPlaying(true);
-		if (centerTab === "scene") setTlPlaying(false);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [centerTab]);
+	}, [lookThroughShot, embedMode]);
+	/** The one way in. The shot camera takes the whole pane (DualRender's
+	 * playMode branch), the piece restarts from frame 0, and auto-play only
+	 * exists once there is a motion to play. Look-through rides along so every
+	 * site that picks a camera keeps pointing at the shot camera. */
+	function enterPreview() {
+		setPreview(true);
+		setLookThroughShot(true);
+		setTlFrame(0);
+		if (motion) setTlPlaying(true);
+	}
+	/** ...and the one way out: editing chrome back, playback paused, so leaving
+	 * the player never leaves the timeline running underneath it. */
+	function exitPreview() {
+		setPreview(false);
+		setLookThroughShot(false);
+		setTlPlaying(false);
+	}
 	const stageRef = useRef();
 	const mainPaneRef = useRef();
 	const insetPaneRef = useRef();
@@ -1169,7 +1189,9 @@ globalThis.playMode = centerTab === "play";
 	const [workflowMode, setWorkflowMode] = useState("scene");
 	function selectWorkflowMode(next) {
 		setWorkflowMode(next);
-		setCenterTab("scene");
+		// Picking a department is an editing act: it always lands in the editor
+		// view, never inside the player.
+		exitPreview();
 		if (next === "camera") setSelectedHierarchyId("camera");
 		else if (next === "motion") {
 			// The active character's ROW, not the group: the placement gizmo only
@@ -6545,7 +6567,7 @@ globalThis.playMode = centerTab === "play";
 			// the selected prop's route, so QA can aim a gesture at the line
 			objectPath: selectedSceneObject?.path ?? null,
 			pathPointIndex,
-			pathHandlesEnabled: centerTab === "scene" && !lookThroughShot && !ikMode && !posing && !playMode && !!selectedSceneObject?.path,
+			pathHandlesEnabled: !preview && !lookThroughShot && !ikMode && !posing && !!selectedSceneObject?.path,
 			scrub: (frame) => setTlFrame(Math.max(0, Math.min(tlFrameCount - 1, Math.round(frame)))),
 			pause: () => setTlPlaying(false),
 			// Motion-trail QA surface: read the current trail policy and drive the
@@ -6591,7 +6613,7 @@ globalThis.playMode = centerTab === "play";
 			apRun: runAutoPhysics,
 			physics: { preview: physicsPreview, show: physicsShow, running: autoPhysicsRunning, options: physicsOptions },
 			apOptions: changePhysicsOptions,
-			centerTab,
+			preview,
 			pathDraw,
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -6599,7 +6621,7 @@ globalThis.playMode = centerTab === "play";
 		// close over them: a stale closure would report the set as it was two
 		// edits ago — and, after an undo that removes a subject, would keep
 		// reporting the ghost's capsules.
-	}, [activeRig, motion, tlFrame, ikMode, ikChains, ikFocus, ikTick, charA, committedIkEdits, waypoints, lookThroughShot, selectedSceneObject, sceneObjects, rigs, characters, pathPointIndex, centerTab, posing, playMode, pathDraw, trailEdit, trailFalloffFrames, trailFalloffS, ikEditTool, showTrails, physicsPreview, physicsShow, physicsOptions, autoPhysicsRunning]);
+	}, [activeRig, motion, tlFrame, ikMode, ikChains, ikFocus, ikTick, charA, committedIkEdits, waypoints, lookThroughShot, selectedSceneObject, sceneObjects, rigs, characters, pathPointIndex, preview, posing, playMode, pathDraw, trailEdit, trailFalloffFrames, trailFalloffS, ikEditTool, showTrails, physicsPreview, physicsShow, physicsOptions, autoPhysicsRunning]);
 	// QA hook (plan §6.5): exposes history depth and the present === objects
 	// invariant so the browser suite can assert undo entry counts directly.
 	// Reads live store state at call time; re-registered after every render.
@@ -6718,7 +6740,7 @@ globalThis.playMode = centerTab === "play";
 	// The follow camera owns the shot camera in the same situations key
 	// following would: never while an authoring mode holds the viewport.
 	const followCamActive =
-		activeCamera.mode !== "keys" && !!followTrack?.[tlFrame] && (centerTab === "play" || (!ikMode && !waypointMode && !posing));
+		activeCamera.mode !== "keys" && !!followTrack?.[tlFrame] && (preview || (!ikMode && !waypointMode && !posing));
 
 	// Implied locomotion speed per authored segment, on the timeline clock
 	// (m/s is physical, so the judge always uses tlFps). Shown in the
@@ -9020,13 +9042,13 @@ function resizePromptClip(id, edge, rawFrame) {
 		poll();
 		const id = window.setInterval(poll, 250);
 		return () => window.clearInterval(id);
-		// lookThroughShot / centerTab / ikMode are dependencies even though the
+		// lookThroughShot / preview / ikMode are dependencies even though the
 		// body never reads them directly: they are what lineEditPane branches on,
 		// so a stale closure would keep measuring the camera the pane used to
 		// hold and a view SWITCH — the most obvious way to invalidate a curve —
 		// would go undetected. Lens and aspect changes need no dependency: they
 		// move fx/fy, which the comparison sees on its own.
-	}, [lineEditMode, lineCurve, lookThroughShot, centerTab, ikMode]);
+	}, [lineEditMode, lineCurve, lookThroughShot, preview, ikMode]);
 
 	// Wave-2 capability preflight. `checkBridge` reports health only, so the
 	// line-edit route is probed here: today's bridge IGNORES unknown request
@@ -10381,27 +10403,6 @@ function resizePromptClip(id, edge, rawFrame) {
 						</button>
 					))}
 				</div>
-				<div className="pane-tabs" role="tablist" aria-label={ko("Center view", "가운데 보기")}>
-					<button
-						type="button"
-						role="tab"
-						aria-selected={centerTab === "scene"}
-						className={centerTab === "scene" ? "active" : ""}
-						onClick={() => setCenterTab("scene")}
-					>
-						{ko("Scene", "장면")}
-					</button>
-					<button
-						type="button"
-						role="tab"
-						aria-selected={centerTab === "play"}
-						className={centerTab === "play" ? "active" : ""}
-						onClick={() => setCenterTab("play")}
-					>
-						{ko("PlayView", "재생 보기")}
-					</button>
-				</div>
-				{centerTab === "scene" ? (
 				<div className="editor-toolbar scene-tools" aria-label={ko("Scene tools", "장면 도구")}>
 					{workflowMode === "motion" && (
 						<span className="workflow-toolbar-hint" role="status">
@@ -10629,12 +10630,6 @@ function resizePromptClip(id, edge, rawFrame) {
 							)}
 						</div>
 					</div>
-				) : (
-					<div className="editor-toolbar play-tools" aria-label={ko("PlayView tools", "재생 보기 도구")}>
-						<span className="viewport-readout">{shotOutput.label}</span>
-						<span className="viewport-readout">FOV {Math.round(fovDeg)}° · {shot.focalMm}mm</span>
-					</div>
-				)}
 				</div>
 
 					<div className="stage" id="stage" ref={stageRef} data-render-loop={renderActive ? "always" : "demand"}>
@@ -10689,7 +10684,7 @@ function resizePromptClip(id, edge, rawFrame) {
 							<KeyLightPuck
 								keyLight={keyLight}
 								selected={keyLightSelected}
-								visible={centerTab === "scene" && !lookThroughShot && !playMode}
+								visible={!preview && !lookThroughShot}
 								paneRef={mainPaneRef}
 								camRef={editorCamRef}
 								onSelect={() => selectHierarchy("light")}
@@ -10824,12 +10819,12 @@ function resizePromptClip(id, edge, rawFrame) {
 								// waypoint scrubs the playhead as a side effect, and follow
 								// must not turn that scrub into a camera lurch. Same for IK
 								// and pose studio, where the shot camera is deliberately frozen.
-								// PlayView is the finished-output player: the move always rides
+								// Preview is the finished-output player: the move always rides
 								// the playhead there. The Follow toggle and authoring-mode gates
-								// only protect the Scene tab's manipulation surfaces.
+								// only protect the editor view's manipulation surfaces.
 								// This shot's Camera Block owns the camera while Follow or Rail is active;
 								// editorial camera keys resume when the block returns to Keys mode.
-								following={!followCamActive && hasCameraKeys && (centerTab === "play" || (moveFollow && !ikMode && !waypointMode && !posing))}
+								following={!followCamActive && hasCameraKeys && (preview || (moveFollow && !ikMode && !waypointMode && !posing))}
 								followFrame={tlFrame}
 								fps={tlFps}
 								keys={cameraKeys}
@@ -11010,7 +11005,7 @@ function resizePromptClip(id, edge, rawFrame) {
 								onGroundClick={waypointMode && !planIsMain ? addFloorWaypoint : undefined}
 								claimPointer={lineEditMode ? lineGrabProbe : undefined}
 							/>
-							{centerTab === "scene" && railCurve && (
+							{!preview && railCurve && (
 								<CameraRailScenePreview
 									points={railCurve.points}
 									cumLen={railCurve.cumLen}
@@ -11021,7 +11016,7 @@ function resizePromptClip(id, edge, rawFrame) {
 							<ObjectPathHandles
 								path={selectedSceneObject?.path ?? null}
 								selectedIndex={pathPointIndex}
-								enabled={centerTab === "scene" && !lookThroughShot && !ikMode && !posing && !playMode && !!selectedSceneObject?.path}
+								enabled={!preview && !lookThroughShot && !ikMode && !posing && !!selectedSceneObject?.path}
 								paneRef={mainPaneRef}
 								camRef={editorCamRef}
 								onSelect={setPathPointIndex}
@@ -11042,7 +11037,7 @@ function resizePromptClip(id, edge, rawFrame) {
 								crane={activeCamera.craneHeight}
 								controlPoints={activeCamera.cameraRail}
 								selectedIndex={craneSelectedIndex}
-								enabled={centerTab === "scene" && !lookThroughShot && !ikMode && !posing && !playMode && !!railCurve && !!activeCamera.craneHeight}
+								enabled={!preview && !lookThroughShot && !ikMode && !posing && !!railCurve && !!activeCamera.craneHeight}
 								paneRef={mainPaneRef}
 								camRef={editorCamRef}
 								onSelect={setCraneSelectedIndex}
@@ -11083,10 +11078,10 @@ function resizePromptClip(id, edge, rawFrame) {
 								camRef={shotCamRef}
 								fovDeg={fovDeg}
 								aspect={shotOutput.aspect}
-								visible={centerTab === "scene" && !lookThroughShot && !ikMode && !posing}
+								visible={!preview && !lookThroughShot && !ikMode && !posing}
 								selected={shotCameraSelected}
 							/>
-							{waypointMode && centerTab === "scene" && (
+							{waypointMode && !preview && (
 								<ShotPathPreview waypoints={waypoints} start={charA} activeWaypointId={activeWaypointId} />
 							)}
 							<CaptureRig
@@ -11124,7 +11119,10 @@ function resizePromptClip(id, edge, rawFrame) {
 								editorCamRef={editorCamRef}
 								ikMode={ikMode}
 								planIsMain={planIsMain}
-								playMode={playMode}
+								// Preview IS PlayView's render path: DualRender tests this branch
+								// first, so look-through lands in the letterboxed, chrome-free
+								// player rather than the editing draw that keeps the plan inset.
+								playMode={preview}
 								lookThrough={lookThroughShot}
 								insetCollapsed={workspaceLayout.insetCollapsed || workflowMode === "motion"}
 								planZoom={workspaceLayout.planZoom}
@@ -11235,8 +11233,8 @@ function resizePromptClip(id, edge, rawFrame) {
 									type="button"
 									className="vp-look-through"
 									aria-label={ko("Look through the shot camera", "샷 카메라 시점으로 보기")}
-									title={ko("Fly the shot camera itself (Esc returns)", "샷 카메라를 직접 조종 (Esc로 복귀)")}
-									onClick={() => setLookThroughShot(true)}
+									title={ko("Look through the shot camera — the framed player, no editing chrome (Esc returns)", "샷 카메라 시점으로 보기 — 편집 도구 없는 플레이어 (Esc로 복귀)")}
+									onClick={enterPreview}
 								>
 									<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
 										<path d="M15 3h6v6" />
@@ -11247,12 +11245,15 @@ function resizePromptClip(id, edge, rawFrame) {
 								</button>
 							</span>
 						</div>
-						{lookThroughShot && !playMode && !ikMode && (
+						{/* The player's only visible affordance: without it Esc would be
+						    the sole way back, and the embed has no way back at all — the
+						    Workflow node's preview is meant to stay in the shot view. */}
+						{lookThroughShot && !ikMode && !embedMode && (
 							<button
 								type="button"
 								className="vp-inset-tag vp-look-through-exit"
 								title={ko("Return to the editor view (Esc)", "에디터 시점으로 돌아가기 (Esc)")}
-								onClick={() => setLookThroughShot(false)}
+								onClick={exitPreview}
 							>
 								<span className="vp-rec-dot" aria-hidden="true" />
 								{ko("Shot camera", "샷 카메라")}
@@ -11260,7 +11261,10 @@ function resizePromptClip(id, edge, rawFrame) {
 							</button>
 						)}
 
-						{lookThroughShot && !playMode && !ikMode && (
+						{/* Composition guides are an opt-in viewer preference (default off),
+						    so they follow the shot camera into the player rather than being
+						    counted as chrome. */}
+						{lookThroughShot && !ikMode && (
 							<ShotGuideOverlay mode={guideMode} aspect={shotOutput.aspect} className="lookthrough" />
 						)}
 						<div className="film-frame" hidden={playMode || !lookThroughShot}>
@@ -11273,21 +11277,6 @@ function resizePromptClip(id, edge, rawFrame) {
 							{subjectVisible ? slateLineKo(shot) : ko("SUBJECT OUT OF FRAME", "피사체가 프레임 밖에 있어요")}
 						</div>
 
-						{playMode && !motion && (
-							<div className="playview-empty" role="status">
-								<strong>{ko("No motion yet", "아직 모션이 없어요")}</strong>
-								{bridge?.ok ? (
-									<span>{ko("Generate motion in the Scene tab — PlayView plays the finished result.", "장면 탭에서 모션을 생성하세요. 재생 보기는 완성 결과를 보여줍니다.")}</span>
-								) : (
-									<>
-										<span>{ko("This hosted demo loads a sample walk cycle for you — switch to the Scene tab and press play.", "이 데모는 샘플 걷기 모션을 불러왔어요 — 장면 탭에서 재생을 눌러보세요.")}</span>
-										<button type="button" className="btn ghost" onClick={() => { setCenterTab("scene"); track("sample:played", { from: "playview_empty" }); }}>
-											{ko("▶ Watch the sample", "▶ 샘플 구경하기")}
-										</button>
-									</>
-								)}
-							</div>
-						)}
 
 						</div>
 					</div>

--- a/src/dualview.jsx
+++ b/src/dualview.jsx
@@ -374,6 +374,10 @@ export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCa
 		}
 		planCam.updateProjectionMatrix();
 
+		// Branch order is the contract: `playMode` (the preview state, #195) is
+		// tested first, so the look-through button lands HERE — the framed player —
+		// and never in the editing draw below that keeps the gizmo layer and the
+		// plan inset.
 		if (playMode) {
 			// PlayView (Unity Game view): the shot camera owns the whole pane —
 			// no plan inset, no editing chrome, just the framed output. Editor
@@ -417,6 +421,10 @@ export function DualRender({ stageRef, mainRef, insetRef, shotPreviewRef, shotCa
 				}
 			}
 		} else {
+			// Shot camera in the main pane WITH the editing chrome. Since #195 the
+			// studio always enters look-through through the preview state above, so
+			// this is the no-editor-camera fallback and the QA hook's
+			// (`window.__cozyclay.setLookThrough`) draw.
 			draw(shotCam, shotPane, fitAspect(shotPane, shotAspect), !navigatingCamera);
 			if (!navigatingCamera || redrawFrozenPanes) drawVisibleInset(planCam, planPane, null, false);
 		}

--- a/src/styles.css
+++ b/src/styles.css
@@ -7648,7 +7648,9 @@ input[type=range]::-moz-range-thumb {
 	padding-top: 13px;
 }
 
-/* Unity pane tabs (Scene / PlayView) — the pane's title strip */
+/* The pane's title strip: mode tabs on the left, scene tools filling the rest.
+   The Scene/PlayView centre tabs that named this strip are gone (#195) — the
+   framed player is an internal state now, entered from the shot PiP. */
 .viewport-titlebar {
 	position: absolute;
 	top: 0;
@@ -7725,37 +7727,7 @@ input[type=range]::-moz-range-thumb {
 .app[data-workflow-mode="camera"] .tl-motion-tools,
 .app[data-workflow-mode="camera"] .take-bar { display: none !important; }
 
-.pane-tabs {
-	position: static;
-	flex: none;
-	display: flex;
-}
-
-.pane-tabs button {
-	height: 26px;
-	padding: 0 14px;
-	border: 0;
-	border-right: 1px solid var(--line);
-	border-bottom: 2px solid transparent;
-	background: var(--panel);
-	color: var(--muted);
-	font: inherit;
-	font-size: 11px;
-	font-weight: 600;
-	cursor: pointer;
-}
-
-.pane-tabs button:hover {
-	color: var(--fg);
-}
-
-.pane-tabs button.active {
-	background: #232323;
-	color: var(--fg);
-	border-bottom-color: #3a7cbf;
-}
-
-/* the Shot/Top-View toggle sits right of the pane tabs in Scene view */
+/* the Shot/Top-View toggle sits right of the mode tabs in Scene view */
 .viewport .viewmode.scene-only {
 	top: 0;
 	left: 168px;
@@ -8012,26 +7984,6 @@ input[type=range]::-moz-range-thumb {
 	width: 13px;
 	height: 13px;
 	flex: none;
-}
-
-.playview-empty {
-	position: absolute;
-	inset: 0;
-	z-index: 7;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 6px;
-	pointer-events: none;
-	color: var(--muted);
-	font-size: 12px;
-}
-
-.playview-empty strong {
-	color: var(--fg);
-	font-size: 14px;
-	font-weight: 600;
 }
 
 /* ------------------------------------------- Unity inspector density ------ */
@@ -8753,8 +8705,7 @@ input[type=range] {
 	display: none;
 }
 
-.editor-toolbar.scene-tools > button,
-.editor-toolbar.play-tools > button {
+.editor-toolbar.scene-tools > button {
 	flex: none;
 	height: 26px;
 	padding: 0 6px;
@@ -8768,43 +8719,9 @@ input[type=range] {
 	white-space: nowrap;
 }
 
-.editor-toolbar.scene-tools > button:hover,
-.editor-toolbar.play-tools > button:hover {
+.editor-toolbar.scene-tools > button:hover {
 	background: #363636;
 	color: #fff;
-}
-
-.editor-toolbar.play-tools > button:disabled {
-	opacity: .38;
-	cursor: default;
-}
-
-.editor-toolbar.play-tools {
-	position: static;
-	flex: 1;
-	min-width: 0;
-	height: 27px;
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
-	gap: 0;
-	background: var(--panel);
-}
-
-.viewport-readout {
-	flex: none;
-	height: 26px;
-	display: inline-flex;
-	align-items: center;
-	padding: 0 8px;
-	border-right: 1px solid var(--line);
-	color: #b7b7b7;
-	font-size: 9px;
-	white-space: nowrap;
-}
-
-.editor-toolbar.play-tools > button.recording {
-	color: #ff8d86;
 }
 
 /* The studio's one Export menu (#165, moved to the topbar in #193). It reuses

--- a/test/qa-preview-browser.mjs
+++ b/test/qa-preview-browser.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// Browser QA for the preview state machine (#195), over CDP through the QA
+// browser wrapper:
+//
+//   QA_URL=http://127.0.0.1:5180/app/ node tools/qa-browser.mjs -- \
+//     node test/qa-preview-browser.mjs
+//
+// The Scene/PlayView centre tabs are gone. PlayView's render path survives as
+// an internal `preview` state with two entry points — the shot PiP's
+// look-through button and the Workflow embed (`?embed=playview`) — and one
+// exit (Escape). This drives the real studio with a character and a motion
+// loaded and pins the whole round trip: enter (shot camera owns the pane, no
+// gizmo handles, no inset, frame 0, playing) and leave (editor chrome back,
+// paused). Every wait is a state condition; nothing here sleeps.
+const port = Number(process.env.CDP_PORT || 9222);
+const baseUrl = process.env.QA_URL || "http://127.0.0.1:5180/app/";
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+/** poll a page condition — every wait in this file is a state condition, never a delay */
+const waitFor = async (expression, timeoutMs = 15000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 60));
+	}
+	return false;
+};
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+const escape = async () => {
+	await send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+	await send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+};
+/** gizmo pick proxies live in the scene graph (src/gizmo-claim.js HANDLE_PROXY_FLAG) */
+const gizmoProxies = `(() => {
+	let node = window.__cozyclay.editorCam; while (node.parent) node = node.parent;
+	let count = 0;
+	node.traverse((child) => { if (child.userData?.gizmoHandleProxy) count += 1; });
+	return count;
+})()`;
+/** an element counts as shown when it is in the box tree and not [hidden] */
+const shown = (selector) => `(() => {
+	const el = document.querySelector(${JSON.stringify(selector)});
+	return !!el && !el.hidden && !!el.offsetParent;
+})()`;
+
+/* ------------------------------------------------------------- the app --- */
+
+await waitFor("location.href.startsWith('http')", 30000);
+await evaluate("localStorage.setItem('cozyclay.locale', 'en')");
+await send("Page.enable");
+await send("Page.navigate", { url: `${baseUrl}?motion=/demo/walk-then-stop.npz` });
+expect("the studio comes up with a character", await waitFor("!!window.__cozyclay?.rigA", 40000));
+expect("the demo motion is loaded", await waitFor("!!window.__cozyclay?.motion && window.__cozyclay.frameCount > 30", 40000));
+expect("the hierarchy has rendered", await waitFor("document.querySelectorAll('.hierarchy-row-wrap').length > 0", 15000));
+
+/* --------------------------------------------- the tabs are gone (#195) --- */
+
+expect("no centre tabs in the DOM", await evaluate("document.querySelectorAll('.pane-tabs').length === 0"));
+expect("no PlayView toolbar in the DOM", await evaluate("document.querySelectorAll('.editor-toolbar.play-tools').length === 0"));
+expect("the scene tools own the title bar", await evaluate(shown(".editor-toolbar.scene-tools")));
+expect("the studio starts outside the player", await evaluate("globalThis.playMode === false"));
+expect("the shot PiP offers the way in", await evaluate(shown(".vp-look-through")));
+
+// A character row mounts the transform gizmo: that is the editing chrome the
+// player has to drop, so it must be on the screen before the comparison.
+await evaluate("document.querySelector('[data-node-id=\"characterA\"] .hierarchy-row').click()");
+expect("the character row is selected", await waitFor("document.querySelector('[data-node-id=\"characterA\"]').getAttribute('aria-selected') === 'true'", 8000));
+expect("the gizmo is mounted in the editor view", await waitFor(`${gizmoProxies} > 0`, 10000));
+
+// Park the playhead near the end so the frame-0 restart is unmistakable —
+// playback would need seconds to reach this frame again.
+const parked = await evaluate("(() => { const f = window.__cozyclay.frameCount - 6; window.__cozyclay.scrub(f); return f; })()");
+expect("the playhead is parked near the end", await waitFor(`window.__cozyclay.tlFrame === ${parked}`, 8000));
+
+/* ------------------------------------------------------ enter the player -- */
+
+await evaluate("document.querySelector('.vp-look-through').click()");
+expect("look-through enters preview", await waitFor("globalThis.playMode === true", 8000));
+expect("the QA hook agrees", await evaluate("window.__cozyclay.preview === true"));
+expect("the rig is still live in the player", await evaluate("!!window.__cozyclay.rigA"));
+expect("the pane renders through the shot camera", await evaluate("window.__cozyclay.activeCam === window.__cozyclay.shotCam"));
+expect("the gizmo layer is gone", await waitFor(`${gizmoProxies} === 0`, 8000));
+expect("no transform gizmo handles remain", await evaluate("typeof window.__gizmoHandles !== 'function' || window.__gizmoHandles().length === 0"));
+expect("the plan inset is gone", await evaluate(`!${shown(".vp-inset")}`));
+expect("the shot PiP is gone", await evaluate(`!${shown(".vp-shot-preview")}`));
+expect("the player keeps one visible way out", await evaluate(shown(".vp-look-through-exit")));
+expect("the piece restarted from frame 0", await waitFor(`window.__cozyclay.tlFrame < ${parked}`, 8000));
+expect("and it is playing", await waitFor("window.__cozyclay.playing === true", 8000));
+
+/* ------------------------------------------------------- leave the player -- */
+
+await escape();
+expect("Escape leaves preview", await waitFor("globalThis.playMode === false", 8000));
+expect("no playback is left running underneath", await waitFor("window.__cozyclay.playing === false", 8000));
+expect("the scene tools are back", await evaluate(shown(".editor-toolbar.scene-tools")));
+expect("the shot PiP is back", await waitFor(shown(".vp-shot-preview"), 8000));
+expect("the plan inset is back", await waitFor(shown(".vp-inset"), 8000));
+expect("the gizmo comes back with the editor view", await waitFor(`${gizmoProxies} > 0`, 10000));
+expect("still no centre tabs to go back to", await evaluate("document.querySelectorAll('.pane-tabs').length === 0"));
+
+/* ------------------------------------------------ the Workflow embed path -- */
+
+await send("Page.navigate", { url: `${baseUrl}?embed=playview` });
+expect("the embed comes up", await waitFor("!!window.__cozyclay?.editorCam", 40000));
+expect("the embed loads straight into the player", await waitFor("globalThis.playMode === true", 15000));
+expect("the embed has no centre tabs either", await evaluate("document.querySelectorAll('.pane-tabs').length === 0"));
+expect("the embed hides the whole title bar", await evaluate(`!${shown(".viewport-titlebar")}`));
+expect("the embed shows no exit affordance", await evaluate("document.querySelectorAll('.vp-look-through-exit').length === 0"));
+
+await send("Page.navigate", { url: baseUrl });
+if (failures > 0) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log("qa-preview-browser: all checks passed");
+process.exit(0);

--- a/test/verify-korean-ui.mjs
+++ b/test/verify-korean-ui.mjs
@@ -122,7 +122,9 @@ for (const path of ["src/result-modal.jsx", "src/hierarchy-panel.jsx", "src/obje
 // and the first-run "한국어" cue — travelled with it.
 includesAll("src/settings-menu.jsx", ["한국어로 전환", "한국어", "Switch to English", "설정"]);
 includesAll("src/result-modal.jsx", ["장면이 준비됐어요", "프롬프트 복사", "프레임 다운로드", "AI에 넣는 순서", "AI에 이미지 첨부"]);
-includesAll("src/App.jsx", ["장면", "재생 보기", "속성", "모션 생성", "변환", "카메라 레일 완성", "연결 중…"]);
+// "재생 보기" was the PlayView centre tab's label; the tabs are gone (#195)
+// and the framed player is entered from the shot PiP instead.
+includesAll("src/App.jsx", ["장면", "샷 카메라 시점으로 보기", "속성", "모션 생성", "변환", "카메라 레일 완성", "연결 중…"]);
 includesAll("src/ardy/client.js", ["브리지 상태가 좋지 않아요", "브리지에 연결할 수 없어요", "생성 응답에 본문 스트림이 없어요"]);
 includesAll("src/hierarchy-panel.jsx", ["이름 바꾸기", "장면 구조", "장면 계층", "프레임 맞추기", "장면 선택", "+ 새 장면", "장면은 최소 하나 필요합니다"]);
 includesAll("src/ardy/timeline.jsx", ["애니메이션 타임라인", "프롬프트", "타임라인 펼치기"]);

--- a/test/verify-layout.mjs
+++ b/test/verify-layout.mjs
@@ -42,12 +42,27 @@ expect(
 	!app.includes('ko("Lens (FOV)", "렌즈 (FOV)")') &&
 	!app.includes('<button className="btn ghost" onClick={() => setNonce((n) => n + 1)}>'),
 );
-expect("Scene and PlayView tools share one horizontal title bar", app.includes('className="viewport-titlebar"') && css.includes(".viewport-titlebar") && css.includes("position: static"));
-// #193: transport, OTIO and Record left this bar — the timeline owns playback
-// and the topbar Export menu owns every delivery. Only the readouts remain.
+// #195: the title bar is one horizontal strip — mode tabs plus the scene
+// tools, rendered unconditionally. The Scene/PlayView centre tabs are gone.
 expect(
-	"PlayView toolbar keeps the framing readouts and nothing else",
-	app.includes("editor-toolbar play-tools") && app.includes("shotOutput.label") && !app.includes("toggleShotRecording"),
+	"the viewport title bar is one horizontal strip without centre tabs",
+	app.includes('className="viewport-titlebar"') &&
+	css.includes(".viewport-titlebar") &&
+	css.includes("position: static") &&
+	app.includes('className="editor-toolbar scene-tools"') &&
+	!app.includes('className="pane-tabs"') &&
+	!css.includes(".pane-tabs"),
+);
+// #193 emptied the PlayView bar down to two readouts; #195 removed the bar
+// itself along with the tab that reached it — the framed player is an internal
+// preview state now, and it carries no toolbar at all.
+expect(
+	"the PlayView toolbar is gone, markup and styles alike",
+	!app.includes("editor-toolbar play-tools") &&
+	!css.includes(".editor-toolbar.play-tools") &&
+	!app.includes("toggleShotRecording") &&
+	!app.includes("viewport-readout") &&
+	!css.includes(".viewport-readout"),
 );
 expect(
 	"one topbar Export menu leads with the keyframe pack",

--- a/test/verify-timeline-camera.mjs
+++ b/test/verify-timeline-camera.mjs
@@ -41,9 +41,20 @@ expect("sequence slate and phrase derive per segment", app.includes("moveSequenc
 expect("generation exports first/last key conditioning frames", app.includes("captureFramingPng(cameraKeys[0].framing)") && app.includes("captureFramingPng(cameraKeys[cameraKeys.length - 1].framing)"));
 expect("the duration slider is gone — dots own timing", !app.includes("moveDurationS"));
 
-expect("PlayView restarts the piece from frame 0", app.includes('if (centerTab === "play") setTlFrame(0);'));
-expect("PlayView always rides the camera move", app.includes('centerTab === "play" || (moveFollow && !ikMode && !waypointMode && !posing)'));
-expect("Scene tab keeps the authoring gates on Follow mode", app.includes("moveFollow && !ikMode && !waypointMode && !posing"));
+// #195: the Scene/PlayView tabs are gone. The framed player is the `preview`
+// state, entered from the shot PiP's look-through button, and the two
+// transitions are the whole contract.
+expect(
+	"entering preview restarts the piece from frame 0 and plays it when there is motion",
+	/function enterPreview\(\) \{[^}]*setPreview\(true\);[^}]*setLookThroughShot\(true\);[^}]*setTlFrame\(0\);[^}]*if \(motion\) setTlPlaying\(true\);/s.test(app),
+);
+expect(
+	"leaving preview restores the editor view and pauses",
+	/function exitPreview\(\) \{[^}]*setPreview\(false\);[^}]*setLookThroughShot\(false\);[^}]*setTlPlaying\(false\);/s.test(app),
+);
+expect("the look-through button is the way in, Escape the way out", app.includes("onClick={enterPreview}") && app.includes('if (event.key === "Escape") exitPreview();'));
+expect("preview always rides the camera move", app.includes("preview || (moveFollow && !ikMode && !waypointMode && !posing)"));
+expect("the editor view keeps the authoring gates on Follow mode", app.includes("moveFollow && !ikMode && !waypointMode && !posing"));
 expect(
 	"Draw Rail row owns the distance Follow On Off toggle",
 	timeline.includes('aria-pressed={mode === "follow"}') &&

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -181,6 +181,7 @@ const BROWSER_FILES = [
 	"test/verify-settings-menu-browser.mjs",
 	"test/verify-static-shot-export-browser.mjs",
 	"test/qa-keyframe-pack-browser.mjs",
+	"test/qa-preview-browser.mjs",
 	"test/qa-reference-slots-browser.mjs",
 	"test/qa-scene-switcher-browser.mjs",
 	"test/qa-send-to-ai-browser.mjs",
@@ -190,7 +191,7 @@ const BROWSER_FILES = [
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
## What changed

The viewport bar had two tab strips side by side: the workflow modes, and `Scene | PlayView`. The second one made the operator *name a view* to see the framed output, while the shot PiP already had the better door — a look-through button one pixel away. The tabs go, the PlayView bar goes (after #193 it was two readouts), and **PlayView's render path stays** as an internal state (docs/studio-ui-ia.md §3 뷰포트 바 "중앙 탭", R1; the debate's rounds 2 and 11 — the PiP does not replace PlayView, look-through must route *into* it).

### The state machine

`centerTab: "scene" | "play"` → `preview: boolean`, with exactly two transitions:

| | |
|---|---|
| `enterPreview()` | `setPreview(true)` · `setLookThroughShot(true)` · `setTlFrame(0)` · `if (motion) setTlPlaying(true)` |
| `exitPreview()` | `setPreview(false)` · `setLookThroughShot(false)` · `setTlPlaying(false)` |

- **In**: the shot PiP's look-through button; the Workflow embed (`?embed=playview`) calls `enterPreview()` from its init effect, while `preview`/`lookThroughShot` still seed from `embedMode` so the embed's first painted frame is the shot view rather than a flash of editor chrome.
- **Out**: `Escape` (still disabled inside the embed) and the `● SHOT CAMERA · Esc · exit` pill. The pill now renders **during** preview (`lookThroughShot && !ikMode && !embedMode`) — the player would otherwise have no visible way back, and the embed must stay in the shot view.
- Picking a workflow mode calls `exitPreview()` (a department switch is an editing act), replacing the old `setCenterTab("scene")`.
- `globalThis.playMode` keeps its **name** and now reads `preview` — `window.__cozyclay` and the MCP live bridge speak it. The old `700-773` effect is gone; the two functions are the whole contract.

### Why the render path is kept

`DualRender`'s `playMode` branch (dualview.jsx:377) is the only draw where the shot camera owns the whole pane, `GIZMO_LAYER` is disabled, the image is `fitAspect`-letterboxed to the delivery aspect and there is no plan inset. It is tested **first** in the branch order, so `playMode={preview}` is what look-through now lands in; the `else if (editorCam && !lookThrough)` editing draw and the trailing shot-camera-with-inset draw are untouched (the latter is now the no-editor-camera fallback and the `window.__cozyclay.setLookThrough` QA draw — both commented as such). mp4 export (`runShotExport` → `exportOffscreenVideo`) is offscreen and never reads `playMode`, so preview needed no export entry point.

### Deleted

- `.pane-tabs` block and the `centerTab === "scene" ? scene-tools : play-tools` ternary — `scene-tools` renders unconditionally now.
- the PlayView bar (`.editor-toolbar.play-tools`, aspect + FOV readouts).
- the empty-state CTA behind `playMode && !motion`, including its `track("sample:played", { from: "playview_empty" })` — 0 events in 90 days.
- dead CSS: `.pane-tabs*`, `.editor-toolbar.play-tools*`, `.viewport-readout`, `.playview-empty*`, and the `play-tools` halves of two shared selectors. `.viewport-titlebar` stays (its comment no longer claims the strip is named after the centre tabs); `[data-embed-mode="playview"]` rules still apply — hiding the whole title bar is exactly right now that the bar is mode tabs + scene tools.

Every surviving `centerTab === "scene"` became `!preview` and `centerTab === "play"` became `preview`, with the redundant `&& !playMode` dropped where `!preview` already covers it: gizmo/key-light puck/rail preview/path handles/crane handles/shot-camera puck/waypoint preview stay editor-only, the PiP stays hidden in preview, and the camera move still always rides the playhead in the player.

## Control count

`git show origin/chore/studio-ui-ia:tools/qa/studio-control-count.mjs`, 1600×1000, §1's scenario (one character + the 432-frame demo take, no shots), both columns measured on dev servers of the same commit pair — `afc05c8` (main) on :5198 vs this branch on :5195:

| state | main `afc05c8` | this branch |
|---|---|---|
| scene-none | 40 | **38** |
| scene-char | 40 | **38** |
| camera | 43 | **41** |
| motion | 57 | **55** |

Per-control diff of the same runs, in **every** state:

```
removed: ["viewport-bar | Scene", "viewport-bar | PlayView"]   added: []
```

Nothing else moved. With no take loaded, this branch reads scene 38 / camera 41 / **motion 47**. The doc's R6 budget (Scene ≤35 / Camera ≤38 / Motion ≤52) is met for Motion without a take; the remaining Scene/Camera overage is the topbar + hierarchy + inspector rows that this issue does not touch. `docs/studio-ui-ia.md` §1's "목표" column lives on the unmerged `chore/studio-ui-ia` branch (PR #189), so the measured numbers are recorded here for it.

## Browser QA

Dev server `npm run dev -- --port 5195`, Chrome over CDP through `tools/qa-browser.mjs`.

**New: `test/qa-preview-browser.mjs`** — same shape as the sibling `qa-*-browser.mjs` suites, every wait is a state condition (no sleeps). Registered in `tools/run-tests.mjs` (`BROWSER_FILES` + `EXTRA_INVENTORY`), run with `?motion=/demo/walk-then-stop.npz`.

```
34 PASS, 0 FAIL — qa-preview-browser: all checks passed
PASS no centre tabs in the DOM / no PlayView toolbar in the DOM
PASS the scene tools own the title bar
PASS the studio starts outside the player / the shot PiP offers the way in
PASS the gizmo is mounted in the editor view
PASS the playhead is parked near the end
PASS look-through enters preview (globalThis.playMode === true)
PASS the QA hook agrees (window.__cozyclay.preview === true)
PASS the rig is still live in the player (window.__cozyclay.rigA)
PASS the pane renders through the shot camera (activeCam === shotCam)
PASS the gizmo layer is gone (0 gizmoHandleProxy nodes)
PASS no transform gizmo handles remain (window.__gizmoHandles())
PASS the plan inset is gone / the shot PiP is gone
PASS the player keeps one visible way out
PASS the piece restarted from frame 0 / and it is playing
PASS Escape leaves preview / no playback is left running underneath
PASS the scene tools are back / the shot PiP is back / the plan inset is back
PASS the gizmo comes back with the editor view
PASS still no centre tabs to go back to
PASS the embed comes up / loads straight into the player
PASS the embed has no centre tabs either / hides the whole title bar
PASS the embed shows no exit affordance
```

**Unchanged suites re-run against this branch:** `qa-shot-guides-browser` (12 PASS — including `look-through draws the letterbox-fitted overlay` and `Esc leaves look-through and drops its overlay`, which still hold because the guides follow the shot camera into the player), `verify-camera-mode-browser` (all PASS), `verify-camera-rail-browser` (all PASS). `verify-object-gizmo` reports the same **10 FAIL** on this branch and on `afc05c8` (a storage-fixture suite that needs its own profile) — pre-existing, untouched by this PR.

### Screenshots

Captured at 1600×1000 by the QA browser (`/tmp/pr195/*.png`), demo walk at frame 8:

1. **`1-scene-no-center-tabs.png` — Studio in the editor view.** The title bar is one strip: `Scene | Camera | Motion`, `TRANSFORM` move/rotate/scale, `Snap`, `View ▾`. **No `Scene | PlayView` tabs.** Character gizmo on stage, Top-View inset and SHOT PiP in place.
2. **`2-preview-player.png` — after clicking the PiP's look-through button.** The shot camera owns the pane, letterboxed to 16:9 (the dark bar under the image), no gizmo, no Top-View inset, no SHOT PiP, no toolbar over the image — only the `● SHOT CAMERA · ESC · EXIT` pill. The subject is framed and the take is playing from frame 0.
3. **`3-editor-chrome-back.png` — after Escape.** Editor camera, gizmo, Top-View inset and SHOT PiP are back; the playhead stays where the player left it and playback is paused (no autoplay left running).
4. **`4-workflow-scene-node-embed.png` — `/workflow/` with a CozyClay Scene node.** The node's `/app/?embed=playview` iframe previews the shot view exactly as before, with no title bar and no exit pill. `src/workflow/` is untouched; `verify-cozy-scene-node.mjs` passes unchanged.

## Tests

```
node tools/run-tests.mjs
TEST MANIFEST scope=all runnable=158 total=182
PASS 158 Node verification files          (exit 0)
```

- `verify-timeline-camera.mjs` — the old `centerTab` source strings are replaced by the new contract: `enterPreview` (preview + look-through + frame 0 + autoplay-if-motion), `exitPreview` (all off + paused), `onClick={enterPreview}` / `Escape → exitPreview()`, and `preview || (moveFollow && …)` for the camera move.
- `verify-layout.mjs` — one horizontal title bar **without** centre tabs (`!app.includes('className="pane-tabs"') && !css.includes(".pane-tabs")`), and the PlayView bar gone from markup *and* stylesheet (`editor-toolbar play-tools`, `.viewport-readout`).
- `verify-korean-ui.mjs` — drops the deleted `"재생 보기"` tab label, reads the PiP's `"샷 카메라 시점으로 보기"` instead.
- `verify-cozy-scene-node.mjs` — untouched; both of its App.jsx pins (`useState(embedMode)`, the embed's Escape guard) still hold.

## Noted, not fixed

The `.film-frame` corner marks and the `.caption` slate (`SUBJECT OUT OF FRAME`) are gated on `playMode || !lookThroughShot`, i.e. look-through **without** preview. Since look-through now always enters preview, that combination is only reachable through the `window.__cozyclay.setLookThrough` QA hook, so those two overlays no longer render for users. Deleting them (or moving the out-of-frame warning into the PiP) is a copy/affordance decision beyond this issue's scope — worth its own issue.

Closes #195
