### PR TITLE
feat(studio): camera tutorial spotlights the control each step needs (#211)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -646,6 +646,9 @@ export default function App() {
 	// always call the current render's closure (the confirm reads projectDirty).
 	const cameraTutorialQuery = !embedMode && new URLSearchParams(globalThis.location?.search || "").get("tutorial") === "camera";
 	const [cameraTutorial, setCameraTutorial] = useState(false);
+	// The step the tutorial is on, published on the .app root so styles.css can
+	// spotlight the one control that step needs (#211).
+	const [cameraTutorialStep, setCameraTutorialStep] = useState(null);
 	const startCameraTutorialRef = useRef(null);
 	const cameraTutorialStarted = useRef(false);
 	// The starter scene the tutorial opened for itself: replacing it again is not
@@ -10289,7 +10292,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					: ko("Saved", "저장됨");
 
 	return (
-		<div className={"app" + (renderActive ? "" : " render-idle")} data-workflow-mode={workflowMode} data-embed-mode={embedMode ? "playview" : playgroundMode ? "playground" : undefined} data-playground-hint={playgroundMode ? playgroundHint ?? undefined : undefined} data-rail-draw={railDraw ? 1 : undefined}>
+		<div className={"app" + (renderActive ? "" : " render-idle")} data-workflow-mode={workflowMode} data-embed-mode={embedMode ? "playview" : playgroundMode ? "playground" : undefined} data-playground-hint={playgroundMode ? playgroundHint ?? undefined : undefined} data-tutorial-step={cameraTutorial ? cameraTutorialStep ?? undefined : undefined} data-rail-draw={railDraw ? 1 : undefined}>
 			<header className="topbar">
 				<div className="logo">
 					<span className="wordmark">
@@ -10771,7 +10774,7 @@ function resizePromptClip(id, edge, rawFrame) {
 					    stage it is teaching. The overlay itself never takes the pointer
 					    (styles.css) — every step is completed in the studio underneath. */}
 					{cameraTutorial && !embedMode && (
-						<CameraTutorial previewing={lookThroughShot} onClose={() => setCameraTutorial(false)} />
+						<CameraTutorial previewing={lookThroughShot} onStepChange={setCameraTutorialStep} onClose={() => setCameraTutorial(false)} />
 					)}
 					<div className="stage" id="stage" ref={stageRef} data-render-loop={renderActive ? "always" : "demand"}>
 						{/* Shadows were off, so every castShadow in props.jsx was inert and

--- a/src/camera-tutorial.jsx
+++ b/src/camera-tutorial.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { ko } from "./locale.js";
 
 // The camera tutorial, Studio-native (#206).
@@ -66,6 +67,9 @@ export const CAMERA_TUTORIAL_STEPS = [
 	{
 		kind: "shot",
 		label: ko("Shot", "샷"),
+		// The control lives in another region than the card, so the card says
+		// which way to look before it says what to do.
+		where: ko("↓ Timeline, Shots lane", "↓ 타임라인 샷 레인"),
 		how: () => ko(
 			<>In the timeline's Shots lane click <b>+ Add shot</b>. That is your cut.</>,
 			<>타임라인의 샷 레인에서 <b>+ 샷 추가</b>를 누르세요. 그게 컷입니다.</>,
@@ -74,6 +78,7 @@ export const CAMERA_TUTORIAL_STEPS = [
 	{
 		kind: "rail",
 		label: ko("Rail", "레일"),
+		where: ko("↓ Timeline, Shots lane", "↓ 타임라인 샷 레인"),
 		how: () => ko(
 			<>Select the shot, click <b>Draw rail</b> in the camera bar, and drag a line across the top view. That line is the dolly move.</>,
 			<>샷을 선택하고 카메라 바의 <b>레일 그리기</b>를 누른 뒤, 탑뷰에 선을 그으세요. 그 선이 돌리 이동입니다.</>,
@@ -82,6 +87,7 @@ export const CAMERA_TUTORIAL_STEPS = [
 	{
 		kind: "play",
 		label: ko("Play", "재생"),
+		where: ko("→ Viewport", "→ 뷰포트"),
 		how: () => ko(
 			<>Click the look-through button in the viewport to see the shot camera; <b>▶</b> rides the rail, <kbd>Esc</kbd> returns to the free camera.</>,
 			<>뷰포트의 시점 보기 버튼을 눌러 샷 카메라를 보세요. <b>▶</b>는 레일을 타고, <kbd>Esc</kbd>로 자유 카메라로 돌아옵니다.</>,
@@ -92,15 +98,239 @@ export const CAMERA_TUTORIAL_STEPS = [
 const NAV_KINDS = new Set(["fly", "walk", "dolly", "orbit"]);
 const SIGNAL_KINDS = new Set(["shot", "rail"]);
 
+/* ------------------------------------------------------------- beacons --- */
+
+// Where each of the last three steps actually happens (#211). The card names
+// the gesture; these pin a numbered circle and a caption onto the control
+// itself, so "click + Add shot" stops being a treasure hunt across two panes.
+//
+// `absent`/`requires` gate a beacon on the studio's own state instead of on
+// tutorial bookkeeping: the camera bar (.tl-rail-draw) only exists once a shot
+// is selected, which is exactly the moment the rail step's advice changes.
+export const TUTORIAL_BEACONS = {
+	shot: [
+		{ role: "add-shot", selector: ".tl-track.shots .tl-track-add", label: () => ko("Click here", "여기를 클릭") },
+	],
+	rail: [
+		{
+			role: "select-shot",
+			selector: ".tl-track.shots .tl-shot-block:not(.selected)",
+			absent: ".tl-rail-draw",
+			label: () => ko("1. Select the shot", "1. 샷을 선택"),
+		},
+		{ role: "draw-rail", selector: ".tl-rail-draw", label: () => ko("2. Draw rail, then drag across the top view", "2. 레일 그리기 후 탑뷰에 선 긋기") },
+		{ role: "top-view", selector: ".vp-inset", requires: ".tl-rail-draw", label: () => ko("Drag a line here", "여기에 선을 그으세요") },
+	],
+	play: [
+		{ role: "look-through", selector: ".vp-look-through", label: () => ko("Click to look through the shot camera", "클릭해 샷 카메라로 보기") },
+	],
+};
+
+/** the beacon's own geometry, in px — the circle sits above-left of the target */
+const DOT = 22;
+const LIFT_X = 30;
+const LIFT_Y = 44;
+/** nominal box used only for edge clamping; the chip itself is auto-sized */
+const BEACON_W = 190;
+const BEACON_H = 26;
+
+const reducedMotion = () => globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+
+const boxOf = (element) => {
+	if (!element) return null;
+	const box = element.getBoundingClientRect();
+	if (box.width < 2 || box.height < 2) return null;
+	if (box.right < 0 || box.bottom < 0 || box.left > window.innerWidth || box.top > window.innerHeight) return null;
+	return box;
+};
+
+/** first element matching `selector` that is actually laid out on screen */
+const firstVisible = (selector) => {
+	if (!selector) return null;
+	for (const element of document.querySelectorAll(selector)) {
+		const box = boxOf(element);
+		if (box) return { element, box };
+	}
+	return null;
+};
+
+const round = (value) => Math.round(value * 2) / 2;
+
+/**
+ * Place the beacon above-left of the target and clamp it inside whatever
+ * scrolls the target (the timeline body, or the viewport pane). The leader
+ * line is aimed at the real target, so a shot block scrolled past the lane's
+ * edge still gets an arrow pointing off toward it.
+ *
+ * Above is the default; when the target hugs the top of its own pane — the
+ * camera bar under the transport row, the Top-View inset under the titlebar —
+ * the beacon flips below rather than sitting on the pane's header controls.
+ */
+function place(element, box) {
+	const clip = element.closest(".tl-body, .timeline, .viewport")?.getBoundingClientRect();
+	const edge = Math.min(14, box.height / 2);
+	const above = box.top + edge - LIFT_Y - DOT / 2;
+	const flip = above < (clip ? clip.top : 0) + BEACON_H;
+	const aimX = box.left + Math.min(18, box.width / 2);
+	const aimY = flip ? box.bottom - edge : box.top + edge;
+	const minLeft = Math.max(8, clip ? clip.left + 6 : 8);
+	const maxLeft = Math.max(minLeft, Math.min(window.innerWidth - 8, clip ? clip.right - 6 : window.innerWidth - 8) - BEACON_W);
+	const left = Math.min(Math.max(aimX - LIFT_X - DOT / 2, minLeft), maxLeft);
+	const top = Math.min(Math.max(flip ? aimY + LIFT_Y - DOT / 2 : above, 8), Math.max(8, window.innerHeight - 46));
+	return { left: round(left), top: round(top), aimX: round(aimX - left), aimY: round(aimY - top) };
+}
+
+const samePlace = (a, b) => !!a && !!b && a.left === b.left && a.top === b.top && a.aimX === b.aimX && a.aimY === b.aimY;
+
+/**
+ * One numbered circle plus a caption chip, portalled to <body> and pinned to a
+ * live control. It measures on mount, on resize, on scroll, on a
+ * ResizeObserver of the timeline and viewport, and on any DOM mutation — the
+ * camera bar mounts only after a shot is selected, so "target not there yet"
+ * is the normal case, not an error. Pointer-transparent: the control it points
+ * at must stay clickable through it.
+ */
+export function TutorialBeacon({ kind, step, role, selector, label, requires = null, absent = null }) {
+	const [spot, setSpot] = useState(null);
+
+	useEffect(() => {
+		let frame = 0;
+		const measure = () => {
+			frame = 0;
+			if (absent && firstVisible(absent)) return setSpot(null);
+			if (requires && !firstVisible(requires)) return setSpot(null);
+			const found = firstVisible(selector);
+			if (!found) return setSpot(null);
+			const next = place(found.element, found.box);
+			// Same numbers means no re-render, which keeps the MutationObserver
+			// below from chasing this component's own portal forever.
+			setSpot((prev) => (samePlace(prev, next) ? prev : next));
+		};
+		const schedule = () => {
+			if (!frame) frame = requestAnimationFrame(measure);
+		};
+		measure();
+		window.addEventListener("resize", schedule);
+		window.addEventListener("scroll", schedule, true);
+		const resize = new ResizeObserver(schedule);
+		for (const pane of [document.querySelector(".timeline"), document.querySelector(".viewport")]) {
+			if (pane) resize.observe(pane);
+		}
+		const mutations = new MutationObserver(schedule);
+		mutations.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ["class", "style"] });
+		return () => {
+			if (frame) cancelAnimationFrame(frame);
+			window.removeEventListener("resize", schedule);
+			window.removeEventListener("scroll", schedule, true);
+			resize.disconnect();
+			mutations.disconnect();
+		};
+	}, [selector, requires, absent]);
+
+	if (!spot) return null;
+	return createPortal(
+		<div
+			className="tutorial-beacon"
+			data-testid="camera-tutorial-beacon"
+			data-kind={kind}
+			data-role={role}
+			style={{ left: `${spot.left}px`, top: `${spot.top}px` }}
+		>
+			<svg className="tutorial-beacon-leader" aria-hidden="true">
+				<line x1={DOT / 2} y1={DOT / 2} x2={spot.aimX} y2={spot.aimY} />
+			</svg>
+			<span className="tutorial-beacon-dot" aria-hidden="true">{step}</span>
+			<span className="tutorial-beacon-label">{label()}</span>
+		</div>,
+		document.body,
+	);
+}
+
+/* -------------------------------------------------------- gesture cues --- */
+
+// Steps 1–4 have no control to point at: the gesture IS the interface. The cue
+// draws the mouse and the keys the step wants, animated the way the hand is
+// supposed to move, and sits centre-bottom of the viewport where the eye
+// already is while flying.
+const GESTURE_CAPTIONS = {
+	fly: () => ko("Right-drag to look", "오른쪽 끌어 둘러보기"),
+	walk: () => ko("Hold right, press keys", "오른쪽 누른 채 키 입력"),
+	dolly: () => ko("Scroll to push in", "스크롤로 밀고 당기기"),
+	orbit: () => ko("Alt + left-drag to circle", "Alt+왼쪽 끌어 돌기"),
+};
+
+function MouseGlyph() {
+	return (
+		<svg className="tutorial-cue-mouse" viewBox="0 0 40 58" aria-hidden="true">
+			<rect className="cue-mouse-body" x="4" y="3" width="32" height="52" rx="16" />
+			<path className="cue-mouse-left" d="M20 3 A16 16 0 0 0 4 19 L20 19 Z" />
+			<path className="cue-mouse-right" d="M20 3 A16 16 0 0 1 36 19 L20 19 Z" />
+			<rect className="cue-mouse-wheel" x="17.5" y="8" width="5" height="11" rx="2.5" />
+		</svg>
+	);
+}
+
+/**
+ * The animated gesture glyph for one nav step. `leaving` starts the fade; the
+ * parent unmounts it when the opacity transition ends, so the cue never blinks
+ * out mid-step. Under prefers-reduced-motion the glyph is static (styles.css)
+ * and the parent drops it outright.
+ */
+export function GestureCue({ kind, walked, leaving = false, onLeft }) {
+	const caption = GESTURE_CAPTIONS[kind]?.() ?? "";
+	return (
+		<div
+			className="tutorial-cue"
+			data-testid="camera-tutorial-gesture"
+			data-kind={kind}
+			data-leaving={leaving ? 1 : 0}
+			aria-hidden="true"
+			onTransitionEnd={(event) => {
+				if (leaving && event.propertyName === "opacity" && event.target === event.currentTarget) onLeft?.();
+			}}
+		>
+			<div className="tutorial-cue-stage">
+				{kind === "orbit" && <span className="tutorial-cue-key">Alt</span>}
+				<span className="tutorial-cue-arm">
+					<MouseGlyph />
+					{kind === "fly" && (
+						<svg className="tutorial-cue-arc" viewBox="0 0 64 20" aria-hidden="true">
+							<path className="cue-arc-line" d="M8 14 Q32 3 56 14" />
+							<path className="cue-arc-head" d="M13 9 L7 14 L14 17" />
+							<path className="cue-arc-head" d="M51 9 L57 14 L50 17" />
+						</svg>
+					)}
+				</span>
+				{kind === "orbit" && <span className="tutorial-cue-pivot" />}
+				{kind === "dolly" && (
+					<svg className="tutorial-cue-updown" viewBox="0 0 14 44" aria-hidden="true">
+						<path className="cue-up" d="M7 16 L7 4 M3 8 L7 4 L11 8" />
+						<path className="cue-down" d="M7 28 L7 40 M3 36 L7 40 L11 36" />
+					</svg>
+				)}
+			</div>
+			{kind === "walk" && (
+				<span className="tutorial-cue-keys">
+					{WALK_KEYS.map((walkKey) => (
+						<kbd key={walkKey} data-done={walked?.has(walkKey) ? 1 : 0}>{walkKey.toUpperCase()}</kbd>
+					))}
+				</span>
+			)}
+			<span className="tutorial-cue-caption">{caption}</span>
+		</div>
+	);
+}
+
 /**
  * The overlay itself: a seven-chip strip plus one hint card for the step the
  * operator is on. It sits at the top of the viewport pane, left of the
  * Top-View inset, and never takes the pointer except on its own close button
  * — every step is completed by working the studio underneath it.
  */
-export function CameraTutorial({ previewing = false, onClose }) {
+export function CameraTutorial({ previewing = false, onStepChange, onClose }) {
 	const [done, setDone] = useState(() => new Set());
 	const [walked, setWalked] = useState(() => new Set());
+	const [cue, setCue] = useState(null);
 
 	useEffect(() => {
 		const complete = (kind) => setDone((current) => (current.has(kind) ? current : new Set(current).add(kind)));
@@ -141,8 +371,32 @@ export function CameraTutorial({ previewing = false, onClose }) {
 
 	const current = useMemo(() => CAMERA_TUTORIAL_STEPS.find((step) => !done.has(step.kind)) ?? null, [done]);
 	const complete = current === null;
+	const currentKind = current?.kind ?? null;
+
+	// The step the operator is on is the studio's business too: App puts it on
+	// the .app root as data-tutorial-step, and styles.css spotlights whichever
+	// control that step needs (#211).
+	useEffect(() => {
+		onStepChange?.(currentKind);
+	}, [currentKind, onStepChange]);
+	useEffect(() => () => onStepChange?.(null), [onStepChange]);
+
+	// Steps 1–4 carry a gesture cue instead of a beacon. It fades out when its
+	// step completes rather than vanishing under the hand that just finished it.
+	useEffect(() => {
+		if (currentKind && NAV_KINDS.has(currentKind)) {
+			setCue({ kind: currentKind, leaving: false });
+			return;
+		}
+		setCue((prev) => {
+			if (!prev) return prev;
+			if (reducedMotion()) return null;
+			return prev.leaving ? prev : { ...prev, leaving: true };
+		});
+	}, [currentKind]);
 
 	return (
+	<>
 		<aside
 			className="camera-tutorial"
 			data-testid="camera-tutorial"
@@ -176,7 +430,10 @@ export function CameraTutorial({ previewing = false, onClose }) {
 				) : (
 					<>
 						<span className="camera-tutorial-count">{`${CAMERA_TUTORIAL_STEPS.indexOf(current) + 1} / ${CAMERA_TUTORIAL_STEPS.length}`}</span>
-						<p>{current.how({ walked })}</p>
+						<p>
+							{current.where && <span className="camera-tutorial-where">{current.where}</span>}
+							{current.how({ walked })}
+						</p>
 					</>
 				)}
 			</div>
@@ -191,6 +448,27 @@ export function CameraTutorial({ previewing = false, onClose }) {
 				×
 			</button>
 		</aside>
+		{cue && (
+			<GestureCue
+				kind={cue.kind}
+				walked={walked}
+				leaving={cue.leaving}
+				onLeft={() => setCue((prev) => (prev?.leaving ? null : prev))}
+			/>
+		)}
+		{(TUTORIAL_BEACONS[currentKind] ?? []).map((beacon) => (
+			<TutorialBeacon
+				key={beacon.role}
+				kind={currentKind}
+				step={CAMERA_TUTORIAL_STEPS.indexOf(current) + 1}
+				role={beacon.role}
+				selector={beacon.selector}
+				label={beacon.label}
+				requires={beacon.requires ?? null}
+				absent={beacon.absent ?? null}
+			/>
+		))}
+	</>
 	);
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1165,6 +1165,29 @@ select {
 	50% { box-shadow: 0 0 0 7px rgba(217, 160, 102, 0); }
 }
 
+/* The Studio tutorial's spotlight (#211). Same idea as the landing hints
+   above, one region louder: inside the full studio the operator is scanning
+   two panes and forty controls, so the ring is 3px in the accent with a halo
+   breathing out of it rather than a thin amber outline. data-tutorial-step is
+   the current step's kind, published by CameraTutorial through App. */
+.app[data-tutorial-step="shot"] .tl-track.shots .tl-track-add,
+.app[data-tutorial-step="rail"] .tl-track.shots .tl-shot-block:not(.selected),
+.app[data-tutorial-step="rail"] .tl-rail-draw,
+.app[data-tutorial-step="play"] .vp-look-through {
+	animation: tutorial-spotlight 1.5s var(--ease) infinite;
+	box-shadow: 0 0 0 3px var(--accent);
+}
+/* The rail is drawn INTO the top view, so the inset is the second half of the
+   step's target: a soft accent outline, no pulse — two pulsing things in one
+   step read as an alarm, not an instruction. */
+.app[data-tutorial-step="rail"] .vp-inset {
+	box-shadow: 0 10px 30px #00000073, 0 0 0 2px var(--accent-ring);
+}
+@keyframes tutorial-spotlight {
+	0%, 100% { box-shadow: 0 0 0 3px var(--accent), 0 0 0 0 rgba(58, 124, 191, .45); }
+	50% { box-shadow: 0 0 0 3px var(--accent), 0 0 0 8px rgba(58, 124, 191, 0); }
+}
+
 /* ------------------------------------------------------- dual viewport ---- */
 
 /* Both panes render every frame out of one canvas; these divs only supply the
@@ -10692,4 +10715,351 @@ input[type=range] {
 .camera-tutorial-close:hover,
 .camera-tutorial-close:focus-visible {
 	color: var(--fg);
+}
+
+/* The card's region pointer: the control the step needs is in another pane,
+   so the copy opens with which way to look before it says what to do. */
+.camera-tutorial-where {
+	margin-right: 6px;
+	padding: 1px 5px;
+	border: 1px solid var(--accent-ring);
+	border-radius: 4px;
+	color: var(--accent);
+	font-size: 9.5px;
+	font-weight: 700;
+	letter-spacing: .02em;
+	white-space: nowrap;
+	vertical-align: 1px;
+}
+
+/* ------------------------------------------------- tutorial beacon ------- */
+
+/* A numbered circle, a leader line and a caption chip pinned to the control
+   the current step needs (#211). Portalled to <body>, so it clears every pane
+   in the studio (the highest viewport/timeline layer is 13) and clips to
+   nothing; never takes the pointer, so the control underneath stays
+   clickable. */
+.tutorial-beacon {
+	position: fixed;
+	z-index: 14;
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	pointer-events: none;
+	animation: rise var(--med) var(--ease) backwards;
+}
+
+.tutorial-beacon-leader {
+	position: absolute;
+	inset: 0;
+	overflow: visible;
+	width: 100%;
+	height: 100%;
+}
+
+.tutorial-beacon-leader line {
+	stroke: var(--accent);
+	stroke-width: 1.5;
+	stroke-linecap: round;
+	stroke-dasharray: 3 3;
+	opacity: .85;
+}
+
+.tutorial-beacon-dot {
+	position: relative;
+	flex: none;
+	width: 22px;
+	height: 22px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 50%;
+	background: var(--accent);
+	color: var(--on-accent);
+	font-family: var(--mono);
+	font-size: 11px;
+	font-weight: 700;
+	box-shadow: 0 0 0 3px rgba(58, 124, 191, .28), var(--shadow);
+	animation: tutorial-beacon-breathe 1.5s var(--ease) infinite;
+}
+
+.tutorial-beacon-label {
+	position: relative;
+	max-width: 190px;
+	padding: 3px 8px;
+	border: 1px solid var(--accent-ring);
+	border-radius: 6px;
+	background: color-mix(in srgb, var(--panel) 94%, #000);
+	box-shadow: var(--shadow-md);
+	color: var(--fg);
+	font-size: 10.5px;
+	font-weight: 600;
+	line-height: 1.35;
+	word-break: keep-all;
+}
+
+@keyframes tutorial-beacon-breathe {
+	0%, 100% { box-shadow: 0 0 0 3px rgba(58, 124, 191, .28), var(--shadow); }
+	50% { box-shadow: 0 0 0 8px rgba(58, 124, 191, 0), var(--shadow); }
+}
+
+/* ------------------------------------------------- gesture cue ----------- */
+
+/* Steps 1–4 have no control to point at, so the cue draws the hand instead:
+   a mouse glyph with the button the step wants lit, moving the way the hand
+   is supposed to move. Centre-bottom of the viewport, clear of the shot
+   preview (bottom-right) and the Top-View inset (top-right). */
+.tutorial-cue {
+	position: absolute;
+	left: 50%;
+	bottom: 18px;
+	z-index: 7;
+	width: 120px;
+	transform: translateX(-50%);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 7px;
+	padding: 10px 8px 8px;
+	border: 1px solid var(--line2);
+	border-radius: 10px;
+	background: color-mix(in srgb, var(--panel) 82%, transparent);
+	box-shadow: var(--shadow-md);
+	backdrop-filter: blur(6px);
+	pointer-events: none;
+	opacity: 1;
+	transition: opacity var(--med) var(--ease), transform var(--med) var(--ease);
+	/* `backwards`, not `both`: a filled-forwards animation would pin opacity at
+	   the keyframe's value and the fade-out below would never run. riseCenter
+	   keeps the -50% centring the base rule needs. */
+	animation: riseCenter var(--med) var(--ease) backwards;
+}
+
+.tutorial-cue[data-leaving="1"] {
+	opacity: 0;
+	transform: translateX(-50%) translateY(6px);
+}
+
+.tutorial-cue-stage {
+	position: relative;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+	gap: 6px;
+	/* full width so the orbit keycap and pivot anchor to the panel, not to the
+	   glyph's own shrink-wrapped box */
+	width: 100%;
+	height: 54px;
+}
+
+.tutorial-cue-arm {
+	position: relative;
+	display: inline-flex;
+	align-items: flex-end;
+}
+
+.tutorial-cue-mouse {
+	width: 30px;
+	height: 44px;
+	overflow: visible;
+}
+
+.cue-mouse-body {
+	fill: none;
+	stroke: var(--muted);
+	stroke-width: 2.5;
+}
+
+.cue-mouse-left,
+.cue-mouse-right {
+	fill: var(--card2);
+	stroke: var(--muted);
+	stroke-width: 1.5;
+}
+
+.cue-mouse-wheel {
+	fill: var(--muted2);
+}
+
+/* the lit control per step */
+.tutorial-cue[data-kind="fly"] .cue-mouse-right,
+.tutorial-cue[data-kind="walk"] .cue-mouse-right {
+	fill: var(--accent);
+	stroke: var(--accent);
+}
+
+.tutorial-cue[data-kind="orbit"] .cue-mouse-left {
+	fill: var(--accent);
+	stroke: var(--accent);
+}
+
+.tutorial-cue[data-kind="dolly"] .cue-mouse-wheel {
+	fill: var(--accent);
+}
+
+/* fly: the mouse slides left and right under a two-headed arc */
+.tutorial-cue[data-kind="fly"] .tutorial-cue-arm {
+	animation: cue-swing 2.2s var(--ease) infinite;
+}
+
+.tutorial-cue-arc {
+	position: absolute;
+	left: 50%;
+	top: -13px;
+	width: 56px;
+	height: 18px;
+	transform: translateX(-50%);
+	overflow: visible;
+}
+
+.cue-arc-line,
+.cue-arc-head {
+	fill: none;
+	stroke: var(--accent);
+	stroke-width: 1.6;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+/* dolly: the wheel is lit and the arrows breathe up and down */
+.tutorial-cue-updown {
+	width: 12px;
+	height: 40px;
+	overflow: visible;
+}
+
+.cue-up,
+.cue-down {
+	fill: none;
+	stroke: var(--accent);
+	stroke-width: 1.6;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+.cue-up { animation: cue-up 1.8s var(--ease) infinite; }
+.cue-down { animation: cue-down 1.8s var(--ease) infinite; }
+
+/* orbit: Alt is held while the mouse arcs around the subject. The keycap sits
+   in the stage's bottom-left corner and the pivot dot in its bottom-centre,
+   so the swing above them never crosses either. */
+.tutorial-cue[data-kind="orbit"] .tutorial-cue-stage {
+	height: 64px;
+	align-items: flex-start;
+}
+
+.tutorial-cue-key {
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	padding: 2px 5px;
+	border: 1px solid var(--accent);
+	border-radius: 4px;
+	background: var(--accent-soft);
+	color: var(--fg);
+	font-family: var(--mono);
+	font-size: 9px;
+	font-weight: 700;
+}
+
+.tutorial-cue-pivot {
+	position: absolute;
+	left: 50%;
+	bottom: 1px;
+	width: 6px;
+	height: 6px;
+	transform: translateX(-50%);
+	border-radius: 50%;
+	background: var(--muted);
+	box-shadow: 0 0 0 3px var(--card2);
+}
+
+/* the pivot is 20px below the mouse, so the arc reads as circling a subject */
+.tutorial-cue[data-kind="orbit"] .tutorial-cue-arm {
+	transform-origin: 50% 145%;
+	animation: cue-orbit 2.8s var(--ease) infinite;
+}
+
+/* walk: the six keys, pulsing until each one has been pressed */
+.tutorial-cue-keys {
+	display: grid;
+	grid-template-columns: repeat(6, 1fr);
+	gap: 3px;
+	width: 100%;
+}
+
+.tutorial-cue-keys kbd {
+	padding: 2px 0;
+	border: 1px solid var(--line2);
+	border-radius: 3px;
+	background: var(--card2);
+	color: var(--muted);
+	font-family: var(--mono);
+	font-size: 8.5px;
+	font-weight: 700;
+	text-align: center;
+	animation: cue-key 1.6s var(--ease) infinite;
+}
+
+.tutorial-cue-keys kbd[data-done="1"] {
+	border-color: color-mix(in srgb, #65c18c 60%, transparent);
+	background: color-mix(in srgb, #65c18c 16%, transparent);
+	color: #65c18c;
+	animation: none;
+}
+
+.tutorial-cue-caption {
+	color: var(--fg);
+	font-size: 9.5px;
+	font-weight: 600;
+	line-height: 1.3;
+	text-align: center;
+	word-break: keep-all;
+}
+
+@keyframes cue-swing {
+	0%, 100% { transform: translateX(-7px); }
+	50% { transform: translateX(7px); }
+}
+
+@keyframes cue-orbit {
+	0%, 100% { transform: rotate(-13deg); }
+	50% { transform: rotate(13deg); }
+}
+
+@keyframes cue-up {
+	0%, 100% { transform: translateY(2px); opacity: .45; }
+	40% { transform: translateY(-2px); opacity: 1; }
+}
+
+@keyframes cue-down {
+	0%, 100% { transform: translateY(-2px); opacity: .45; }
+	90% { transform: translateY(2px); opacity: 1; }
+}
+
+@keyframes cue-key {
+	0%, 100% { border-color: var(--line2); color: var(--muted); }
+	50% { border-color: var(--accent); color: var(--fg); }
+}
+
+/* Reduced motion: the tutorial still points at the control, it just stops
+   moving — a static ring, a static glyph, static keycaps. */
+@media (prefers-reduced-motion: reduce) {
+	.app[data-tutorial-step="shot"] .tl-track.shots .tl-track-add,
+	.app[data-tutorial-step="rail"] .tl-track.shots .tl-shot-block:not(.selected),
+	.app[data-tutorial-step="rail"] .tl-rail-draw,
+	.app[data-tutorial-step="play"] .vp-look-through {
+		animation: none;
+		box-shadow: 0 0 0 3px var(--accent);
+	}
+	.tutorial-beacon,
+	.tutorial-beacon-dot,
+	.tutorial-cue,
+	.tutorial-cue-arm,
+	.tutorial-cue-keys kbd,
+	.cue-up,
+	.cue-down {
+		animation: none;
+	}
+	.tutorial-cue { transition: none; }
 }

--- a/test/qa-camera-tutorial-browser.mjs
+++ b/test/qa-camera-tutorial-browser.mjs
@@ -109,6 +109,50 @@ const step = (kind) => `document.querySelector('[data-testid="camera-tutorial-st
 const doneFlag = (kind) => `${step(kind)}?.dataset.done === "1"`;
 const currentFlag = (kind) => `${step(kind)}?.dataset.current === "1"`;
 
+/* ------------------------------------------- the step → control map (#211) */
+
+/** the gesture cue for one of the four nav steps */
+const cue = (kind) => `document.querySelector('[data-testid="camera-tutorial-gesture"][data-kind="${kind}"]')`;
+/** one beacon, optionally the one pinned to a named target */
+const beacon = (kind, role = null) =>
+	`document.querySelector('[data-testid="camera-tutorial-beacon"][data-kind="${kind}"]${role ? `[data-role="${role}"]` : ""}')`;
+/** the gap in px between two elements' boxes — 0 when they overlap */
+const gapBetween = (one, two) => evaluate(`(() => {
+	const a = ${one};
+	const b = document.querySelector(${JSON.stringify(two)});
+	if (!a || !b) return null;
+	const p = a.getBoundingClientRect();
+	const q = b.getBoundingClientRect();
+	const dx = Math.max(q.left - p.right, p.left - q.right, 0);
+	const dy = Math.max(q.top - p.bottom, p.top - q.bottom, 0);
+	return Math.round(Math.hypot(dx, dy));
+})()`);
+/** true once an entrance animation has landed, so screenshots catch the settled frame */
+const settled = (expression) => waitFor(`(() => { const el = ${expression}; return !!el && Number(getComputedStyle(el).opacity) === 1; })()`);
+/** do two elements' boxes intersect at all? the beacon must never cover a control */
+const overlaps = (one, two) => evaluate(`(() => {
+	const a = ${one};
+	const b = document.querySelector(${JSON.stringify(two)});
+	if (!a || !b) return null;
+	const p = a.getBoundingClientRect();
+	const q = b.getBoundingClientRect();
+	return p.left < q.right && q.left < p.right && p.top < q.bottom && q.top < p.bottom;
+})()`);
+/** the spotlight is a real running animation on the real control */
+const spotlightOn = (selector) => evaluate(`(() => {
+	const el = document.querySelector(${JSON.stringify(selector)});
+	return el ? getComputedStyle(el).animationName : null;
+})()`);
+const tutorialStep = `document.querySelector('.app').dataset.tutorialStep ?? null`;
+const PINNED = 60;
+
+/** every beacon must sit on its target, and its step must own the .app root */
+const expectPinned = async (kind, role, target, label) => {
+	expect(`${label}: the beacon is up`, await waitFor(`!!${beacon(kind, role)}`), await evaluate(tutorialStep));
+	const gap = await gapBetween(beacon(kind, role), target);
+	expect(`${label}: it is pinned within ${PINNED}px of ${target}`, gap !== null && gap <= PINNED, String(gap));
+};
+
 /* --------------------------------------------------------- page setup --- */
 
 // The QA browser inherits the host locale; pin English so label matching is
@@ -170,6 +214,17 @@ expect("the card carries the first instruction", await evaluate(`/Right-drag/.te
 await screenshot("tutorial-step1");
 await screenshot("tutorial-city-block-step1");
 
+// #211: the studio has to SHOW where the step happens. Steps 1–4 are gestures
+// with no control to point at, so they get an animated cue; steps 5–7 point at
+// a real control with a beacon plus a spotlight on the control itself.
+expect("the .app root publishes the current step", await waitFor(`${tutorialStep} === "fly"`), String(await evaluate(tutorialStep)));
+expect("step 1 shows the Look gesture cue", await waitFor(`!!${cue("fly")}`));
+expect("no beacon is up while the step is a gesture", await evaluate(`!document.querySelector('[data-testid="camera-tutorial-beacon"]')`));
+expect("the cue never takes the pointer", await evaluate(`getComputedStyle(${cue("fly")}).pointerEvents === "none"`));
+expect("the cue settles before it is judged", await settled(cue("fly")));
+expect("the cue clears the shot preview", await overlaps(cue("fly"), ".vp-shot-preview") === false);
+await screenshot("step1-fly-cue");
+
 /* ------------------------------------------------------- the gestures --- */
 
 const canvas = await centreOf(".stage canvas");
@@ -181,6 +236,9 @@ await mouse("mouseMoved", { x: canvas.x + 70, y: canvas.y + 20, button: "right",
 await mouse("mouseMoved", { x: canvas.x + 130, y: canvas.y + 34, button: "right", buttons: 2 });
 expect("right-drag completes the Look step", await waitFor(doneFlag("fly")));
 expect("Walk becomes the current step", await waitFor(currentFlag("walk")));
+expect("the Look cue leaves with its step", await waitFor(`!${cue("fly")}`));
+expect("step 2 shows the Walk gesture cue", await waitFor(`!!${cue("walk")}`));
+expect("the .app root follows the step", await waitFor(`${tutorialStep} === "walk"`), String(await evaluate(tutorialStep)));
 
 // 2. Walk — the six keys, pressed while the right button is still held.
 await key("KeyW", "w", 87);
@@ -188,6 +246,13 @@ await key("KeyA", "a", 65);
 await key("KeyS", "s", 83);
 expect("three of six keys do not finish Walk", await evaluate(`${step("walk")}.dataset.done === "0"`));
 expect("the pressed keys are marked on the card", await waitFor(`document.querySelectorAll('[data-testid="camera-tutorial-card"] kbd[data-done="1"]').length === 3`));
+expect(
+	"the cue's keycaps light up with them",
+	await waitFor(`${cue("walk")}.querySelectorAll('kbd[data-done="1"]').length === 3`),
+	String(await evaluate(`${cue("walk")}?.querySelectorAll('kbd[data-done="1"]').length`)),
+);
+expect("the Walk cue settles before it is judged", await settled(cue("walk")));
+await screenshot("step2-walk-cue");
 await key("KeyD", "d", 68);
 await key("KeyQ", "q", 81);
 await key("KeyE", "e", 69);
@@ -195,10 +260,19 @@ expect("all six keys complete the Walk step", await waitFor(doneFlag("walk")));
 await mouse("mouseReleased", { x: canvas.x + 130, y: canvas.y + 34, button: "right", buttons: 0, clickCount: 1 });
 
 // 3. Dolly — the wheel over the viewport.
+expect("the Walk cue leaves with its step", await waitFor(`!${cue("walk")}`));
+expect("step 3 shows the Dolly gesture cue", await waitFor(`!!${cue("dolly")}`));
+expect("the Dolly cue settles before it is judged", await settled(cue("dolly")));
+await screenshot("step3-dolly-cue");
 await mouse("mouseWheel", { x: canvas.x, y: canvas.y, deltaX: 0, deltaY: -120 });
 expect("the wheel completes the Dolly step", await waitFor(doneFlag("dolly")));
 
 // 4. Orbit — Alt + left drag (modifier bit 1 is Alt in the CDP contract).
+expect("the Dolly cue leaves with its step", await waitFor(`!${cue("dolly")}`));
+expect("step 4 shows the Orbit gesture cue", await waitFor(`!!${cue("orbit")}`));
+expect("the .app root follows the step", await waitFor(`${tutorialStep} === "orbit"`), String(await evaluate(tutorialStep)));
+expect("the Orbit cue settles before it is judged", await settled(cue("orbit")));
+await screenshot("step4-orbit-cue");
 await mouse("mousePressed", { x: canvas.x, y: canvas.y, button: "left", buttons: 1, clickCount: 1, modifiers: 1 });
 await mouse("mouseMoved", { x: canvas.x + 90, y: canvas.y, button: "left", buttons: 1, modifiers: 1 });
 await mouse("mouseReleased", { x: canvas.x + 90, y: canvas.y, button: "left", buttons: 0, clickCount: 1, modifiers: 1 });
@@ -208,14 +282,47 @@ await screenshot("tutorial-midway");
 
 // 5. Shot — the timeline's Shots lane header button.
 expect("the Shots lane offers + Add shot", await waitFor(`!!document.querySelector('.tl-track-add.cut')`));
+expect("the Orbit cue leaves with the gesture steps", await waitFor(`!document.querySelector('[data-testid="camera-tutorial-gesture"]')`));
+expect("the .app root switches to the Shot step", await waitFor(`${tutorialStep} === "shot"`), String(await evaluate(tutorialStep)));
+await expectPinned("shot", "add-shot", ".tl-track.shots .tl-track-add", "step 5");
+expect(
+	"step 5 spotlights + Add shot itself",
+	await spotlightOn(".tl-track.shots .tl-track-add") === "tutorial-spotlight",
+	String(await spotlightOn(".tl-track.shots .tl-track-add")),
+);
+expect("the beacon never takes the pointer", await evaluate(`getComputedStyle(${beacon("shot")}).pointerEvents === "none"`));
+expect("the beacon carries the step number", await evaluate(`${beacon("shot")}.querySelector('.tutorial-beacon-dot').textContent === "5"`));
+expect("the beacon settles before it is judged", await settled(beacon("shot")));
+expect("it does not cover the timeline's transport row", await overlaps(beacon("shot"), ".tl-transport") === false);
+await screenshot("step5-shot-beacon");
 expect("+ Add shot is clickable", await click(".tl-track-add.cut"));
 expect("adding a shot completes the Shot step", await waitFor(doneFlag("shot")));
 expect("the shot block appears in the lane", await waitFor("!!document.querySelector('.tl-shot-block')"));
 await screenshot("tutorial-city-block-shot");
 
 // 6. Rail — select the shot, arm Draw rail, then stroke across the Top-View.
+expect("the .app root switches to the Rail step", await waitFor(`${tutorialStep} === "rail"`), String(await evaluate(tutorialStep)));
+await expectPinned("rail", "select-shot", ".tl-track.shots .tl-shot-block", "step 6a");
+expect(
+	"the unselected shot block is the one spotlit",
+	await spotlightOn(".tl-track.shots .tl-shot-block:not(.selected)") === "tutorial-spotlight",
+	String(await spotlightOn(".tl-track.shots .tl-shot-block:not(.selected)")),
+);
 expect("the shot block can be selected", await click(".tl-shot-block"));
 expect("the camera bar appears for the shot", await waitFor("!!document.querySelector('.tl-camera-editor .tl-rail-draw')"));
+expect("the select-the-shot beacon steps aside once it is selected", await waitFor(`!${beacon("rail", "select-shot")}`));
+await expectPinned("rail", "draw-rail", ".tl-rail-draw", "step 6b");
+await expectPinned("rail", "top-view", ".vp-inset", "step 6c");
+expect(
+	"Draw rail is spotlit once it exists",
+	await spotlightOn(".tl-rail-draw") === "tutorial-spotlight",
+	String(await spotlightOn(".tl-rail-draw")),
+);
+expect("both rail beacons settle before they are judged", await settled(beacon("rail", "draw-rail")) && await settled(beacon("rail", "top-view")));
+expect("the Draw rail beacon clears the transport row", await overlaps(beacon("rail", "draw-rail"), ".tl-transport") === false);
+expect("the Top-View beacon sits outside the inset it points at", await overlaps(beacon("rail", "top-view"), ".vp-inset") === false);
+expect("and clears the shot preview", await overlaps(beacon("rail", "top-view"), ".vp-shot-preview") === false);
+await screenshot("step6-rail-beacon");
 expect("Draw rail is clickable", await click(".tl-camera-editor .tl-rail-draw"));
 expect("the studio arms rail drawing", await waitFor(`document.querySelector('.app').dataset.railDraw === "1"`));
 const inset = await centreOf(".vp-inset");
@@ -236,12 +343,27 @@ expect(
 
 // 7. Play — the look-through button hands the pane to the shot camera.
 expect("Play is the last current step", await waitFor(currentFlag("play")));
+expect("the .app root switches to the Play step", await waitFor(`${tutorialStep} === "play"`), String(await evaluate(tutorialStep)));
+expect("the rail beacons are gone with their step", await evaluate(`!${beacon("rail")}`));
+await expectPinned("play", "look-through", ".vp-look-through", "step 7");
+expect(
+	"the look-through button is spotlit",
+	await spotlightOn(".vp-look-through") === "tutorial-spotlight",
+	String(await spotlightOn(".vp-look-through")),
+);
+expect("the Play beacon settles before it is judged", await settled(beacon("play")));
+expect("it sits clear of the viewport titlebar", await overlaps(beacon("play"), ".viewport-titlebar") === false);
+expect("it sits clear of the shot preview it points into", await overlaps(beacon("play"), ".vp-shot-preview") === false);
+await screenshot("step7-play-beacon");
 expect("the look-through button is clickable", await click(".vp-look-through"));
 expect("look-through completes the Play step", await waitFor(doneFlag("play")));
 expect("every step reads done", await evaluate(`[...document.querySelectorAll('[data-testid="camera-tutorial-step"]')].every((li) => li.dataset.done === "1")`));
 expect("the overlay reports the Done state", await waitFor(`document.querySelector('[data-testid="camera-tutorial"]').dataset.state === "done"`));
 expect("the card says the run is finished", await evaluate(`/Done/.test(document.querySelector('[data-testid="camera-tutorial-card"]').textContent)`));
+expect("nothing is left pointing at a control", await waitFor(`!document.querySelector('[data-testid="camera-tutorial-beacon"]') && !document.querySelector('[data-testid="camera-tutorial-gesture"]')`));
+expect("the .app root drops the step attribute", await waitFor(`${tutorialStep} === null`), String(await evaluate(tutorialStep)));
 await screenshot("tutorial-done");
+await screenshot("done");
 
 // The close button removes the overlay outright.
 expect("the close button is clickable", await click('[data-testid="camera-tutorial-close"]'));

--- a/test/verify-camera-tutorial.mjs
+++ b/test/verify-camera-tutorial.mjs
@@ -85,7 +85,7 @@ expect(
 expect("there is exactly one mount site", (app.match(/<CameraTutorial/g) ?? []).length === 1);
 expect(
 	"it is mounted only while the tutorial is on and outside embeds",
-	/\{cameraTutorial && !embedMode && \(\s*<CameraTutorial previewing=\{lookThroughShot\} onClose=\{\(\) => setCameraTutorial\(false\)\} \/>/.test(app),
+	/\{cameraTutorial && !embedMode && \(\s*<CameraTutorial previewing=\{lookThroughShot\} onStepChange=\{setCameraTutorialStep\} onClose=\{\(\) => setCameraTutorial\(false\)\} \/>/.test(app),
 );
 expect(
 	"the mount sits inside the viewport pane, above the stage",
@@ -179,6 +179,53 @@ expect(
 expect("it closes the menu behind itself", /cozyclay:camera-tutorial[\s\S]{0,120}setOpen\(false\)/.test(settings));
 expect("no topbar button was added (R4)", (settings.match(/topbar-action/g) ?? []).length === 1 && !/topbar-action[^"]*tutorial/i.test(app));
 
+/* ------------------------------------------- the step → control map (#211) */
+
+// The overlay names the gesture; the studio has to show WHERE. The current
+// step leaves the component through onStepChange, lands on the .app root as
+// data-tutorial-step, and styles.css spotlights that step's control.
+expect("the overlay reports its current step outward", tutorial.includes("onStepChange?.(currentKind)"));
+expect("it reports null when it unmounts", tutorial.includes("useEffect(() => () => onStepChange?.(null), [onStepChange])"));
+expect("App keeps the reported step", app.includes("const [cameraTutorialStep, setCameraTutorialStep] = useState(null);"));
+expect(
+	"the .app root publishes it only while the tutorial is open",
+	app.includes("data-tutorial-step={cameraTutorial ? cameraTutorialStep ?? undefined : undefined}"),
+);
+expect(
+	"the landing playground's own hint attribute is untouched",
+	app.includes("data-playground-hint={playgroundMode ? playgroundHint ?? undefined : undefined}"),
+);
+expect("the beacon and the gesture cue are exported", /export function TutorialBeacon\(/.test(tutorial) && /export function GestureCue\(/.test(tutorial));
+expect("the beacon targets are declared as a table", tutorial.includes("export const TUTORIAL_BEACONS = {"));
+for (const [name, needle] of [
+	["the Shots lane's add button", '.tl-track.shots .tl-track-add"'],
+	["the shot to select", '.tl-track.shots .tl-shot-block:not(.selected)"'],
+	["Draw rail", '".tl-rail-draw"'],
+	["the Top-View inset", '".vp-inset"'],
+	["the look-through button", '".vp-look-through"'],
+]) expect(`the map names ${name}`, tutorial.includes(needle), needle);
+expect(
+	"the rail step swaps its advice on the camera bar's own existence",
+	tutorial.includes('absent: ".tl-rail-draw"') && tutorial.includes('requires: ".tl-rail-draw"'),
+);
+expect("the beacon and the cue are addressable", tutorial.includes('data-testid="camera-tutorial-beacon"') && tutorial.includes('data-testid="camera-tutorial-gesture"'));
+expect("the beacon publishes the step kind and which target it is on", /data-kind=\{kind\}[\s\S]{0,80}data-role=\{role\}/.test(tutorial));
+expect("the beacon rides a portal so no pane can clip it", tutorial.includes("createPortal(") && tutorial.includes("document.body,"));
+expect(
+	"it re-measures on resize, on the panes, and on DOM churn",
+	tutorial.includes('window.addEventListener("resize", schedule)')
+		&& tutorial.includes("new ResizeObserver(schedule)")
+		&& tutorial.includes("new MutationObserver(schedule)"),
+);
+expect(
+	"every observer is torn down with the beacon",
+	tutorial.includes("resize.disconnect()") && tutorial.includes("mutations.disconnect()") && tutorial.includes('window.removeEventListener("resize", schedule)'),
+);
+expect("the gesture cue only stands in for the four nav steps", /NAV_KINDS\.has\(currentKind\)/.test(tutorial));
+expect("the walk cue reads the same pressed-key set as the card", /walked\?\.has\(walkKey\)/.test(tutorial));
+expect("the card points at the region the control lives in", tutorial.includes('where: ko("\u2193 Timeline, Shots lane"') && tutorial.includes('where: ko("\u2192 Viewport"'));
+expect("the card renders that pointer before the copy", /camera-tutorial-where"?>\{current\.where\}/.test(tutorial));
+
 /* ------------------------------------------------------------ styles ----- */
 
 expect("the overlay has its own block", css.includes(".camera-tutorial {"));
@@ -186,6 +233,33 @@ expect("it hangs under the 27px viewport titlebar", /\.camera-tutorial \{[^}]*to
 expect("the overlay never takes the pointer", /\.camera-tutorial \{[^}]*pointer-events: none/.test(css));
 expect("except on the close button", /\.camera-tutorial-close \{[^}]*pointer-events: auto/.test(css));
 expect("it uses the studio's own tokens", /\.camera-tutorial \{[^}]*var\(--panel\)/.test(css) && /\.camera-tutorial \{[^}]*var\(--line2\)/.test(css));
+
+// The spotlight (#211): the same idea as the landing page's hint pulse, keyed
+// on the Studio's own attribute and one region louder.
+for (const selector of [
+	'.app[data-tutorial-step="shot"] .tl-track.shots .tl-track-add',
+	'.app[data-tutorial-step="rail"] .tl-track.shots .tl-shot-block:not(.selected)',
+	'.app[data-tutorial-step="rail"] .tl-rail-draw',
+	'.app[data-tutorial-step="play"] .vp-look-through',
+]) expect(`the spotlight covers ${selector}`, css.includes(selector), selector);
+expect("the rail step also outlines the Top-View it is drawn into", /\.app\[data-tutorial-step="rail"\] \.vp-inset \{[^}]*var\(--accent-ring\)/.test(css));
+expect("the spotlight has its own, stronger keyframes", /@keyframes tutorial-spotlight \{[^}]*0 0 0 3px var\(--accent\)/.test(css));
+expect("the landing page's own hint pulse is untouched", css.includes('.app[data-playground-hint="look"] .vp-look-through') && /@keyframes playground-pulse \{/.test(css));
+expect("the beacon never takes the pointer", /\.tutorial-beacon \{[^}]*pointer-events: none/.test(css));
+expect("the beacon clears every viewport and timeline layer", /\.tutorial-beacon \{[^}]*z-index: 14/.test(css));
+expect("the cue never takes the pointer either", /\.tutorial-cue \{[^}]*pointer-events: none/.test(css));
+expect("the cue fades rather than blinking out", /\.tutorial-cue \{[^}]*transition: opacity/.test(css) && /\.tutorial-cue\[data-leaving="1"\] \{[^}]*opacity: 0/.test(css));
+expect("every cue and beacon colour is a studio token", /\.tutorial-beacon-dot \{[^}]*background: var\(--accent\)/.test(css) && /\.tutorial-cue-caption \{[^}]*color: var\(--fg\)/.test(css));
+expect(
+	"reduced motion keeps the pointing and drops the movement",
+	(() => {
+		const block = css.slice(css.lastIndexOf("@media (prefers-reduced-motion: reduce)"));
+		return block.includes('.app[data-tutorial-step="shot"] .tl-track.shots .tl-track-add')
+			&& block.includes(".tutorial-cue,")
+			&& block.includes(".tutorial-beacon,")
+			&& /animation: none/.test(block);
+	})(),
+);
 
 /* ---------------------------------------------------------- manifest ----- */
 


### PR DESCRIPTION
## What

The Studio camera tutorial named the gesture and then left the operator to find the control. Steps 5–7 happen in two different panes, so "click **+ Add shot**" meant scanning a forty-control studio for a button the overlay never pointed at, and steps 1–4 described a mouse gesture in prose only.

Now every step shows where it happens and what the hand should do:

- **Step → target wiring.** The current step leaves `CameraTutorial` through a new `onStepChange(kind | null)` callback (fired on mount, on every step change, and with `null` when the run is done or the overlay unmounts). App keeps it in `cameraTutorialStep` and the root `.app` div publishes `data-tutorial-step` while the tutorial is open. The landing playground's `data-playground-hint` is untouched.
- **Spotlight (steps shot / rail / play).** The landing page's hint pulse, one region louder: a 3 px accent ring with a halo breathing 0 → 8 px out of it (`@keyframes tutorial-spotlight`), keyed on `data-tutorial-step`. The Top-View inset gets a soft accent outline for the rail step instead of a second pulse.
- **Beacon + caption pinned to the target.** New `TutorialBeacon`, portalled to `<body>`: a numbered accent circle (the step number), a dashed leader line and a caption chip pinned to the live control. It re-measures on resize, on scroll, on a `ResizeObserver` of the timeline and viewport, and on a `MutationObserver` retry — the camera bar only mounts after a shot is selected, so "target not there yet" is the normal case. It flips below the target when the target hugs the top of its own pane, and clamps to the pane's visible edge with the leader still aimed at the real target.
- **Gesture cues (steps fly / walk / dolly / orbit).** New `GestureCue` at the viewport's centre-bottom: an inline SVG mouse (two buttons + wheel) with the control the step wants lit, animated the way the hand moves — sliding left/right under a two-headed arc for Look, steady right button plus a W A S D Q E keycap row that turns green key by key for Walk, a lit wheel with breathing up/down arrows for Dolly, and an `Alt` keycap plus the mouse arcing around a pivot dot for Orbit. It fades out when its step completes.
- **Card arrow.** The hint card opens with the region the control lives in — "↓ Timeline, Shots lane" for shot/rail, "→ Viewport" for play — before the how-to copy.

Both overlays are `pointer-events: none` and exist only while the tutorial is open, so nothing in the studio becomes harder to click. Under `prefers-reduced-motion` the pointing stays and the movement goes: static ring, static glyph, and the cue is dropped outright instead of faded. All colour, spacing, radius, shadow and motion values come from existing studio tokens (`--accent`, `--accent-ring`, `--panel`, `--line2`, `--shadow-md`, `--med`, `--ease`) plus the tutorial's existing done-green.

## Per-step target map

| # | Step | What is shown | Target |
|---|---|---|---|
| 1 | fly | gesture cue: right button lit, mouse sliding under a two-headed arc | — (viewport gesture) |
| 2 | walk | gesture cue: right button lit + W A S D Q E keycaps, green as pressed | — (viewport gesture) |
| 3 | dolly | gesture cue: wheel lit + up/down arrows | — (viewport gesture) |
| 4 | orbit | gesture cue: `Alt` keycap + left button lit, mouse arcing around a dot | — (viewport gesture) |
| 5 | shot | beacon "Click here" + spotlight | `.tl-track.shots .tl-track-add` |
| 6 | rail (no shot selected) | beacon "1. Select the shot" + spotlight | `.tl-track.shots .tl-shot-block:not(.selected)` |
| 6 | rail (shot selected) | beacon "2. Draw rail, then drag across the top view" + spotlight | `.tl-rail-draw` |
| 6 | rail (shot selected) | second beacon "Drag a line here" + soft accent outline | `.vp-inset` |
| 7 | play | beacon "Click to look through the shot camera" + spotlight | `.vp-look-through` |

Every caption is bilingual through `ko()`.

## QA

- Browser QA (real CDP input, one step at a time, state-condition waits only): **124 PASS / 0 FAIL**, exit 0.
  `QA_URL=http://127.0.0.1:5370/app/ CDP_PORT=9370 QA_SHOT_DIR=/tmp/tutorial-spot-qa node tools/qa-browser.mjs -- node test/qa-camera-tutorial-browser.mjs` → `qa-camera-tutorial-browser: all checks passed`
  The suite now asserts, at each step: the cue's presence and its removal after the step completes, the beacon's presence, its bounding box within 60 px of the real control, `getComputedStyle(...).animationName === "tutorial-spotlight"` on the control itself, `data-tutorial-step` on the `.app` root, and that no beacon overlaps the transport row, the Top-View inset, the shot preview or the viewport titlebar.
- Node suite: `node tools/run-tests.mjs` → `PASS 165 Node verification files`, exit 0. `test/verify-camera-tutorial.mjs` grew the step → control map, the spotlight selectors, the exports, and the `prefers-reduced-motion` rule.
- `npm run build` → exit 0.
- Reduced-motion pass (emulated `prefers-reduced-motion: reduce`): the cue's `animation-name` computes to `none`, the cue is removed immediately on completion, and the next step's cue comes up.

### Control-count audit — unchanged

`QA_URL=http://127.0.0.1:5370/app/ CDP_PORT=9371 OUT=/tmp/tutorial-spot-count node tools/qa-browser.mjs -- node tools/qa/studio-control-count.mjs` on plain `/app/` (tutorial off):

```
scene-none 35
scene-char 35
camera 38
motion 51
```

Expected 35 / 35 / 38 / 51 — the beacons and cues are pointer-transparent and only exist while the tutorial is open, so the audit does not move.

## Screenshots

Step 1 — Look cue
![step1](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/step1-fly-cue.png)

Step 2 — Walk cue, three of six keys pressed
![step2](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/step2-walk-cue.png)

Step 3 — Dolly cue
![step3](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/step3-dolly-cue.png)

Step 4 — Orbit cue
![step4](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/step4-orbit-cue.png)

Step 5 — beacon and spotlight on + Add shot
![step5](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/step5-shot-beacon.png)

Step 6 — shot selected: beacons on Draw rail and on the Top-View
![step6](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/step6-rail-beacon.png)

Step 7 — beacon and spotlight on the look-through button
![step7](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/step7-play-beacon.png)

Done — everything green, nothing left pointing
![done](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-spot/done.png)

## Scope

Touches `src/camera-tutorial.jsx`, `src/App.jsx`, `src/styles.css`, `test/verify-camera-tutorial.mjs`, `test/qa-camera-tutorial-browser.mjs`. No change to `index.html`, the landing playground's hint behaviour, `timeline.jsx`, `controls.jsx`, the topbar or the starter-scene seeding.

Closes #211
