### PR TITLE
feat(studio): camera tutorial starts on the city-block scene with the walk take (#209)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -635,11 +635,38 @@ export default function App() {
 	const playgroundExportRef = useRef(null);
 	// The camera tutorial (#206): the landing page's seven steps, run against
 	// the real studio instead of the playground iframe. It opens from
-	// /app/?tutorial=camera or from Settings ▾; opening it changes nothing else
-	// about the session, and it is not offered inside an embed.
-	const [cameraTutorial, setCameraTutorial] = useState(() => !embedMode && new URLSearchParams(globalThis.location?.search || "").get("tutorial") === "camera");
+	// /app/?tutorial=camera or from Settings ▾, and it is not offered inside an
+	// embed.
+	//
+	// Both doors go through startCameraTutorial (#209), which puts the studio in
+	// the state the landing page teaches these steps in — the city-block starter
+	// scene with the walk take on its character — so Shot / Rail / Play always
+	// have something to frame. That function is declared with the project
+	// actions further down; the listeners here reach it through a ref so they
+	// always call the current render's closure (the confirm reads projectDirty).
+	const cameraTutorialQuery = !embedMode && new URLSearchParams(globalThis.location?.search || "").get("tutorial") === "camera";
+	const [cameraTutorial, setCameraTutorial] = useState(false);
+	const startCameraTutorialRef = useRef(null);
+	const cameraTutorialStarted = useRef(false);
+	// The starter scene the tutorial opened for itself: replacing it again is not
+	// work anyone can lose, so the confirm below stays out of the way.
+	const tutorialStarterRef = useRef(false);
+	// Armed once the starter is applied, consumed by the seed effect next to the
+	// hosted-demo seed as soon as the new character's rig exists.
+	const [tutorialSeedPending, setTutorialSeedPending] = useState(false);
 	useEffect(() => {
-		const onTutorial = (event) => setCameraTutorial(event.detail?.open !== false);
+		if (!cameraTutorialQuery || cameraTutorialStarted.current) return;
+		cameraTutorialStarted.current = true;
+		void startCameraTutorialRef.current?.({ source: "query" });
+	}, [cameraTutorialQuery]);
+	useEffect(() => {
+		const onTutorial = (event) => {
+			if (event.detail?.open === false) {
+				setCameraTutorial(false);
+				return;
+			}
+			void startCameraTutorialRef.current?.({ source: event.detail?.source ?? "settings" });
+		};
 		window.addEventListener("cozyclay:camera-tutorial", onTutorial);
 		return () => window.removeEventListener("cozyclay:camera-tutorial", onTutorial);
 	}, []);
@@ -3066,7 +3093,9 @@ export default function App() {
 	// A first-run author should choose a document (or explicitly start a named
 	// local draft). Keep this as a light startup sheet so the studio remains
 	// inspectable while the choice is pending; it never traps the topbar.
-	const [projectStartupOpen, setProjectStartupOpen] = useState(() => !playgroundMode && !playgroundSceneUrl(globalThis.location?.search) && !loadProjectSession()?.name);
+	// ?tutorial=camera opens the starter scene itself (#209), so the chooser is
+	// suppressed the same way a ?scene= launch suppresses it.
+	const [projectStartupOpen, setProjectStartupOpen] = useState(() => !playgroundMode && !cameraTutorialQuery && !playgroundSceneUrl(globalThis.location?.search) && !loadProjectSession()?.name);
 
 	// Dismissal mirrors the inspector-actions menu: only listen while open,
 	// ignore presses inside the wrap (the trigger's own click keeps toggling),
@@ -3289,6 +3318,9 @@ export default function App() {
 		setProjectName(project.name);
 		storeProjectSession(project.name);
 		setProjectStartupOpen(false);
+		// Whatever document this is, it is no longer the scene the tutorial opened
+		// for itself; startCameraTutorial re-arms the flag after its own open.
+		tutorialStarterRef.current = false;
 		track("project:opened", { age_bucket: bucketProjectAge(Date.now() - (project.savedAt ?? Date.now())) });
 	}
 
@@ -3307,6 +3339,44 @@ export default function App() {
 		track("scene:loaded", { scene_source: source });
 		return true;
 	}
+	/** The camera tutorial's single entry (#209), for both /app/?tutorial=camera
+	 * and the Settings ▾ item.
+	 *
+	 * The seven steps teach Shot / Rail / Play, which need a set and somebody
+	 * moving through it. On cozyclay.org they get both for free: the landing
+	 * playground opens the city-block starter and the hosted-demo seed below
+	 * loads the walk take because a statically served build has no motion
+	 * bridge. A local session HAS a bridge, so that seed is skipped and the
+	 * tutorial used to open on whatever was loaded — usually an empty room.
+	 * This puts the studio in the landing page's state explicitly. */
+	async function startCameraTutorial({ source = "settings" } = {}) {
+		// QA hook, same spirit as window.__cozyclayRenders: which door the tutorial
+		// came in by, so a headless run can prove both of them land here.
+		window.__cozyclayTutorialSource = source;
+		// Replacing the scene is the destructive part, so it asks the way New
+		// Project asks — unless the scene on screen is the starter this function
+		// opened, where there is nothing of the author's to lose.
+		if (projectDirty && !tutorialStarterRef.current && !window.confirm(ko(
+			"The camera tutorial opens the City Block starter scene and replaces the current scene. Continue?",
+			"카메라 튜토리얼은 City Block 시작 장면을 열고 현재 장면을 대체합니다. 계속할까요?",
+		))) return;
+		// A build without the starter file toasts "not in this build" from
+		// openStarterScene; the tutorial then runs on the scene already open,
+		// which still teaches the gestures.
+		const opened = await openStarterScene("city-block", "tutorial");
+		if (opened) {
+			tutorialStarterRef.current = true;
+			setTutorialSeedPending(true);
+		}
+		setProjectStartupOpen(false);
+		setCameraTutorial(true);
+		// Frame 0 of a free camera: the first step is looking around, and the
+		// shot camera does not exist yet.
+		exitPreview();
+		setTlFrame(0);
+	}
+	startCameraTutorialRef.current = startCameraTutorial;
+
 	const starterOpened = useRef(false);
 	useEffect(() => {
 		if (starterOpened.current || playgroundMode) return;
@@ -5895,6 +5965,22 @@ export default function App() {
 			/* the seed is a nicety, never a failure the visitor must act on */
 		});
 	}, [bridge, activeRig, motion, motionBusy]);
+
+	// The camera tutorial's seed (#209). The hosted-demo seed above is gated on
+	// a missing bridge, which is why the tutorial used to open on an empty room
+	// in a local session. startCameraTutorial arms tutorialSeedPending once the
+	// starter scene is applied, and the same clip goes on regardless of bridge
+	// state as soon as that scene's character has a parsed rig — a state
+	// condition, not a timer, exactly like the seed above.
+	useEffect(() => {
+		if (!tutorialSeedPending || !activeRig || motionBusy) return;
+		setTutorialSeedPending(false);
+		demoSeeded.current = true; // one seeded clip per session, whichever got here first
+		loadMotion(DEMO_MOTION_URL, DEMO_MOTION_PROMPT).catch(() => {
+			/* the take is the tutorial's set dressing, never an error to act on */
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [tutorialSeedPending, activeRig, motionBusy]);
 
 	/** Drop the ACTIVE character's take, its IK corrections and the stature the
 	 * take imposed. One Ctrl+Z entry brings all three back; nothing to clear

--- a/test/qa-camera-tutorial-browser.mjs
+++ b/test/qa-camera-tutorial-browser.mjs
@@ -11,6 +11,10 @@
 // the Top-View, and the look-through button — and reads each step's data-done
 // back off the strip. Nothing here pokes React state: if a real gesture stops
 // announcing itself, this suite goes red. Screenshots land in QA_SHOT_DIR.
+//
+// It also proves the seeded set (#209): both entries must land on the
+// city-block starter with the shipped walk take on its character, and the
+// Settings entry must ask before replacing a scene with unsaved changes.
 // Evidence script; not part of the Node manifest.
 import { mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -89,6 +93,18 @@ const key = async (code, keyName, virtualKeyCode) => {
 	await send("Input.dispatchKeyEvent", { type: "keyDown", text: keyName, ...common });
 	await send("Input.dispatchKeyEvent", { type: "keyUp", ...common });
 };
+/** The shipped walk take's length on the production clock (24 fps): the
+ * transport counts 0 … 431 and the hierarchy says "432 frames". */
+const WALK_FRAMES = 432;
+const projectLabel = `document.querySelector('.hierarchy-project strong')?.textContent.trim()`;
+const propCount = `Number(document.querySelector('[data-node-id="props"] .hierarchy-badge')?.textContent ?? -1)`;
+/** window.confirm is a page-level dialog CDP would have to answer out of band;
+ * override it in the page instead, record every question, and answer `true`. */
+const armConfirm = (answer = true) => evaluate(`(() => {
+	window.__qaConfirms = [];
+	window.confirm = (message) => { window.__qaConfirms.push(String(message)); return ${answer ? "true" : "false"}; };
+	return true;
+})()`);
 const step = (kind) => `document.querySelector('[data-testid="camera-tutorial-step"][data-kind="${kind}"]')`;
 const doneFlag = (kind) => `${step(kind)}?.dataset.done === "1"`;
 const currentFlag = (kind) => `${step(kind)}?.dataset.current === "1"`;
@@ -106,6 +122,44 @@ expect("the studio comes up on ?tutorial=camera", await waitFor("!!document.quer
 expect("the editor camera is live", await waitFor("!!window.__cozyclay?.editorCam", 30000));
 expect("the tutorial mounts from the query", await waitFor('!!document.querySelector(\'[data-testid="camera-tutorial"]\')', 15000));
 
+/* ----------------------------------------- the set the steps run on (#209) */
+
+// The seven steps teach Shot / Rail / Play, so the tutorial has to open on a
+// set with somebody moving through it: the city-block starter plus the walk
+// take, whatever the local motion bridge is doing.
+const starterProps = await evaluate(`(async () => {
+	const project = await (await fetch('/scenes/city-block.cclayproject')).json();
+	return project.scenes.scenes[0].objects.length;
+})()`);
+expect("the starter scene ships with props to frame", starterProps > 0, String(starterProps));
+expect("the query entry went through startCameraTutorial", await waitFor(`window.__cozyclayTutorialSource === "query"`));
+expect("the tutorial opened the City Block project", await waitFor(`${projectLabel} === "City Block"`), await evaluate(projectLabel));
+expect(
+	"the hierarchy holds the starter's props",
+	await waitFor(`${propCount} === ${starterProps}`),
+	String(await evaluate(propCount)),
+);
+expect("the startup project chooser never appeared", await evaluate(`!document.querySelector('.project-startup')`));
+expect("a take is loaded on the character", await waitFor("!!window.__cozyclay?.motion", 40000));
+expect(
+	`the take is the ${WALK_FRAMES}-frame walk clip`,
+	await waitFor(`window.__cozyclay?.frameCount === ${WALK_FRAMES}`),
+	String(await evaluate("window.__cozyclay?.frameCount")),
+);
+expect(
+	"the hierarchy reports the clip length instead of Blocking",
+	await waitFor(`document.querySelector('.hierarchy-frame-status')?.textContent.trim() === "${WALK_FRAMES} frames"`),
+	await evaluate(`document.querySelector('.hierarchy-frame-status')?.textContent`),
+);
+expect("the Full-Body lane shows the clip", await waitFor("document.querySelectorAll('.tl-motion-clip').length === 1"));
+expect(
+	"the transport counts the whole take from frame 0",
+	await waitFor(`/^\\u2039\\u25b6\\u203a?0 \\/ ${WALK_FRAMES - 1} /.test(document.querySelector('.tl-transport')?.textContent ?? "")`),
+	await evaluate(`document.querySelector('.tl-transport')?.textContent`),
+);
+expect("the playhead sits on frame 0", await evaluate("window.__cozyclay?.tlFrame === 0"));
+expect("the pane is on the free camera, not the shot camera", await evaluate("window.__cozyclay?.lookThroughShot === false"));
+
 expect(
 	"the strip shows the seven steps in order",
 	await evaluate(`JSON.stringify([...document.querySelectorAll('[data-testid="camera-tutorial-step"]')].map((li) => li.dataset.kind)) === '["fly","walk","dolly","orbit","shot","rail","play"]'`),
@@ -114,6 +168,7 @@ expect("nothing starts done", await evaluate(`[...document.querySelectorAll('[da
 expect("the first step is the current one", await evaluate(`${currentFlag("fly")} && ${step("walk")}.dataset.current === "0"`));
 expect("the card carries the first instruction", await evaluate(`/Right-drag/.test(document.querySelector('[data-testid="camera-tutorial-card"]').textContent)`));
 await screenshot("tutorial-step1");
+await screenshot("tutorial-city-block-step1");
 
 /* ------------------------------------------------------- the gestures --- */
 
@@ -156,6 +211,7 @@ expect("the Shots lane offers + Add shot", await waitFor(`!!document.querySelect
 expect("+ Add shot is clickable", await click(".tl-track-add.cut"));
 expect("adding a shot completes the Shot step", await waitFor(doneFlag("shot")));
 expect("the shot block appears in the lane", await waitFor("!!document.querySelector('.tl-shot-block')"));
+await screenshot("tutorial-city-block-shot");
 
 // 6. Rail — select the shot, arm Draw rail, then stroke across the Top-View.
 expect("the shot block can be selected", await click(".tl-shot-block"));
@@ -191,19 +247,67 @@ await screenshot("tutorial-done");
 expect("the close button is clickable", await click('[data-testid="camera-tutorial-close"]'));
 expect("× removes the tutorial from the DOM", await waitFor('!document.querySelector(\'[data-testid="camera-tutorial"]\')'));
 
-/* ------------------------------------------- the entry points, plainly --- */
+/* ------------------------------- Settings ▾ on a scene of one's own (#209) */
 
+// Second scenario: a plain session on its own scene, modified by hand. The
+// Settings entry must ask before it replaces that scene, and then land on the
+// same seeded set the query entry lands on.
+await evaluate(`(() => {
+	localStorage.clear();
+	localStorage.setItem('cozyclay.locale', 'en');
+	localStorage.setItem('cozyclay.project-session.v1', JSON.stringify({ name: 'QA Scene', updatedAt: Date.now() }));
+	return true;
+})()`);
 await send("Page.navigate", { url: appUrl });
 expect("plain /app/ comes back up", await waitFor("!!document.querySelector('canvas')", 40000));
 expect("plain /app/ carries no tutorial", await evaluate('!document.querySelector(\'[data-testid="camera-tutorial"]\')'));
+expect("it comes up on its own project, not the starter", await waitFor(`${projectLabel} === "QA Scene"`), await evaluate(projectLabel));
+expect("and with no take loaded", await evaluate("!window.__cozyclay?.motion"));
+
+// Modify the scene by hand: the hierarchy's "+ Add object" menu, one prop.
+const propsBefore = Math.max(await evaluate(propCount), 0);
+expect("the hierarchy offers + Add object", await waitFor("!!document.querySelector('.add-object-trigger')"));
+expect("the add-object menu opens", await click(".add-object-trigger") && await waitFor("!!document.querySelector('.add-object-item')"));
+expect("an object can be added", await click(".add-object-item"));
+expect(
+	"the object lands in the scene",
+	await waitFor(`${propCount} === ${propsBefore + 1}`),
+	String(await evaluate(propCount)),
+);
+expect("the project reads as unsaved", await waitFor("!!document.querySelector('.hierarchy-project .project-dirty-dot')"));
+
+// Open the tutorial from Settings ▾ with the confirm answered in the page.
+expect("window.confirm is armed for this scenario", await armConfirm(true));
 expect("the Settings trigger is present", await waitFor('!!document.querySelector(\'[data-testid="settings-menu-trigger"]\')'));
 expect("the Settings menu opens", await click('[data-testid="settings-menu-trigger"]') && await waitFor('!!document.querySelector(\'[data-testid="settings-camera-tutorial"]\')'));
 expect("the item is labelled Camera tutorial", await evaluate(`document.querySelector('[data-testid="settings-camera-tutorial"]').textContent.trim() === "Camera tutorial"`));
 await screenshot("tutorial-settings-menu");
 expect("the Settings item is clickable", await click('[data-testid="settings-camera-tutorial"]'));
+expect("replacing the modified scene is confirmed first", await waitFor("(window.__qaConfirms ?? []).length === 1"), JSON.stringify(await evaluate("window.__qaConfirms ?? null")));
+expect(
+	"the question names the starter scene it is about to open",
+	await evaluate(`/City Block starter scene and replaces the current scene/.test(window.__qaConfirms[0])`),
+	JSON.stringify(await evaluate("window.__qaConfirms?.[0] ?? null")),
+);
+expect("the Settings entry went through startCameraTutorial", await evaluate(`window.__cozyclayTutorialSource === "settings"`));
 expect("Settings ▾ mounts the tutorial", await waitFor('!!document.querySelector(\'[data-testid="camera-tutorial"]\')'));
 expect("the menu closes behind it", await waitFor('!document.querySelector(\'[data-testid="settings-camera-tutorial"]\')'));
 expect("it opens at step one", await evaluate(`${currentFlag("fly")} && [...document.querySelectorAll('[data-testid="camera-tutorial-step"]')].every((li) => li.dataset.done === "0")`));
+expect("the scene switched to City Block", await waitFor(`${projectLabel} === "City Block"`), await evaluate(projectLabel));
+expect(
+	"the hand-added object is gone, the starter's props are in",
+	await waitFor(`${propCount} === ${starterProps}`),
+	String(await evaluate(propCount)),
+);
+expect("the walk take is loaded here too", await waitFor("!!window.__cozyclay?.motion", 40000));
+expect(
+	`the same ${WALK_FRAMES}-frame clip is on the Full-Body lane`,
+	await waitFor(`window.__cozyclay?.frameCount === ${WALK_FRAMES} && document.querySelectorAll('.tl-motion-clip').length === 1`),
+	String(await evaluate("window.__cozyclay?.frameCount")),
+);
+expect("the playhead sits on frame 0", await evaluate("window.__cozyclay?.tlFrame === 0"));
+expect("the pane is on the free camera", await evaluate("window.__cozyclay?.lookThroughShot === false"));
+await screenshot("tutorial-settings-city-block");
 
 ws.close();
 if (failures > 0) { console.error(`${failures} FAILURES`); process.exit(1); }

--- a/test/verify-camera-tutorial.mjs
+++ b/test/verify-camera-tutorial.mjs
@@ -71,10 +71,11 @@ expect("the close button is labelled in both locales", tutorial.includes('ko("Cl
 
 expect("App imports the component", app.includes('import { CameraTutorial } from "./camera-tutorial.jsx"'));
 expect(
-	"the query string opens it, and never inside an embed",
-	app.includes('const [cameraTutorial, setCameraTutorial] = useState(() => !embedMode && new URLSearchParams(globalThis.location?.search || "").get("tutorial") === "camera")'),
+	"the query string requests it, and never inside an embed",
+	app.includes('const cameraTutorialQuery = !embedMode && new URLSearchParams(globalThis.location?.search || "").get("tutorial") === "camera"'),
 );
-expect("Settings can open it through a window event", app.includes('window.addEventListener("cozyclay:camera-tutorial", onTutorial)') && app.includes('setCameraTutorial(event.detail?.open !== false)'));
+expect("Settings can open it through a window event", app.includes('window.addEventListener("cozyclay:camera-tutorial", onTutorial)'));
+expect("the same event still closes it", /event\.detail\?\.open === false\)? \{\s*setCameraTutorial\(false\)/.test(app));
 expect("the listener is removed on unmount", app.includes('removeEventListener("cozyclay:camera-tutorial", onTutorial)'));
 expect("opening it is tracked once, under a declared feature name", app.includes('trackFeature("camera_tutorial")'));
 expect(
@@ -95,7 +96,76 @@ expect(
 		return viewport !== -1 && viewport < mount && mount < stage;
 	})(),
 );
-expect("opening the tutorial changes nothing else", !/setCameraTutorial\((true|value)\)[\s\S]{0,80}set(Preview|LookThroughShot|WorkflowMode)/.test(app));
+/* ------------------------------------------- the seeded set (#209) ------ */
+
+// The seven steps need a set and somebody walking through it. Both entries go
+// through one function that opens the city-block starter and puts the shipped
+// walk take on its character — the state the landing playground gets for free
+// because a statically served build has no motion bridge.
+const start = app.slice(app.indexOf("async function startCameraTutorial"), app.indexOf("startCameraTutorialRef.current = startCameraTutorial;"));
+expect("there is a single startCameraTutorial", (app.match(/async function startCameraTutorial/g) ?? []).length === 1 && start.length > 0);
+expect("it takes the entry it was called from", /async function startCameraTutorial\(\{ source = "settings" \} = \{\} \)?/.test(start) || start.includes('async function startCameraTutorial({ source = "settings" } = {})'));
+expect(
+	"the query entry routes through it",
+	/if \(!cameraTutorialQuery \|\| cameraTutorialStarted\.current\) return;[\s\S]{0,160}startCameraTutorialRef\.current\?\.\(\{ source: "query" \}\)/.test(app),
+);
+expect(
+	"the window-event entry routes through it",
+	/startCameraTutorialRef\.current\?\.\(\{ source: event\.detail\?\.source \?\? "settings" \}\)/.test(app),
+);
+expect(
+	"nothing else opens the tutorial behind its back",
+	(app.match(/setCameraTutorial\(true\)/g) ?? []).length === 1 && start.includes("setCameraTutorial(true)"),
+);
+expect("the entry is reachable from the listeners through a ref", app.includes("startCameraTutorialRef.current = startCameraTutorial;"));
+expect("it opens the city-block starter", start.includes('await openStarterScene("city-block", "tutorial")'));
+expect(
+	"a scene it could not fetch still opens the tutorial (openStarterScene toasts)",
+	/const opened = await openStarterScene\("city-block", "tutorial"\);[\s\S]*?setCameraTutorial\(true\)/.test(start)
+		&& app.includes('setToast(ko("That starter scene is not in this build", "이 빌드에는 그 시작 장면이 없어요"))'),
+);
+expect(
+	"unsaved changes are confirmed first, in both locales",
+	start.includes("projectDirty && !tutorialStarterRef.current && !window.confirm(ko(")
+		&& start.includes('"The camera tutorial opens the City Block starter scene and replaces the current scene. Continue?"')
+		&& start.includes('"카메라 튜토리얼은 City Block 시작 장면을 열고 현재 장면을 대체합니다. 계속할까요?"'),
+);
+expect("cancelling does nothing at all", /window\.confirm\(ko\([\s\S]*?\)\)\) return;/.test(start));
+expect("the tutorial's own starter is not re-confirmed", app.includes("tutorialStarterRef.current = true;") && /tutorialStarterRef\.current = false;/.test(app));
+expect("it opens on frame 0 with the free camera", start.includes("exitPreview()") && start.includes("setTlFrame(0)"));
+expect("it leaves the project chooser closed", start.includes("setProjectStartupOpen(false)"));
+expect(
+	"the query entry also suppresses the startup chooser",
+	app.includes("useState(() => !playgroundMode && !cameraTutorialQuery && !playgroundSceneUrl(globalThis.location?.search) && !loadProjectSession()?.name)"),
+);
+expect("the seed is armed by state, so an effect can wait on the rig", start.includes("setTutorialSeedPending(true)"));
+
+const seed = app.slice(app.indexOf("// The camera tutorial's seed (#209)"), app.indexOf("}, [tutorialSeedPending, activeRig, motionBusy]);"));
+expect("the seed effect exists", seed.length > 0);
+expect(
+	"it waits on the new character's rig, never on a timer",
+	seed.includes("if (!tutorialSeedPending || !activeRig || motionBusy) return;") && !/setTimeout|requestAnimationFrame/.test(seed),
+);
+expect("it loads the shipped walk take", seed.includes("loadMotion(DEMO_MOTION_URL, DEMO_MOTION_PROMPT)"));
+expect("it fires regardless of bridge state", !/if \([^)]*bridge/.test(seed));
+expect("it consumes the flag once", seed.includes("setTutorialSeedPending(false)") && seed.includes("demoSeeded.current = true"));
+expect(
+	"the hosted-demo seed keeps its own bridge rule",
+	/if \(!bridge \|\| bridge\.ok\) return;\s*demoSeeded\.current = true;/.test(app),
+);
+expect("the take the tutorial seeds is the landing page's", app.includes("DEMO_MOTION_URL,") && app.includes("DEMO_MOTION_PROMPT,"));
+expect(
+	"the walk clip still ships with the build",
+	readFileSync(new URL("../src/app-stage.jsx", import.meta.url), "utf8").includes('export const DEMO_MOTION_URL = "/demo/walk-then-stop.npz"'),
+);
+expect(
+	"the starter it opens is a real bundled scene named City Block",
+	(() => {
+		const project = JSON.parse(readFileSync(new URL("../public/scenes/city-block.cclayproject", import.meta.url), "utf8"));
+		return project.name === "City Block" && (project.scenes?.scenes?.[0]?.objects?.length ?? 0) > 0;
+	})(),
+);
+expect("opening it still changes no mode beyond the camera and the playhead", !/setCameraTutorial\(true\)[\s\S]{0,200}set(WorkflowMode|IkMode|Posing)/.test(app));
 
 /* -------------------------------------------------------- Settings ▾ ----- */
 


### PR DESCRIPTION
## What

Both camera-tutorial entries — `/app/?tutorial=camera` and Settings ▾ → Camera tutorial — now open the studio on the **City Block starter scene with the shipped walk take loaded**, playhead at 0, free camera. One function does it for both doors: `startCameraTutorial({ source })` in `src/App.jsx`.

## Why

The seven steps teach Shot / Rail / Play, which need a set and somebody moving through it. On cozyclay.org the tutorial gets both for free:

- the landing playground opens `/app/?embed=playground&scene=/scenes/city-block.cclayproject`, and
- the shipped demo seed loads `/demo/walk-then-stop.npz` **only when `bridge && !bridge.ok`** — a statically served build has no motion bridge, so the clip seeds itself.

A local `npm run dev` session HAS a bridge, so that seed was skipped and the tutorial opened on whatever was loaded — usually an empty room, where Shot / Rail / Play have nothing to frame. This PR puts the studio in the landing page's state explicitly instead of relying on a missing bridge.

## How

- `startCameraTutorial({ source })`: confirm (if needed) → `await openStarterScene("city-block", "tutorial")` → arm `tutorialSeedPending` → open the overlay, `exitPreview()` (free camera), frame 0.
- The take is seeded by an effect next to the hosted-demo seed, keyed on `activeRig` / `motionBusy`: the clip goes on as soon as the *new* scene's character has a parsed rig — a state condition, never a timer — and regardless of bridge state. The hosted-demo seed keeps its own bridge rule for non-tutorial sessions.
- `?tutorial=camera` also suppresses the first-run project chooser, the way `playgroundSceneUrl(...)` already suppresses it, and it no longer double-triggers the `?scene=` startup effect.
- If the starter file is missing from the build, `openStarterScene` toasts the existing "That starter scene is not in this build" and the tutorial still opens on the current scene.

### The confirm rule

If the current project has unsaved changes and the scene on screen is **not** the starter the tutorial opened for itself, it asks first, with the repo's `window.confirm` pattern (same as New Project):

> The camera tutorial opens the City Block starter scene and replaces the current scene. Continue?
> (카메라 튜토리얼은 City Block 시작 장면을 열고 현재 장면을 대체합니다. 계속할까요?)

Cancel does nothing at all — no scene swap, no overlay. Re-opening the tutorial on the starter it just opened does not nag: seeding the take marks the project dirty, and that is not the author's work.

## QA

Node suites (`node tools/run-tests.mjs`):

```
PASS 165 Node verification files
```

`test/verify-camera-tutorial.mjs` grew the #209 source contract (both entries route through the single `startCameraTutorial`, it opens `city-block`, the seed effect loads `DEMO_MOTION_URL`/`DEMO_MOTION_PROMPT` with no bridge condition, the confirm strings, the chooser guard) — 70 checks, all PASS.

Browser QA, real CDP input against the dev server:

```
QA_URL=http://127.0.0.1:5350/app/ CDP_PORT=9350 QA_SHOT_DIR=/tmp/tutorial-seed-qa \
  node tools/qa-browser.mjs -- node test/qa-camera-tutorial-browser.mjs
...
qa-camera-tutorial-browser: all checks passed
```

**73 PASS / 0 FAIL.** Scenario 1 (`/app/?tutorial=camera`) asserts, before driving a single gesture: project reads `City Block`, the hierarchy holds all 34 starter props (count read from `public/scenes/city-block.cclayproject`, not hard-coded), `hierarchy-frame-status` says `432 frames`, one `.tl-motion-clip` on the Full-Body lane, the transport reads `0 / 431`, playhead 0, free camera, no startup chooser — then runs the seven steps with real right-drag / WASDQE / wheel / Alt-drag / + Add shot / Draw rail / look-through. Scenario 2 starts on a plain `/app/` session with its own scene, adds an object through the hierarchy's **+ Add object**, checks the project reads unsaved, then opens Settings ▾ → Camera tutorial with `window.confirm` overridden in the page to record and answer: the question is asked exactly once, the scene switches to City Block, the hand-added object is gone, the 432-frame take is loaded. Every wait is a state condition; there are no sleeps.

### Screenshots

Step 1 on the City Block set, walk take loaded (`432 frames` on the Full-Body lane):

![tutorial step 1 on City Block](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-seed/tutorial-city-block-step1.png)

After the Shot step — `Shot 1` block in the Shots lane, five chips done:

![tutorial after the Shot step](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-seed/tutorial-city-block-shot.png)

### Control-count audit (unchanged)

```
QA_URL=http://127.0.0.1:5350/app/ CDP_PORT=9351 OUT=/tmp/tutorial-seed-count \
  node tools/qa-browser.mjs -- node tools/qa/studio-control-count.mjs

scene-none 35
scene-char 35
camera     38
motion     51
```

`npm run build` exits 0.

## Scope

`src/App.jsx` (the single entry, the two callers, the seed effect, the chooser guard) plus the two test files. No change to `index.html` / the landing playground, `src/playground.js`, the demo seed's existing bridge rule for non-tutorial sessions, the topbar or menu structure, the starter scene content, or `src/camera-tutorial.jsx` / `src/settings-menu.jsx` (the existing event payload was enough; `source` defaults to `settings`).

Closes #209
