### PR TITLE
feat(studio): camera tutorial uses the minimal top view (#214)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11025,8 +11025,11 @@ function resizePromptClip(id, edge, rawFrame) {
 								onSolve={ikSolve}
 								onDragEnd={ikDragEnd}
 							/>
+							{/* The tutorial's top view is the landing playground's: camera, cast
+							    and the rail only, so the line the Rail step asks for is drawn on
+							    a clean floor instead of over 34 footprints. */}
 							<PlanBoard
-								minimal={playgroundMode}
+								minimal={playgroundMode || cameraTutorial}
 								hostRef={planHostRef}
 								planCamRef={planCamRef}
 								shotCamRef={shotCamRef}

--- a/test/verify-camera-tutorial.mjs
+++ b/test/verify-camera-tutorial.mjs
@@ -261,6 +261,16 @@ expect(
 	})(),
 );
 
+/* ---------------------------------------------------------- top view ----- */
+
+// The Rail step is drawn on the Top-View. The landing playground clears that
+// board down to camera, cast and rail (PlanBoard's `minimal`); the studio
+// tutorial must get the same board, not 34 footprints under the stroke.
+expect(
+	"the top view is minimal while the tutorial is open",
+	/<PlanBoard\s+minimal=\{playgroundMode \|\| cameraTutorial\}/.test(app),
+);
+
 /* ---------------------------------------------------------- manifest ----- */
 
 expect("the browser suite is registered", manifest.includes('"test/qa-camera-tutorial-browser.mjs"'));


### PR DESCRIPTION
While the camera tutorial is open the Top-View inset now renders PlanBoard's `minimal` board — the one the landing playground uses: camera, cast and the rail only. Closing the tutorial brings the full working board (footprints, labels, guides, key light) back.

One-line wiring: `minimal={playgroundMode || cameraTutorial}` at the PlanBoard mount in src/App.jsx, plus a verify-camera-tutorial assertion (RED on main, GREEN here).

**Top view with the tutorial open** — camera frustum, character, floor:

![topview open](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-plan/topview-tutorial-open.png)

**Same inset after × closes the tutorial** — full board is back:

![topview closed](https://raw.githubusercontent.com/NomaDamas/CozyClay/qa-evidence/tutorial-plan/topview-tutorial-closed.png)

QA: `node test/verify-camera-tutorial.mjs` all PASS; `test/qa-camera-tutorial-browser.mjs` (full 7-step run, 124 checks) and `node tools/run-tests.mjs` results in the comments below.

Closes #214
