### PR TITLE
feat(studio): camera tutorial inside the studio (#206)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -224,6 +224,7 @@ import {
 } from "./project.js";
 import ProjectBrowser, { ProjectNameDialog } from "./project-browser.jsx";
 import FirstSuccessGuide from "./first-success-guide.jsx";
+import { CameraTutorial } from "./camera-tutorial.jsx";
 import ObjectGizmo from "./object-gizmo.jsx";
 import AssetPane from "./asset-pane.jsx";
 import AddObjectMenu from "./object-catalog.jsx";
@@ -632,6 +633,19 @@ export default function App() {
 	const playgroundMode = isPlaygroundEmbed(globalThis.location?.search);
 	const [playgroundHint, setPlaygroundHint] = useState(null);
 	const playgroundExportRef = useRef(null);
+	// The camera tutorial (#206): the landing page's seven steps, run against
+	// the real studio instead of the playground iframe. It opens from
+	// /app/?tutorial=camera or from Settings ▾; opening it changes nothing else
+	// about the session, and it is not offered inside an embed.
+	const [cameraTutorial, setCameraTutorial] = useState(() => !embedMode && new URLSearchParams(globalThis.location?.search || "").get("tutorial") === "camera");
+	useEffect(() => {
+		const onTutorial = (event) => setCameraTutorial(event.detail?.open !== false);
+		window.addEventListener("cozyclay:camera-tutorial", onTutorial);
+		return () => window.removeEventListener("cozyclay:camera-tutorial", onTutorial);
+	}, []);
+	useEffect(() => {
+		if (cameraTutorial) trackFeature("camera_tutorial");
+	}, [cameraTutorial]);
 	useEffect(() => {
 		if (!embedMode) return undefined;
 		// The Workflow page's Scene node embeds the studio as its preview, so the
@@ -10667,6 +10681,12 @@ function resizePromptClip(id, edge, rawFrame) {
 					</div>
 				</div>
 
+					{/* Sits under the mode tabs and left of the Top-View inset, over the
+					    stage it is teaching. The overlay itself never takes the pointer
+					    (styles.css) — every step is completed in the studio underneath. */}
+					{cameraTutorial && !embedMode && (
+						<CameraTutorial previewing={lookThroughShot} onClose={() => setCameraTutorial(false)} />
+					)}
 					<div className="stage" id="stage" ref={stageRef} data-render-loop={renderActive ? "always" : "demand"}>
 						{/* Shadows were off, so every castShadow in props.jsx was inert and
 						    nothing on the open stage ever touched the floor. A contact

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -34,7 +34,7 @@ const EVENT_PROPERTIES = Object.freeze({
 const FEATURE_NAMES = new Set([
 	"pose_edit", "camera_fly", "orbit", "dolly_rail", "crane_graph", "timeline_scrub",
 	"prompt_block_add", "shot_add", "shot_cut", "export_pose", "export_frame", "export_video",
-	"mcp_connected", "auto_color", "plan_view",
+	"mcp_connected", "auto_color", "plan_view", "camera_tutorial",
 ]);
 const HEARD_FROM_VALUES = new Set(["x", "hn", "reddit", "github", "friend", "other"]);
 const DENIED_PROPERTY_KEYS = new Set(["prompt", "text", "url", "path", "file"]);

--- a/src/camera-tutorial.jsx
+++ b/src/camera-tutorial.jsx
@@ -1,0 +1,197 @@
+import { useEffect, useMemo, useState } from "react";
+import { ko } from "./locale.js";
+
+// The camera tutorial, Studio-native (#206).
+//
+// The landing page runs the same seven steps against the playground iframe
+// (index.html), where the studio is a black box and every signal crosses the
+// frame boundary as a postMessage. Inside /app/ there is no frame: the
+// gestures already announce themselves on `window`, so this component listens
+// to them directly.
+//
+//   cozyclay:nav               fly / walk / dolly / orbit  (src/controls.jsx)
+//   cozyclay:playground-signal shot / rail                 (src/App.jsx)
+//   previewing prop            play                        (lookThroughShot)
+//
+// Nothing here drives the studio. A step is done when the operator has done
+// the thing in the real tool — there is no "next" button to fake progress
+// with, which is the whole point of teaching a camera by flying it.
+
+/** Right-button + these six keys is one gesture, so the walk step only counts
+ * once every key has actually been pressed (the landing page's rule). */
+export const WALK_KEYS = ["w", "a", "s", "d", "q", "e"];
+
+export const CAMERA_TUTORIAL_STEPS = [
+	{
+		kind: "fly",
+		label: ko("Look", "보기"),
+		how: () => ko(
+			"Right-drag in the viewport to look around.",
+			"뷰포트에서 오른쪽 버튼을 끌어 주위를 둘러보세요.",
+		),
+	},
+	{
+		kind: "walk",
+		label: ko("Walk", "걷기"),
+		how: ({ walked }) => {
+			const keys = (
+				<span className="camera-tutorial-keys">
+					{WALK_KEYS.map((key) => (
+						<kbd key={key} data-key={key} data-done={walked.has(key) ? 1 : 0}>{key.toUpperCase()}</kbd>
+					))}
+				</span>
+			);
+			return ko(
+				<>Hold the right button and press each key once: {keys} W A S D walk, Q E crane.</>,
+				<>오른쪽 버튼을 누른 채 각 키를 한 번씩 누르세요: {keys} W A S D 이동, Q E 크레인.</>,
+			);
+		},
+	},
+	{
+		kind: "dolly",
+		label: ko("Dolly", "돌리"),
+		how: () => ko(
+			"Scroll in the viewport to push in and pull out.",
+			"뷰포트에서 스크롤해 앞뒤로 밀고 당겨 보세요.",
+		),
+	},
+	{
+		kind: "orbit",
+		label: ko("Orbit", "궤도"),
+		how: () => ko(
+			<>Hold <kbd>Alt</kbd> (<kbd>⌥ Option</kbd> on Mac) and left-drag to circle the character.</>,
+			<><kbd>Alt</kbd>(맥은 <kbd>⌥ Option</kbd>)을 누른 채 왼쪽 버튼을 끌어 캐릭터 주위를 도세요.</>,
+		),
+	},
+	{
+		kind: "shot",
+		label: ko("Shot", "샷"),
+		how: () => ko(
+			<>In the timeline's Shots lane click <b>+ Add shot</b>. That is your cut.</>,
+			<>타임라인의 샷 레인에서 <b>+ 샷 추가</b>를 누르세요. 그게 컷입니다.</>,
+		),
+	},
+	{
+		kind: "rail",
+		label: ko("Rail", "레일"),
+		how: () => ko(
+			<>Select the shot, click <b>Draw rail</b> in the camera bar, and drag a line across the top view. That line is the dolly move.</>,
+			<>샷을 선택하고 카메라 바의 <b>레일 그리기</b>를 누른 뒤, 탑뷰에 선을 그으세요. 그 선이 돌리 이동입니다.</>,
+		),
+	},
+	{
+		kind: "play",
+		label: ko("Play", "재생"),
+		how: () => ko(
+			<>Click the look-through button in the viewport to see the shot camera; <b>▶</b> rides the rail, <kbd>Esc</kbd> returns to the free camera.</>,
+			<>뷰포트의 시점 보기 버튼을 눌러 샷 카메라를 보세요. <b>▶</b>는 레일을 타고, <kbd>Esc</kbd>로 자유 카메라로 돌아옵니다.</>,
+		),
+	},
+];
+
+const NAV_KINDS = new Set(["fly", "walk", "dolly", "orbit"]);
+const SIGNAL_KINDS = new Set(["shot", "rail"]);
+
+/**
+ * The overlay itself: a seven-chip strip plus one hint card for the step the
+ * operator is on. It sits at the top of the viewport pane, left of the
+ * Top-View inset, and never takes the pointer except on its own close button
+ * — every step is completed by working the studio underneath it.
+ */
+export function CameraTutorial({ previewing = false, onClose }) {
+	const [done, setDone] = useState(() => new Set());
+	const [walked, setWalked] = useState(() => new Set());
+
+	useEffect(() => {
+		const complete = (kind) => setDone((current) => (current.has(kind) ? current : new Set(current).add(kind)));
+		const onNav = (event) => {
+			const kind = event.detail?.kind;
+			if (!NAV_KINDS.has(kind)) return;
+			if (kind !== "walk") {
+				complete(kind);
+				return;
+			}
+			const key = typeof event.detail?.key === "string" ? event.detail.key.toLowerCase() : null;
+			if (!WALK_KEYS.includes(key)) return;
+			setWalked((current) => {
+				if (current.has(key)) return current;
+				const next = new Set(current).add(key);
+				if (WALK_KEYS.every((walkKey) => next.has(walkKey))) complete("walk");
+				return next;
+			});
+		};
+		const onSignal = (event) => {
+			if (SIGNAL_KINDS.has(event.detail?.kind)) complete(event.detail.kind);
+		};
+		window.addEventListener("cozyclay:nav", onNav);
+		window.addEventListener("cozyclay:playground-signal", onSignal);
+		return () => {
+			window.removeEventListener("cozyclay:nav", onNav);
+			window.removeEventListener("cozyclay:playground-signal", onSignal);
+		};
+	}, []);
+
+	// The player is the last step, and only once there is a rail to ride:
+	// look-through before the dolly exists shows a still frame, which teaches
+	// nothing about the move.
+	useEffect(() => {
+		if (!previewing) return;
+		setDone((current) => (!current.has("rail") || current.has("play") ? current : new Set(current).add("play")));
+	}, [previewing]);
+
+	const current = useMemo(() => CAMERA_TUTORIAL_STEPS.find((step) => !done.has(step.kind)) ?? null, [done]);
+	const complete = current === null;
+
+	return (
+		<aside
+			className="camera-tutorial"
+			data-testid="camera-tutorial"
+			data-state={complete ? "done" : "active"}
+			data-previewing={previewing ? 1 : 0}
+			aria-label={ko("Camera tutorial", "카메라 튜토리얼")}
+		>
+			<ol className="camera-tutorial-steps">
+				{CAMERA_TUTORIAL_STEPS.map((step, index) => (
+					<li
+						key={step.kind}
+						data-testid="camera-tutorial-step"
+						data-kind={step.kind}
+						data-done={done.has(step.kind) ? 1 : 0}
+						data-current={step === current ? 1 : 0}
+					>
+						<i aria-hidden="true">{done.has(step.kind) ? "✓" : index + 1}</i>
+						{step.label}
+					</li>
+				))}
+			</ol>
+			<div className="camera-tutorial-card" data-testid="camera-tutorial-card" role="status">
+				{complete ? (
+					<>
+						<span className="camera-tutorial-count done">{ko("Done", "완료")}</span>
+						<p>{ko(
+							"That is the whole camera: look, walk, dolly, orbit, cut, rail, play.",
+							"카메라의 전부입니다: 보기, 걷기, 돌리, 궤도, 컷, 레일, 재생.",
+						)}</p>
+					</>
+				) : (
+					<>
+						<span className="camera-tutorial-count">{`${CAMERA_TUTORIAL_STEPS.indexOf(current) + 1} / ${CAMERA_TUTORIAL_STEPS.length}`}</span>
+						<p>{current.how({ walked })}</p>
+					</>
+				)}
+			</div>
+			<button
+				type="button"
+				className="camera-tutorial-close"
+				data-testid="camera-tutorial-close"
+				aria-label={ko("Close tutorial", "튜토리얼 닫기")}
+				title={ko("Close tutorial", "튜토리얼 닫기")}
+				onClick={() => onClose?.()}
+			>
+				×
+			</button>
+		</aside>
+	);
+}
+
+export default CameraTutorial;

--- a/src/settings-menu.jsx
+++ b/src/settings-menu.jsx
@@ -95,6 +95,21 @@ export default function SettingsMenu() {
 						{ko("Anonymous analytics", "익명 사용 통계")}
 						<span className="mark">{optedOut ? ko("off", "끔") : ko("on", "켬")}</span>
 					</button>
+					{/* Learning the camera is not a document edit and not a topbar
+					    button (R4): the tutorial opens from this closed popover, so the
+					    mode budgets in docs/studio-ui-ia.md §1 are untouched. */}
+					<h4>{ko("Help", "도움말")}</h4>
+					<button
+						type="button"
+						data-testid="settings-camera-tutorial"
+						title={ko("Learn the camera in seven steps", "일곱 단계로 카메라 익히기")}
+						onClick={() => {
+							window.dispatchEvent(new CustomEvent("cozyclay:camera-tutorial", { detail: { open: true } }));
+							setOpen(false);
+						}}
+					>
+						{ko("Camera tutorial", "카메라 튜토리얼")}
+					</button>
 				</div>
 			)}
 		</div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -10554,3 +10554,142 @@ input[type=range] {
 	margin: 0;
 	color: #e08a7a;
 }
+
+/* ------------------------------------------------- camera tutorial ------- */
+
+/* The Studio-native camera tutorial (#206): a strip of seven step chips and
+   one hint card, hung under the 27px viewport titlebar, left of the Top-View
+   inset (right:15px). The overlay is transparent to the pointer — every step
+   is finished by working the stage underneath it — so only the close button
+   takes clicks. */
+.camera-tutorial {
+	position: absolute;
+	top: 35px;
+	left: 12px;
+	z-index: 7;
+	width: min(430px, calc(100% - 24px - 26%));
+	padding: 8px 10px 9px;
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+	background: color-mix(in srgb, var(--panel) 94%, #000);
+	border: 1px solid var(--line2);
+	border-radius: 8px;
+	box-shadow: var(--shadow-md);
+	pointer-events: none;
+	animation: rise var(--med) var(--ease) both;
+}
+
+/* The look-through exit pill is centred in the same band (top:60px), and it
+   is the only way back to the free camera without the keyboard. While the
+   player is up the card gives that width back rather than covering it. */
+.camera-tutorial[data-previewing="1"] {
+	width: clamp(220px, calc(50% - 92px), 360px);
+}
+
+.camera-tutorial-steps {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin: 0;
+	padding: 0 22px 0 0;
+	list-style: none;
+}
+
+.camera-tutorial-steps li {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	padding: 2px 7px;
+	border: 1px solid var(--line2);
+	border-radius: 999px;
+	color: var(--muted);
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: .02em;
+}
+
+.camera-tutorial-steps li i {
+	font-family: var(--mono);
+	font-style: normal;
+	font-size: 9px;
+	opacity: .85;
+}
+
+.camera-tutorial-steps li[data-current="1"] {
+	border-color: var(--accent);
+	background: var(--accent-soft);
+	color: var(--fg);
+}
+
+.camera-tutorial-steps li[data-done="1"] {
+	border-color: color-mix(in srgb, #65c18c 55%, transparent);
+	color: #65c18c;
+}
+
+.camera-tutorial-card {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	color: var(--fg);
+	font-size: 11.5px;
+	line-height: 1.45;
+}
+
+.camera-tutorial-card p {
+	margin: 0;
+}
+
+.camera-tutorial-count {
+	flex: none;
+	color: var(--accent);
+	font-family: var(--mono);
+	font-size: 9.5px;
+	font-weight: 700;
+	letter-spacing: .06em;
+	text-transform: uppercase;
+}
+
+.camera-tutorial-count.done {
+	color: #65c18c;
+}
+
+.camera-tutorial kbd {
+	padding: 1px 5px;
+	border: 1px solid var(--line2);
+	border-radius: 4px;
+	background: var(--card2);
+	color: var(--fg);
+	font-family: var(--mono);
+	font-size: 9.5px;
+}
+
+.camera-tutorial-keys {
+	display: inline-flex;
+	gap: 3px;
+	margin: 0 2px;
+}
+
+.camera-tutorial-keys kbd[data-done="1"] {
+	border-color: color-mix(in srgb, #65c18c 55%, transparent);
+	color: #65c18c;
+}
+
+.camera-tutorial-close {
+	position: absolute;
+	top: 4px;
+	right: 5px;
+	padding: 0 4px;
+	border: 0;
+	background: transparent;
+	color: var(--muted);
+	font-size: 15px;
+	line-height: 1;
+	cursor: pointer;
+	pointer-events: auto;
+}
+
+.camera-tutorial-close:hover,
+.camera-tutorial-close:focus-visible {
+	color: var(--fg);
+}

--- a/test/qa-camera-tutorial-browser.mjs
+++ b/test/qa-camera-tutorial-browser.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// Browser QA for the Studio-native camera tutorial (#206), over CDP through
+// the QA browser wrapper:
+//
+//   QA_URL=http://127.0.0.1:5320/app/ CDP_PORT=9320 \
+//     node tools/qa-browser.mjs -- node test/qa-camera-tutorial-browser.mjs
+//
+// It drives the REAL studio with real input events — a right-drag to look, the
+// six walk keys pressed while the right button is held, a wheel dolly, an
+// Alt+left orbit, "+ Add shot" in the timeline, "Draw rail" plus a stroke over
+// the Top-View, and the look-through button — and reads each step's data-done
+// back off the strip. Nothing here pokes React state: if a real gesture stops
+// announcing itself, this suite goes red. Screenshots land in QA_SHOT_DIR.
+// Evidence script; not part of the Node manifest.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const port = Number(process.env.CDP_PORT || 9222);
+const appUrl = (process.env.QA_URL || "http://127.0.0.1:5180/app/").replace(/\?.*$/, "");
+const shotDir = process.env.QA_SHOT_DIR || join(tmpdir(), "tutorial-qa");
+mkdirSync(shotDir, { recursive: true });
+
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+if (!page) throw new Error("no page target on the QA browser");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let nextId = 1;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const { resolve, reject } = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) reject(new Error(JSON.stringify(message.error)));
+	else resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+	const id = nextId++;
+	pending.set(id, { resolve, reject });
+	ws.send(JSON.stringify({ id, method, params }));
+});
+const evaluate = async (expression) => {
+	const result = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "evaluate failed");
+	return result.result.value;
+};
+/** poll a page condition — every wait in this file is a state condition, never a delay */
+const waitFor = async (expression, timeoutMs = 15000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await evaluate(expression).catch(() => false)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 60));
+	}
+	return false;
+};
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+const screenshot = async (name) => {
+	const capture = await send("Page.captureScreenshot", { format: "png" });
+	writeFileSync(join(shotDir, `${name}.png`), Buffer.from(capture.data, "base64"));
+};
+
+/* ------------------------------------------------------------ helpers --- */
+
+const centreOf = (selector) => evaluate(`(() => {
+	const el = document.querySelector(${JSON.stringify(selector)});
+	if (!el) return null;
+	const box = el.getBoundingClientRect();
+	if (box.width < 2 || box.height < 2) return null;
+	return { x: box.x + box.width / 2, y: box.y + box.height / 2, width: box.width, height: box.height, left: box.x, top: box.y };
+})()`);
+const mouse = (type, { x, y, button = "none", buttons = 0, modifiers = 0, clickCount = 0, deltaX = 0, deltaY = 0 }) =>
+	send("Input.dispatchMouseEvent", { type, x, y, button, buttons, modifiers, clickCount, deltaX, deltaY });
+/** a real press/release pair at an element's centre */
+const click = async (selector, modifiers = 0) => {
+	const box = await centreOf(selector);
+	if (!box) return false;
+	await mouse("mousePressed", { x: box.x, y: box.y, button: "left", buttons: 1, clickCount: 1, modifiers });
+	await mouse("mouseReleased", { x: box.x, y: box.y, button: "left", buttons: 0, clickCount: 1, modifiers });
+	return true;
+};
+const key = async (code, keyName, virtualKeyCode) => {
+	const common = { code, key: keyName, windowsVirtualKeyCode: virtualKeyCode, nativeVirtualKeyCode: virtualKeyCode };
+	await send("Input.dispatchKeyEvent", { type: "keyDown", text: keyName, ...common });
+	await send("Input.dispatchKeyEvent", { type: "keyUp", ...common });
+};
+const step = (kind) => `document.querySelector('[data-testid="camera-tutorial-step"][data-kind="${kind}"]')`;
+const doneFlag = (kind) => `${step(kind)}?.dataset.done === "1"`;
+const currentFlag = (kind) => `${step(kind)}?.dataset.current === "1"`;
+
+/* --------------------------------------------------------- page setup --- */
+
+// The QA browser inherits the host locale; pin English so label matching is
+// deterministic, then boot the studio with the tutorial query on.
+await send("Page.enable");
+await send("Emulation.setDeviceMetricsOverride", { width: 1600, height: 1000, deviceScaleFactor: 1, mobile: false });
+await waitFor("location.href.startsWith('http')", 30000);
+await evaluate("localStorage.setItem('cozyclay.locale', 'en')");
+await send("Page.navigate", { url: `${appUrl}?tutorial=camera` });
+expect("the studio comes up on ?tutorial=camera", await waitFor("!!document.querySelector('canvas')", 40000));
+expect("the editor camera is live", await waitFor("!!window.__cozyclay?.editorCam", 30000));
+expect("the tutorial mounts from the query", await waitFor('!!document.querySelector(\'[data-testid="camera-tutorial"]\')', 15000));
+
+expect(
+	"the strip shows the seven steps in order",
+	await evaluate(`JSON.stringify([...document.querySelectorAll('[data-testid="camera-tutorial-step"]')].map((li) => li.dataset.kind)) === '["fly","walk","dolly","orbit","shot","rail","play"]'`),
+);
+expect("nothing starts done", await evaluate(`[...document.querySelectorAll('[data-testid="camera-tutorial-step"]')].every((li) => li.dataset.done === "0")`));
+expect("the first step is the current one", await evaluate(`${currentFlag("fly")} && ${step("walk")}.dataset.current === "0"`));
+expect("the card carries the first instruction", await evaluate(`/Right-drag/.test(document.querySelector('[data-testid="camera-tutorial-card"]').textContent)`));
+await screenshot("tutorial-step1");
+
+/* ------------------------------------------------------- the gestures --- */
+
+const canvas = await centreOf(".stage canvas");
+expect("the stage canvas is on screen", !!canvas, JSON.stringify(canvas));
+
+// 1. Look — a right-button drag in the viewport.
+await mouse("mousePressed", { x: canvas.x, y: canvas.y, button: "right", buttons: 2, clickCount: 1 });
+await mouse("mouseMoved", { x: canvas.x + 70, y: canvas.y + 20, button: "right", buttons: 2 });
+await mouse("mouseMoved", { x: canvas.x + 130, y: canvas.y + 34, button: "right", buttons: 2 });
+expect("right-drag completes the Look step", await waitFor(doneFlag("fly")));
+expect("Walk becomes the current step", await waitFor(currentFlag("walk")));
+
+// 2. Walk — the six keys, pressed while the right button is still held.
+await key("KeyW", "w", 87);
+await key("KeyA", "a", 65);
+await key("KeyS", "s", 83);
+expect("three of six keys do not finish Walk", await evaluate(`${step("walk")}.dataset.done === "0"`));
+expect("the pressed keys are marked on the card", await waitFor(`document.querySelectorAll('[data-testid="camera-tutorial-card"] kbd[data-done="1"]').length === 3`));
+await key("KeyD", "d", 68);
+await key("KeyQ", "q", 81);
+await key("KeyE", "e", 69);
+expect("all six keys complete the Walk step", await waitFor(doneFlag("walk")));
+await mouse("mouseReleased", { x: canvas.x + 130, y: canvas.y + 34, button: "right", buttons: 0, clickCount: 1 });
+
+// 3. Dolly — the wheel over the viewport.
+await mouse("mouseWheel", { x: canvas.x, y: canvas.y, deltaX: 0, deltaY: -120 });
+expect("the wheel completes the Dolly step", await waitFor(doneFlag("dolly")));
+
+// 4. Orbit — Alt + left drag (modifier bit 1 is Alt in the CDP contract).
+await mouse("mousePressed", { x: canvas.x, y: canvas.y, button: "left", buttons: 1, clickCount: 1, modifiers: 1 });
+await mouse("mouseMoved", { x: canvas.x + 90, y: canvas.y, button: "left", buttons: 1, modifiers: 1 });
+await mouse("mouseReleased", { x: canvas.x + 90, y: canvas.y, button: "left", buttons: 0, clickCount: 1, modifiers: 1 });
+expect("Alt+left-drag completes the Orbit step", await waitFor(doneFlag("orbit")));
+expect("Shot is now the current step", await waitFor(currentFlag("shot")));
+await screenshot("tutorial-midway");
+
+// 5. Shot — the timeline's Shots lane header button.
+expect("the Shots lane offers + Add shot", await waitFor(`!!document.querySelector('.tl-track-add.cut')`));
+expect("+ Add shot is clickable", await click(".tl-track-add.cut"));
+expect("adding a shot completes the Shot step", await waitFor(doneFlag("shot")));
+expect("the shot block appears in the lane", await waitFor("!!document.querySelector('.tl-shot-block')"));
+
+// 6. Rail — select the shot, arm Draw rail, then stroke across the Top-View.
+expect("the shot block can be selected", await click(".tl-shot-block"));
+expect("the camera bar appears for the shot", await waitFor("!!document.querySelector('.tl-camera-editor .tl-rail-draw')"));
+expect("Draw rail is clickable", await click(".tl-camera-editor .tl-rail-draw"));
+expect("the studio arms rail drawing", await waitFor(`document.querySelector('.app').dataset.railDraw === "1"`));
+const inset = await centreOf(".vp-inset");
+expect("the Top-View inset is on screen", !!inset, JSON.stringify(inset));
+const railY = inset.top + inset.height * 0.55;
+const railFrom = inset.left + inset.width * 0.2;
+const railTo = inset.left + inset.width * 0.8;
+await mouse("mousePressed", { x: railFrom, y: railY, button: "left", buttons: 1, clickCount: 1 });
+for (let i = 1; i <= 8; i += 1) {
+	await mouse("mouseMoved", { x: railFrom + ((railTo - railFrom) * i) / 8, y: railY - i * 2, button: "left", buttons: 1 });
+}
+await mouse("mouseReleased", { x: railTo, y: railY - 16, button: "left", buttons: 0, clickCount: 1 });
+expect("the stroke completes the Rail step", await waitFor(doneFlag("rail")));
+expect(
+	"the rail is real geometry on the shot",
+	await waitFor(`document.querySelector('.tl-camera-editor .tl-rail-draw')?.textContent.trim() === "Redraw rail"`),
+);
+
+// 7. Play — the look-through button hands the pane to the shot camera.
+expect("Play is the last current step", await waitFor(currentFlag("play")));
+expect("the look-through button is clickable", await click(".vp-look-through"));
+expect("look-through completes the Play step", await waitFor(doneFlag("play")));
+expect("every step reads done", await evaluate(`[...document.querySelectorAll('[data-testid="camera-tutorial-step"]')].every((li) => li.dataset.done === "1")`));
+expect("the overlay reports the Done state", await waitFor(`document.querySelector('[data-testid="camera-tutorial"]').dataset.state === "done"`));
+expect("the card says the run is finished", await evaluate(`/Done/.test(document.querySelector('[data-testid="camera-tutorial-card"]').textContent)`));
+await screenshot("tutorial-done");
+
+// The close button removes the overlay outright.
+expect("the close button is clickable", await click('[data-testid="camera-tutorial-close"]'));
+expect("× removes the tutorial from the DOM", await waitFor('!document.querySelector(\'[data-testid="camera-tutorial"]\')'));
+
+/* ------------------------------------------- the entry points, plainly --- */
+
+await send("Page.navigate", { url: appUrl });
+expect("plain /app/ comes back up", await waitFor("!!document.querySelector('canvas')", 40000));
+expect("plain /app/ carries no tutorial", await evaluate('!document.querySelector(\'[data-testid="camera-tutorial"]\')'));
+expect("the Settings trigger is present", await waitFor('!!document.querySelector(\'[data-testid="settings-menu-trigger"]\')'));
+expect("the Settings menu opens", await click('[data-testid="settings-menu-trigger"]') && await waitFor('!!document.querySelector(\'[data-testid="settings-camera-tutorial"]\')'));
+expect("the item is labelled Camera tutorial", await evaluate(`document.querySelector('[data-testid="settings-camera-tutorial"]').textContent.trim() === "Camera tutorial"`));
+await screenshot("tutorial-settings-menu");
+expect("the Settings item is clickable", await click('[data-testid="settings-camera-tutorial"]'));
+expect("Settings ▾ mounts the tutorial", await waitFor('!!document.querySelector(\'[data-testid="camera-tutorial"]\')'));
+expect("the menu closes behind it", await waitFor('!document.querySelector(\'[data-testid="settings-camera-tutorial"]\')'));
+expect("it opens at step one", await evaluate(`${currentFlag("fly")} && [...document.querySelectorAll('[data-testid="camera-tutorial-step"]')].every((li) => li.dataset.done === "0")`));
+
+ws.close();
+if (failures > 0) { console.error(`${failures} FAILURES`); process.exit(1); }
+console.log("qa-camera-tutorial-browser: all checks passed");
+process.exit(0);

