### PR TITLE
ux(studio): no fold caret on the scene root, characters sit under the root, Generate-all waits for a block (IA tail)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12199,6 +12199,11 @@ function resizePromptClip(id, edge, rawFrame) {
 								)}
 							</Field>
 						)}
+						{/* Nothing to generate yet is not a disabled button: with no blocks
+						    the panel's own "Add block at frame N" and its hint already say
+						    what comes next, so the action stays absent until there is at
+						    least one block to run (docs/studio-ui-ia.md R3). */}
+						{promptClips.length >= 1 && (
 						<button
 							type="button"
 							className="btn primary full generate prompt-block-generate"
@@ -12216,6 +12221,7 @@ function resizePromptClip(id, edge, rawFrame) {
 									? `${promptClips.length}개 블록 모두 생성`
 									: `Generate all ${promptClips.length} blocks`}
 						</button>
+						)}
 						{ardyRunning && (
 							<button type="button" className="btn ghost full" onClick={cancelArdy}>
 								{ko("Cancel run", "실행 취소")}

--- a/src/hierarchy-panel.jsx
+++ b/src/hierarchy-panel.jsx
@@ -314,6 +314,10 @@ function TreeRow({
 	// The scene root row hands its name to the pill in `rowExtra`; printing it
 	// twice on one row is the duplication this panel just removed.
 	showLabel = true,
+	// A row that owns children still does not always earn a fold caret: the
+	// scene ROOT would fold the whole scene away, which no workflow needs
+	// (docs/studio-ui-ia.md R6).
+	foldable = true,
 	rowExtra,
 	dropHandlers,
 	reparent,
@@ -443,7 +447,7 @@ function TreeRow({
 			aria-expanded={branch ? expanded : undefined}
 			onContextMenu={(event) => onRowContextMenu(event, node.id)}
 		>
-			{branch ? (
+			{branch && foldable ? (
 				<button
 					type="button"
 					className="hierarchy-toggle"
@@ -453,7 +457,9 @@ function TreeRow({
 					{expanded ? "▾" : "▸"}
 				</button>
 			) : (
-				<span className="hierarchy-toggle placeholder" />
+				// A leaf has nothing to fold and the root must not fold; both keep the
+				// caret column so every row's icon stays on the same line.
+				<span className={foldable ? "hierarchy-toggle placeholder" : "hierarchy-fold-space"} />
 			)}
 			{editing ? (
 				// In-place rename, Unity-style: Enter commits, Escape reverts,
@@ -526,7 +532,7 @@ export default function HierarchyPanel({
 	onSceneRename,
 	onSceneDelete,
 }) {
-	const [expanded, setExpanded] = useState(() => new Set(["shot", "characters", "characterA"]));
+	const [expanded, setExpanded] = useState(() => new Set(["shot", "characterA"]));
 	const [contextMenu, setContextMenu] = useState(null);
 	// Row currently in in-place rename. The panel owns it: F2/Return and the
 	// row context menu are the only ways in, so app state stays out of it.
@@ -547,8 +553,19 @@ export default function HierarchyPanel({
 	const activeSceneName = activeScene.name;
 	const hierarchyNodes = useMemo(() => {
 		const nodes = buildHierarchyNodes(sceneObjects, characters);
-		const labelled = nodes.map((node) => node.kind === "scene" ? { ...node, label: activeSceneName } : node);
-		return labelled;
+		// The model keeps the `characters` GROUP so every id selection, the
+		// inspector and IK already route to stays exactly where it was; the
+		// RENDERED tree drops that row. One heading over one character row cost
+		// two controls (the row and its caret) and its badge only repeated the
+		// number of rows underneath it (docs/studio-ui-ia.md R6), so the cast
+		// sits directly under the root beside Camera/Light/Environment/Props.
+		return nodes.map((node) => ({
+			...node,
+			...(node.kind === "scene" ? { label: activeSceneName } : {}),
+			...(node.children
+				? { children: node.children.flatMap((child) => (child.id === "characters" ? (child.children ?? []) : [child])) }
+				: {}),
+		}));
 	}, [activeSceneName, sceneObjects, characters]);
 	const parents = useMemo(() => indexParents(hierarchyNodes), [hierarchyNodes]);
 
@@ -600,9 +617,6 @@ export default function HierarchyPanel({
 		});
 	};
 	const badgeFor = (id) => {
-		if (id === "characters") {
-			return Array.isArray(characters) ? characters.filter((entry) => !entry.hidden).length : (showB ? 2 : 1);
-		}
 		if (id === "props") return sceneObjects.length;
 		return null;
 	};
@@ -704,8 +718,10 @@ export default function HierarchyPanel({
 	const renderNodes = (nodes, depth = 0) =>
 		nodes.flatMap((node) => {
 			if (node.optional === "showB" && !showB) return [];
-			const open = expanded.has(node.id);
 			const sceneRoot = node.id === SCENE_ROOT_ID;
+			// The root carries no fold caret, so nothing can close it: the scene is
+			// always open under its own name.
+			const open = sceneRoot || expanded.has(node.id);
 			const editing = editingId === node.id;
 			return [
 				<TreeRow
@@ -728,6 +744,7 @@ export default function HierarchyPanel({
 					// On the root row the pill IS the name: the row keeps its icon,
 					// and the rename input takes the pill's place while editing.
 					showLabel={!sceneRoot}
+					foldable={!sceneRoot}
 					rowExtra={sceneRoot && !editing ? (
 						<ScenePill
 							scenes={availableScenes}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2156,6 +2156,14 @@ select {
 
 .hierarchy-toggle.placeholder { pointer-events: none; }
 
+/* The scene root has no fold caret — folding it would hide the whole scene
+   (docs/studio-ui-ia.md R6) — but the row still reserves the caret column so
+   its icon lines up with the rows below it. */
+.hierarchy-fold-space {
+	flex: 0 0 20px;
+	pointer-events: none;
+}
+
 .hierarchy-row {
 	flex: 1;
 	min-width: 0;

--- a/test/qa-ia-tail-browser.mjs
+++ b/test/qa-ia-tail-browser.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Browser QA for the last three controls docs/studio-ui-ia.md budgets against
+// (§1 R6, #189): the scene ROOT has no fold caret, the Characters GROUP row is
+// gone (the cast sits directly under the root), and Prompt Blocks' "Generate
+// all" stays absent until there is a block to generate (R3). Drives the real
+// studio over CDP and screenshots both surfaces, because "the count went down"
+// and "the panel still reads right" are two claims.
+//
+//   QA_URL=http://127.0.0.1:5196/app/ CDP_PORT=9256 node tools/qa-browser.mjs \
+//     -- node test/qa-ia-tail-browser.mjs
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const out = process.env.QA_OUT || "/tmp/ia-tail-qa";
+mkdirSync(out, { recursive: true });
+
+const port = Number(process.env.CDP_PORT || 9222);
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+
+let nextId = 1;
+const pending = new Map();
+const pageErrors = [];
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (message.method === "Runtime.exceptionThrown") {
+		pageErrors.push(message.params.exceptionDetails.exception?.description ?? message.params.exceptionDetails.text);
+		return;
+	}
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true, timeout: 120_000 });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+// Every wait is on the state the step produces, never on a fixed delay: React
+// commits when it commits, and a sleep would only decide how flaky this is.
+const waitFor = async (expression, timeoutMs = 20_000) => {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		if (Date.now() >= deadline) return false;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+};
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+// Screenshots the element an EXPRESSION returns, so a card found by its
+// heading can be framed as precisely as one found by class.
+const shotOf = async (name, elementExpression) => {
+	const clip = await evaluate(`(() => {
+		const node = ${elementExpression};
+		if (!node) return null;
+		node.scrollIntoView({ block: "nearest" });
+		const box = node.getBoundingClientRect();
+		return { x: Math.max(0, Math.round(box.x - 8)), y: Math.max(0, Math.round(box.y - 8)), width: Math.round(box.width + 16), height: Math.round(box.height + 16) };
+	})()`);
+	if (!clip) return 0;
+	const image = await send("Page.captureScreenshot", { format: "png", clip: { ...clip, scale: 2 } });
+	writeFileSync(`${out}/${name}.png`, Buffer.from(image.data, "base64"));
+	return Buffer.from(image.data, "base64").byteLength;
+};
+
+const rowDepth = (id) => evaluate(`(() => {
+	const row = document.querySelector("[data-node-id='${id}']");
+	return row ? Number(getComputedStyle(row).getPropertyValue("--hierarchy-depth")) : null;
+})()`);
+const rowLabels = () => evaluate(`[...document.querySelectorAll(".hierarchy-tree .hierarchy-row")].map((node) => (node.getAttribute("aria-label") ?? node.textContent).trim())`);
+const clickMode = async (label) => {
+	await evaluate(`[...document.querySelectorAll(".workflow-mode-switch button")].find((node) => node.textContent.trim() === "${label}")?.click()`);
+	return waitFor(`[...document.querySelectorAll(".workflow-mode-switch button")].find((node) => node.textContent.trim() === "${label}")?.getAttribute("aria-selected") === "true"`);
+};
+// The Prompt Blocks card, found by its heading rather than by index: the
+// inspector column reorders as foldouts show and hide.
+const PROMPT_CARD = `[...document.querySelectorAll(".card.foldout")].find((card) => !card.hidden && card.querySelector(".foldout-title")?.textContent.trim() === "Prompt Blocks")`;
+const generateAllLabels = () => evaluate(`(() => {
+	const card = ${PROMPT_CARD};
+	if (!card) return null;
+	return [...card.querySelectorAll("button")].map((node) => node.textContent.trim()).filter((text) => text.startsWith("Generate all"));
+})()`);
+
+/* --- a QA project with one character ----------------------------------------- */
+
+await send("Runtime.enable");
+await send("Page.enable");
+await send("Emulation.setDeviceMetricsOverride", { width: 1600, height: 1000, deviceScaleFactor: 1, mobile: false });
+await send("Page.navigate", { url: process.env.QA_URL ?? "http://127.0.0.1:5180/app/" });
+await waitFor("location.href.startsWith('http')");
+await evaluate(`(() => {
+	localStorage.clear();
+	localStorage.setItem("cozyclay.locale", "en");
+	localStorage.setItem("cozyclay.project-session.v1", JSON.stringify({ name: "QA", updatedAt: Date.now() }));
+})()`);
+await send("Page.reload");
+expect("the studio comes up", await waitFor("!!window.__cozyclay?.rigA", 60_000));
+expect("the tree is rendered", await waitFor(`!!document.querySelector("[data-node-id='shot']")`));
+
+/* --- (a) the scene root does not fold ---------------------------------------- */
+
+expect(
+	"the root row carries no fold caret",
+	await evaluate(`!document.querySelector("[data-node-id='shot'] .hierarchy-toggle")`),
+);
+expect(
+	"the root keeps the caret column, so its icon still lines up",
+	await evaluate(`!!document.querySelector("[data-node-id='shot'] .hierarchy-fold-space")`),
+);
+
+/* --- (b) the cast sits directly under the root ------------------------------- */
+
+const labels = await rowLabels();
+expect("no Characters group row is rendered", !labels.includes("Characters"), JSON.stringify(labels));
+expect("the group node itself has no row", await evaluate(`!document.querySelector("[data-node-id='characters']")`));
+expect("Character 1 is still a row", await evaluate(`!!document.querySelector("[data-node-id='characterA']")`));
+const cameraDepth = await rowDepth("camera");
+const characterDepth = await rowDepth("characterA");
+expect("Character 1 sits at the same indent as Camera", characterDepth === cameraDepth && cameraDepth === 1, `camera=${cameraDepth} characterA=${characterDepth}`);
+expect(
+	"the character keeps its own caret and rig subtree",
+	await evaluate(`!!document.querySelector("[data-node-id='characterA'] .hierarchy-toggle") && !!document.querySelector("[data-node-id='characterA.rig']")`),
+);
+await evaluate(`document.querySelector("[data-node-id='characterA'] .hierarchy-row").click()`);
+expect(
+	"clicking Character 1 still selects it",
+	await waitFor(`document.querySelector("[data-node-id='characterA']").classList.contains("selected")`),
+);
+expect("the hierarchy screenshot has bytes", (await shotOf("hierarchy-scene-mode", `document.querySelector(".hierarchy-tree")`)) > 2000);
+
+/* --- (c) Generate all waits for a block -------------------------------------- */
+
+expect("Motion mode opens", await clickMode("Motion"));
+// #201: entering Motion selects the active character's ROW, so the character
+// panels (Prompt Blocks among them) are the ones on screen.
+expect("Motion lands on a character row, not the vanished group", await waitFor(`["characterA", "characterB"].some((id) => document.querySelector("[data-node-id='" + id + "']")?.classList.contains("selected"))`));
+expect("the Prompt Blocks panel is open", await waitFor(`!!(${PROMPT_CARD})?.querySelector(".foldout-body")`));
+expect("with no blocks there is no Generate all button", (await generateAllLabels())?.length === 0, JSON.stringify(await generateAllLabels()));
+expect("the next step is still spelled out", await evaluate(`[...(${PROMPT_CARD}).querySelectorAll("button")].some((node) => node.textContent.trim().startsWith("Add block at frame"))`));
+expect("the empty Prompt Blocks screenshot has bytes", (await shotOf("prompt-blocks-zero", PROMPT_CARD)) > 2000);
+
+await evaluate(`[...(${PROMPT_CARD}).querySelectorAll("button")].find((node) => node.textContent.trim().startsWith("Add block at frame"))?.click()`);
+expect("adding the first block brings the action back", await waitFor(`[...(${PROMPT_CARD}).querySelectorAll("button")].some((node) => node.textContent.trim().startsWith("Generate all"))`));
+const withBlock = await generateAllLabels();
+expect("the action counts the block it would run", withBlock?.[0] === "Generate all 1 blocks", JSON.stringify(withBlock));
+
+writeFileSync(`${out}/summary.json`, JSON.stringify({ labels, cameraDepth, characterDepth, withBlock }, null, 2));
+expect("browser run has no uncaught page errors", pageErrors.length === 0, pageErrors.join(" | "));
+
+ws.close();
+if (failures) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log(`PASS IA tail — no root caret, no Characters group row, Generate all gated on a block; evidence in ${out}`);

--- a/test/qa-scene-switcher-browser.mjs
+++ b/test/qa-scene-switcher-browser.mjs
@@ -124,7 +124,9 @@ expect("the hierarchy column carries no second Projects… button", await evalua
 expect("the tree root row carries the scene pill", await waitFor(`!!document.querySelector("${PILL}")`));
 expect("the pill says which scene is open", await pillLabel() === "SCENE 01", String(await pillLabel()));
 expect("the pill announces itself as the scene selector", await evaluate(`document.querySelector("${PILL}").getAttribute("aria-label")`) === "Select scene");
-expect("the pill carries its own caret, apart from the row's expand caret", await evaluate(`!!document.querySelector(".hierarchy-scene-pill .dd-caret") && !!document.querySelector("${ROOT_ROW} .hierarchy-toggle")`));
+// The pill's caret is the row's ONLY caret: the root lost its fold toggle,
+// because folding the root hid the whole scene (docs/studio-ui-ia.md R6).
+expect("the pill carries the row's only caret", await evaluate(`!!document.querySelector(".hierarchy-scene-pill .dd-caret") && !document.querySelector("${ROOT_ROW} .hierarchy-toggle")`));
 expect("the root row prints the scene name once, in the pill", await rootRowNameCount("SCENE 01") === 1 && await evaluate(`!document.querySelector("${ROOT_ROW} .hierarchy-label")`), String(await rootRowNameCount("SCENE 01")));
 expect("the row still names itself for assistive tech", await rootLabel() === "SCENE 01", String(await rootLabel()));
 
@@ -144,7 +146,9 @@ expect("all three scenes are listed", listed.length === 3, JSON.stringify(listed
 expect("the active scene is marked in the list", await evaluate(`[...document.querySelectorAll('.dropdown-menu [role=option]')].filter((node) => node.getAttribute("aria-selected") === "true").map((node) => node.textContent.trim()).join()`) === "SCENE 03");
 expect("the list offers a create item after the scenes", await evaluate(`/New scene/.test([...document.querySelectorAll(".dropdown-menu [role=option]")].at(-1).textContent)`));
 expect("the pill list is portaled clear of the panel that clips it", await evaluate(`document.querySelector(".dropdown-menu")?.parentElement === document.body`));
-expect("opening the pill does not fold the tree", await evaluate(`document.querySelector("${ROOT_ROW}").getAttribute("aria-expanded")`) === "true");
+// Nothing can fold the root any more, so the proof is the scene's own rows:
+// they are still on screen behind the open pill.
+expect("opening the pill does not fold the tree", await evaluate(`!!document.querySelector("[data-node-id='camera']") && !!document.querySelector("[data-node-id='characterA']")`));
 expect("the pill screenshot has bytes", (await shot("pill-open-three-scenes")) > 2000);
 
 /* --- switch between the three ------------------------------------------------ */

--- a/test/verify-hierarchy.mjs
+++ b/test/verify-hierarchy.mjs
@@ -206,7 +206,25 @@ expect(
 		panelSource.includes("canDelete: availableScenes.length > 1,") &&
 		panelSource.includes('setSceneHint(ko("At least one scene is required", "장면은 최소 하나 필요합니다"))'),
 );
-expect("entity tree root follows the active scene name", panelSource.includes('node.kind === "scene" ? { ...node, label: activeSceneName } : node'));
+expect("entity tree root follows the active scene name", panelSource.includes('node.kind === "scene" ? { label: activeSceneName } : {}'));
+// docs/studio-ui-ia.md R6: the last two hierarchy affordances that folded the
+// whole scene are gone. The MODEL keeps the `characters` group (ids above are
+// unchanged, so selection, IK and inspector routing are too); the RENDERED
+// tree splices its children under the root, and the root gets no fold caret.
+expect(
+	"the rendered tree lifts the cast out of the Characters group",
+	panelSource.includes('node.children.flatMap((child) => (child.id === "characters" ? (child.children ?? []) : [child]))'),
+);
+expect(
+	"the group row's count badge went with it",
+	!panelSource.includes('if (id === "characters")') && panelSource.includes('if (id === "props") return sceneObjects.length;'),
+);
+expect(
+	"the scene root renders no fold caret, and cannot be folded",
+	panelSource.includes("foldable={!sceneRoot}") &&
+		panelSource.includes("{branch && foldable ? (") &&
+		panelSource.includes("const open = sceneRoot || expanded.has(node.id);"),
+);
 
 // The studio source spans App.jsx and app-stage.jsx (module-level extraction); pin against both.
 const appSource = await readFile(new URL("../src/App.jsx", import.meta.url), "utf8")

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -180,6 +180,7 @@ const BROWSER_FILES = [
 	"test/verify-project-menu-browser.mjs",
 	"test/verify-settings-menu-browser.mjs",
 	"test/verify-static-shot-export-browser.mjs",
+	"test/qa-ia-tail-browser.mjs",
 	"test/qa-keyframe-pack-browser.mjs",
 	"test/qa-preview-browser.mjs",
 	"test/qa-reference-slots-browser.mjs",
@@ -191,7 +192,7 @@ const BROWSER_FILES = [
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
Closes the last three simultaneously-visible controls the IA budgets against (docs/studio-ui-ia.md §1 **R6** — Scene ≤35 / Camera ≤38 / Motion ≤52 — and the inspector row that **R3** already spelled out: "Generate all absent until ≥1 block"). After the six IA PRs main was over by exactly three in every mode, and it was the same three controls everywhere: two hierarchy affordances that fold the whole scene, plus one disabled button with nothing to do.

## What changed

**(a) The scene ROOT row has no fold caret.** Folding the root hid the entire scene, which no workflow needs. `TreeRow` takes a `foldable` prop (the rule is stated once, where the caret is drawn); the root keeps `aria-expanded="true"` and `renderNodes` forces it open, so nothing can close it. A caret-width spacer (`.hierarchy-fold-space`) keeps the root's icon on the same line as the rows below — the row's geometry is unchanged, only the button is gone.

**(b) The `Characters` GROUP row is gone**, with its caret (2 controls) and its count badge, which only repeated the number of rows underneath it. The cast renders directly under the root, at the same indent as Camera / Light / Environment / Props, each character keeping its own caret and rig subtree.

Only the **rendered** tree changes. `hierarchy-model.js` still nests the rows under `characters`, so every id that selection, IK, the inspector and `selectWorkflowMode("motion")` (`rowIdForCharIndex(activeCharIndex)`) route to is untouched — `hierarchy-panel.jsx` splices the group's children into the root's children in its `hierarchyNodes` memo. `test/verify-hierarchy.mjs`'s model expectations (`characterA.parent === "characters"`, the rig namespace, the attached-prop rules) needed **no** change, which is the point. Entering Motion already selects a character ROW (#201), and `isCharacterSelection` still accepts `"characters"`, so nothing depended on clicking the group row. `+ Add second subject` still lives in the inspector.

**(c) Prompt Blocks' "Generate all 0 blocks" waits for a block.** The button renders only when `promptClips.length >= 1`; with no blocks the panel shows nothing extra, because "Add block at frame N" and the hint above it already say what comes next (R3). The disabled-with-a-reason state for a blank block is unchanged.

No dead CSS to remove (`hierarchy-group` / `characters-group` never existed; `.hierarchy-badge` is still the Props count).

## Control count

`git show origin/chore/studio-ui-ia:tools/qa/studio-control-count.mjs` (the script from #189 — it is not on main), 1600×1000, QA project with one character and no shots, both columns measured on dev servers of the same commit pair: main `e384d00` vs this branch, no take loaded.

| state | main `e384d00` | this branch | budget |
|---|---|---|---|
| scene-none | 38 | **35** | ≤35 |
| scene-char | 38 | **35** | ≤35 |
| camera | 41 | **38** | ≤38 |
| motion | 47 | **43** | ≤52 |

Scene and Camera lose exactly the three hierarchy controls (root caret, group row, group caret); Motion loses those three plus `Generate all 0 blocks`. The parent measurement with the 432-frame take loaded read 38 / 41 / 55, so the same cuts land Motion at **51 ≤ 52**. Every budget in R6 is now met.

## Screenshots

Hierarchy panel, Scene mode — no caret on `SCENE 01`, `Character 1` sits beside Camera/Light/Environment/Props with its own caret and Rig:

![hierarchy after](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/ia-tail/qa/hierarchy-after.png)

Motion inspector, Prompt Blocks with 0 blocks — no "Generate all", only the hint and "Add block at frame 0":

![prompt blocks, zero blocks](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/ia-tail/qa/prompt-blocks-zero-after.png)

Whole studio, Scene mode, before (main `e384d00`) and after:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/ia-tail/qa/studio-scene-before.png) | ![after](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/ia-tail/qa/studio-scene-after.png) |

## Tests

`node tools/run-tests.mjs` after `npm run build`:

```
TEST MANIFEST scope=all runnable=158 total=183
...
PASS 158 Node verification files
```

Browser suites run for real against `npm run dev` (port 5296 — 5196 was held by an unrelated ARDY bridge), Chrome over CDP through `tools/qa-browser.mjs`:

- **New `test/qa-ia-tail-browser.mjs`** (registered in `BROWSER_FILES` + `EXTRA_INVENTORY`; every wait is a state condition, no sleeps) — 21 PASS / 0 FAIL: root row has no `.hierarchy-toggle` but keeps the caret column; no row labelled `Characters` and no `[data-node-id='characters']`; `Character 1` renders at the same `--hierarchy-depth` as `Camera`, still with its caret and `characterA.rig`; clicking it still selects it; Motion lands on a character row; with 0 blocks no button whose text starts with "Generate all", and after "Add block at frame 0" it returns reading `Generate all 1 blocks`. Both screenshots above come from this run.
- `test/qa-scene-switcher-browser.mjs` — 51 PASS / 0 FAIL. Its two root-caret assertions were rewritten: the pill now carries the row's **only** caret, and "opening the pill does not fold the tree" is proven by the scene's rows still being on screen rather than by the root's `aria-expanded`.
- `test/qa-multichar-rig-browser.mjs` — 10 PASS / 0 FAIL, untouched: it expands `characterA` / `characterB` by their own carets and never touched the group.
- `test/verify-hierarchy.mjs` gains three source contracts (the render-time splice, the dropped group badge, the unfoldable root); `test/verify-layout.mjs:116` still pins `Generate all ${promptClips.length} blocks`, which lives on inside the conditional.

Refs #189
