### PR TITLE
release: v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.8.1
+
+The Studio camera tutorial now starts where the landing page does and shows
+where to click.
+
+- Opening the tutorial (Settings ▾ → Camera tutorial or `/app/?tutorial=camera`)
+  loads the City Block starter scene with the walk take on its character, at
+  frame 0 in the free camera, so Shot / Rail / Play have something to frame.
+  A scene with unsaved changes is replaced only after a confirm.
+- Each step points at its control: a pulsing spotlight plus a numbered beacon
+  and caption pinned to `+ Add shot`, the shot block and `Draw rail`, the
+  top view, and the look-through button; the Look / Walk / Dolly / Orbit steps
+  show an animated mouse-and-keys cue in the viewport, with the walk keycaps
+  turning green as they are pressed. The hint card names the region ("↓
+  Timeline, Shots lane", "→ Viewport"). Overlays never take the pointer and go
+  static under `prefers-reduced-motion`.
+
 ## 1.8.0
 
 The Studio's chrome gets a research-backed cut: the same capabilities, a third

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cozyclay",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cozyclay",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "AGPL-3.0-or-later",
       "bin": {
         "cclay": "bin/cozyclay.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozyclay",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Open source previs software in the browser: block a scene, pose characters, author camera moves and cuts, then take the same shots to an AI video model.",
   "scripts": {
     "dev": "node tools/dev-full.mjs --host 127.0.0.1 --port 5180",


### PR DESCRIPTION
Version bump to 1.8.1 and the changelog section for the two tutorial follow-ups since v1.8.0: the tutorial opens the City Block starter with the walk take (#209 / #210) and spotlights each step's control with beacons and gesture cues (#211 / #212).

After merge: tag v1.8.1 on the merge commit, GitHub release from the changelog section, npm publish from a clean checkout per docs/releasing.md.