--- a/test/verify-camera-tutorial.mjs
+++ b/test/verify-camera-tutorial.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Source contract for the Studio's camera tutorial (#206). The behaviour is
+// proved against the real studio by test/qa-camera-tutorial-browser.mjs (real
+// CDP input, one step at a time); this suite pins what a refactor can break
+// without any test going red: the step table, the signals it listens to, the
+// single mount site and its guard, and the Settings entry point.
+import { readFileSync } from "node:fs";
+
+const tutorial = readFileSync(new URL("../src/camera-tutorial.jsx", import.meta.url), "utf8");
+const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
+const settings = readFileSync(new URL("../src/settings-menu.jsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
+const manifest = readFileSync(new URL("../tools/run-tests.mjs", import.meta.url), "utf8");
+const landing = readFileSync(new URL("../index.html", import.meta.url), "utf8");
+
+let failures = 0;
+const expect = (name, condition, detail = "") => {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+};
+
+/* ------------------------------------------------------- the step table -- */
+
+const table = tutorial.slice(tutorial.indexOf("export const CAMERA_TUTORIAL_STEPS"), tutorial.indexOf("const NAV_KINDS"));
+expect("the module exports the step table", table.startsWith("export const CAMERA_TUTORIAL_STEPS"));
+const kinds = [...table.matchAll(/\bkind: "([a-z]+)"/g)].map((match) => match[1]);
+expect(
+	"the seven steps are the landing page's, in order",
+	JSON.stringify(kinds) === '["fly","walk","dolly","orbit","shot","rail","play"]',
+	JSON.stringify(kinds),
+);
+expect("every step carries a label and a how()", table.match(/\blabel: /g)?.length === 7 && table.match(/\bhow: /g)?.length === 7);
+expect("every step's copy goes through ko()", table.match(/\bko\(/g)?.length >= 7);
+
+// The walk rule is the landing page's: six keys, each pressed once, and only
+// then is the step done. Both surfaces must agree on the key set.
+expect("the walk keys are w a s d q e", /export const WALK_KEYS = \["w", "a", "s", "d", "q", "e"\]/.test(tutorial));
+expect("the landing page teaches the same six keys", /const WALK_KEYS = \["w", "a", "s", "d", "q", "e"\]/.test(landing));
+expect(
+	"walk only completes once every key has been pressed",
+	tutorial.includes('WALK_KEYS.every((walkKey) => next.has(walkKey))') && tutorial.includes('complete("walk")'),
+);
+
+/* ------------------------------------------------------- the signals ----- */
+
+expect("it listens to the navigation events the controls already emit", tutorial.includes('window.addEventListener("cozyclay:nav", onNav)'));
+expect("it listens to the shot/rail signals the studio already emits", tutorial.includes('window.addEventListener("cozyclay:playground-signal", onSignal)'));
+expect("both listeners are removed on unmount", tutorial.includes('removeEventListener("cozyclay:nav", onNav)') && tutorial.includes('removeEventListener("cozyclay:playground-signal", onSignal)'));
+expect("nav kinds are fly/walk/dolly/orbit", tutorial.includes('const NAV_KINDS = new Set(["fly", "walk", "dolly", "orbit"])'));
+expect("signal kinds are shot/rail", tutorial.includes('const SIGNAL_KINDS = new Set(["shot", "rail"])'));
+expect(
+	"the play step needs the rail first, then the player",
+	/if \(!previewing\) return;[\s\S]*?current\.has\("rail"\)[\s\S]*?add\("play"\)/.test(tutorial),
+);
+expect("the component never drives the studio back", !/dispatchEvent/.test(tutorial));
+
+/* ------------------------------------------------------- the surface ----- */
+
+for (const [name, needle] of [
+	["the root", 'data-testid="camera-tutorial"'],
+	["each step chip", 'data-testid="camera-tutorial-step"'],
+	["the hint card", 'data-testid="camera-tutorial-card"'],
+	["the close button", 'data-testid="camera-tutorial-close"'],
+]) expect(`${name} is addressable`, tutorial.includes(needle), needle);
+expect("chips publish kind/done/current", /data-kind=\{step\.kind\}[\s\S]*?data-done=\{done\.has\(step\.kind\) \? 1 : 0\}[\s\S]*?data-current=\{step === current \? 1 : 0\}/.test(tutorial));
+expect("the walk chips publish their own done state", tutorial.includes("data-done={walked.has(key) ? 1 : 0}"));
+expect("the Done state is readable off the root", tutorial.includes('data-state={complete ? "done" : "active"}'));
+expect("the close button is labelled in both locales", tutorial.includes('ko("Close tutorial", "튜토리얼 닫기")'));
+
+/* --------------------------------------------------------- the wiring ---- */
+
+expect("App imports the component", app.includes('import { CameraTutorial } from "./camera-tutorial.jsx"'));
+expect(
+	"the query string opens it, and never inside an embed",
+	app.includes('const [cameraTutorial, setCameraTutorial] = useState(() => !embedMode && new URLSearchParams(globalThis.location?.search || "").get("tutorial") === "camera")'),
+);
+expect("Settings can open it through a window event", app.includes('window.addEventListener("cozyclay:camera-tutorial", onTutorial)') && app.includes('setCameraTutorial(event.detail?.open !== false)'));
+expect("the listener is removed on unmount", app.includes('removeEventListener("cozyclay:camera-tutorial", onTutorial)'));
+expect("opening it is tracked once, under a declared feature name", app.includes('trackFeature("camera_tutorial")'));
+expect(
+	"the analytics contract knows the name",
+	readFileSync(new URL("../src/analytics.js", import.meta.url), "utf8").includes('"camera_tutorial"'),
+);
+expect("there is exactly one mount site", (app.match(/<CameraTutorial/g) ?? []).length === 1);
+expect(
+	"it is mounted only while the tutorial is on and outside embeds",
+	/\{cameraTutorial && !embedMode && \(\s*<CameraTutorial previewing=\{lookThroughShot\} onClose=\{\(\) => setCameraTutorial\(false\)\} \/>/.test(app),
+);
+expect(
+	"the mount sits inside the viewport pane, above the stage",
+	(() => {
+		const viewport = app.indexOf('<div className="viewport" data-drop=');
+		const mount = app.indexOf("<CameraTutorial");
+		const stage = app.indexOf('<div className="stage" id="stage"');
+		return viewport !== -1 && viewport < mount && mount < stage;
+	})(),
+);
+expect("opening the tutorial changes nothing else", !/setCameraTutorial\((true|value)\)[\s\S]{0,80}set(Preview|LookThroughShot|WorkflowMode)/.test(app));
+
+/* -------------------------------------------------------- Settings ▾ ----- */
+
+expect("Settings grows a Help group", settings.includes('<h4>{ko("Help", "도움말")}</h4>'));
+expect("the item is addressable", settings.includes('data-testid="settings-camera-tutorial"'));
+expect("the item is labelled Camera tutorial", settings.includes('{ko("Camera tutorial", "카메라 튜토리얼")}'));
+expect(
+	"it opens the tutorial through the window event",
+	settings.includes('new CustomEvent("cozyclay:camera-tutorial", { detail: { open: true } })'),
+);
+expect("it closes the menu behind itself", /cozyclay:camera-tutorial[\s\S]{0,120}setOpen\(false\)/.test(settings));
+expect("no topbar button was added (R4)", (settings.match(/topbar-action/g) ?? []).length === 1 && !/topbar-action[^"]*tutorial/i.test(app));
+
+/* ------------------------------------------------------------ styles ----- */
+
+expect("the overlay has its own block", css.includes(".camera-tutorial {"));
+expect("it hangs under the 27px viewport titlebar", /\.camera-tutorial \{[^}]*top: 35px/.test(css));
+expect("the overlay never takes the pointer", /\.camera-tutorial \{[^}]*pointer-events: none/.test(css));
+expect("except on the close button", /\.camera-tutorial-close \{[^}]*pointer-events: auto/.test(css));
+expect("it uses the studio's own tokens", /\.camera-tutorial \{[^}]*var\(--panel\)/.test(css) && /\.camera-tutorial \{[^}]*var\(--line2\)/.test(css));
+
+/* ---------------------------------------------------------- manifest ----- */
+
+expect("the browser suite is registered", manifest.includes('"test/qa-camera-tutorial-browser.mjs"'));
+expect("and it is in the inventory sweep", manifest.slice(manifest.indexOf("const EXTRA_INVENTORY")).includes("test/qa-camera-tutorial-browser.mjs"));
+
+if (failures) {
+	console.error(`${failures} FAILURES`);
+	process.exitCode = 1;
+} else {
+	console.log("all camera tutorial checks PASS");
+}

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -68,6 +68,7 @@ const NODE_FILES = [
 	"test/verify-camera-follow.mjs",
 	"test/verify-camera-move.mjs",
 	"test/verify-camera-rail-schedule.mjs",
+	"test/verify-camera-tutorial.mjs",
 	"test/verify-codex-client.mjs",
 	"test/verify-cuts.mjs",
 	"test/verify-shot-guides.mjs",
@@ -187,6 +188,7 @@ const BROWSER_FILES = [
 	"test/verify-settings-menu-browser.mjs",
 	"test/verify-static-shot-export-browser.mjs",
 	"test/qa-agent-view-toggle-browser.mjs",
+	"test/qa-camera-tutorial-browser.mjs",
 	"test/qa-ia-tail-browser.mjs",
 	"test/qa-keyframe-pack-browser.mjs",
 	"test/qa-preview-browser.mjs",
@@ -199,7 +201,7 @@ const BROWSER_FILES = [
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-agent-view-toggle-browser.mjs", "test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-agent-view-toggle-browser.mjs", "test/qa-camera-tutorial-browser.mjs", "test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
## What

The landing page teaches the camera over the playground iframe (#188). Inside the Studio the same seven steps had no home: a first-time operator opening `/app/` gets a viewport with no hint that the right button flies, that Alt orbits, or that a rail is drawn in the Top-View.

`src/camera-tutorial.jsx` runs those seven steps against the real Studio. It listens to the signals the Studio already emits — `cozyclay:nav` (fly / walk / dolly / orbit) from `src/controls.jsx` and `cozyclay:playground-signal` (shot / rail) from `App.jsx` — and takes `lookThroughShot` as the last step. Nothing drives the Studio back; a step is done only once the operator has actually flown, cut or dollied. `src/controls.jsx`, `index.html` and the landing playground are untouched.

## Why

Discoverability, not a new mode. The overlay is transparent to the pointer except its close button, opening it changes no other state, and it never mounts inside an embed (`?embed=…`). Entry points are `/app/?tutorial=camera` and **Settings ▾ → Help → Camera tutorial**, which dispatches `cozyclay:camera-tutorial`. Settings is a closed popover, so nothing is added to the visible-control budget and no topbar button is created (docs/studio-ui-ia.md R4/R6).

## The seven steps (Studio wording)

| # | kind | completes when | copy |
|---|---|---|---|
| 1 | fly | `cozyclay:nav` fly | Right-drag in the viewport to look around. |
| 2 | walk | all six keys seen | Hold the right button and press each key once: `W` `A` `S` `D` `Q` `E` — W A S D walk, Q E crane. |
| 3 | dolly | `cozyclay:nav` dolly | Scroll in the viewport to push in and pull out. |
| 4 | orbit | `cozyclay:nav` orbit | Hold `Alt` (`⌥ Option` on Mac) and left-drag to circle the character. |
| 5 | shot | `playground-signal` shot | In the timeline's Shots lane click **+ Add shot**. That is your cut. |
| 6 | rail | `playground-signal` rail | Select the shot, click **Draw rail** in the camera bar, and drag a line across the top view. That line is the dolly move. |
| 7 | play | `previewing` after the rail | Click the look-through button in the viewport to see the shot camera; ▶ rides the rail, `Esc` returns to the free camera. |

Walk keeps the landing page's rule: the six key chips mark themselves done and the step only closes once every one has been pressed while the right button is held. Copy is bilingual through `ko()`.

## QA

`node tools/run-tests.mjs` — **PASS 165 Node verification files**, exit 0 (was 164; `test/verify-camera-tutorial.mjs` is new: 45/45 PASS).

`npm run build` — exit 0.

Browser, against `npx vite --host 127.0.0.1 --port 5320`:

```
QA_URL=http://127.0.0.1:5320/app/ CDP_PORT=9320 QA_SHOT_DIR=/tmp/tutorial-qa \
  node tools/qa-browser.mjs -- node test/qa-camera-tutorial-browser.mjs
...
qa-camera-tutorial-browser: all checks passed
```

**44 PASS / 0 FAIL**, exit 0. Every step is driven with real CDP input — a right-button drag for Look, the six keys pressed while the button is held (three keys asserted *not* to finish it), a `mouseWheel` dolly, an Alt+left orbit, a click on the timeline's `+ Add shot`, shot select → `Draw rail` → a stroke across the Top-View inset, and a click on `.vp-look-through` — with `data-done` read back off the strip after each. It also asserts the Done state, that `×` removes the overlay from the DOM, that plain `/app/` has no tutorial element, and that Settings ▾ mounts it.

### Screenshots

Step 1 of 7:

![step 1](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/studio-tutorial/tutorial-step1.png)

Mid-way — four steps done, Shot current:

![mid-way](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/studio-tutorial/tutorial-midway.png)

Done, in the shot camera (the card narrows so the ESC · EXIT pill stays legible):

![done](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/studio-tutorial/tutorial-done.png)

Settings ▾ → Help:

![settings](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/studio-tutorial/tutorial-settings-menu.png)

### Control counts (R6, unchanged)

`QA_URL=http://127.0.0.1:5320/app/ CDP_PORT=9320 OUT=/tmp/tutorial-qa/count node tools/qa-browser.mjs -- node tools/qa/studio-control-count.mjs` on plain `/app/`:

| state | count | budget |
|---|---|---|
| Scene (nothing selected) | **35** | ≤35 |
| Scene (character selected) | **35** | ≤35 |
| Camera | **38** | ≤38 |
| Motion | **51** | ≤52 |

## Files

`src/camera-tutorial.jsx` (new), `src/App.jsx` (state + listener + one guarded mount), `src/settings-menu.jsx` (Help group), `src/styles.css` (one `.camera-tutorial` block), `src/analytics.js` (one feature name), `test/verify-camera-tutorial.mjs` + `test/qa-camera-tutorial-browser.mjs` (new), `tools/run-tests.mjs` (registration).

Closes #206
