### PR TITLE
fix(workflow): trim whitespace around agent node data keys (#216)

### DIFF
--- a/src/workflow/canvas-commands.js
+++ b/src/workflow/canvas-commands.js
@@ -28,12 +28,23 @@ export function createCanvasCommands({ store, makeNode, nodeSchemas }) {
 	const snapshot = () => clone(current());
 	const mutate = (fn) => { const before = snapshot(); const next = fn(snapshot()); history.push(before); if (history.length > maxHistory) history.shift(); publish(next); return next; };
 	const findNode = (graph, id) => graph.nodes.find((node) => node.id === id);
-	const validateData = (node, data) => {
+	// The agent sometimes pads data keys with stray whitespace ("prompt ").
+	// Trim keys before validating and merging, keep strict unknown-key
+	// rejection, and refuse edits where trimming would collide two keys.
+	const normalizeData = (node, data, path = "data") => {
 		if (!data || typeof data !== "object" || Array.isArray(data)) throw new Error("data must be an object");
 		const properties = schemaProperties(nodeSchemas, schemaCategoryForType(node.type), node.data?.model || data.model);
 		const allowed = new Set([...commonKeys, ...(typeKeys[node.type] || []), ...Object.keys(properties || {})]);
-		for (const key of Object.keys(data)) if (!allowed.has(key)) throw new Error(`Unknown node data key: ${key}`);
-		if (data.formValues && typeof data.formValues === "object") for (const key of Object.keys(data.formValues)) if (!allowed.has(key)) throw new Error(`Unknown node data key: ${key}`);
+		const normalized = {};
+		const seen = new Map();
+		for (const [key, value] of Object.entries(data)) {
+			const trimmed = key.trim();
+			if (seen.has(trimmed)) throw new Error(`Node data key conflict after whitespace normalization in ${path}: ${JSON.stringify(trimmed)}`);
+			seen.set(trimmed, key);
+			if (!allowed.has(trimmed)) throw new Error(`Unknown node data key: ${trimmed}`);
+			normalized[trimmed] = trimmed === "formValues" && value && typeof value === "object" ? normalizeData(node, value, "data.formValues") : value;
+		}
+		return normalized;
 	};
 	const handlers = {
 		get_graph: () => { const graph = clone(current()); return { ...graph, nodes: graph.nodes.map((node) => ({ id: node.id, type: node.type, model: node.data?.model || null, data: node.data, position: node.position })), outputs: Object.fromEntries(graph.nodes.map((node) => [node.id, node.data?.outputs || []])) }; },
@@ -48,9 +59,9 @@ export function createCanvasCommands({ store, makeNode, nodeSchemas }) {
 				if (!models[modelValue]) throw new Error(`Unknown model: ${modelValue}`);
 				node.data.model = modelValue;
 			}
-			validateData(node, data); node.data = { ...node.data, ...data }; graph.nodes.push(node); return graph;
+			const normalized = normalizeData(node, data); node.data = { ...node.data, ...normalized }; graph.nodes.push(node); return graph;
 		}); return { node: next.nodes.at(-1), graph: next }; },
-		update_node: ({ id, data } = {}) => mutate((graph) => { const node = findNode(graph, id); if (!node) throw new Error(`Unknown node: ${id}`); validateData(node, data); node.data = { ...node.data, ...data, ...(data.formValues ? data.formValues : {}) , ...(data.formValues ? { formValues: { ...(node.data.formValues || {}), ...data.formValues } } : {}) }; return graph; }),
+		update_node: ({ id, data } = {}) => mutate((graph) => { const node = findNode(graph, id); if (!node) throw new Error(`Unknown node: ${id}`); const normalized = normalizeData(node, data); node.data = { ...node.data, ...normalized, ...(normalized.formValues ? normalized.formValues : {}) , ...(normalized.formValues ? { formValues: { ...(node.data.formValues || {}), ...normalized.formValues } } : {}) }; return graph; }),
 		remove_node: ({ id } = {}) => mutate((graph) => { if (!findNode(graph, id)) throw new Error(`Unknown node: ${id}`); graph.nodes = graph.nodes.filter((node) => node.id !== id); graph.edges = graph.edges.filter((edge) => edge.source !== id && edge.target !== id); return graph; }),
 		connect: ({ source, target, sourceHandle, targetHandle = "input" } = {}) => { const next = mutate((graph) => { const from = findNode(graph, source); if (!from || !findNode(graph, target)) throw new Error("Unknown node"); const sources = from.type === "scene" ? ["render", "scene"] : ["output"]; if (sourceHandle === undefined) sourceHandle = sources[0]; if (!sources.includes(sourceHandle)) throw new Error("Invalid source handle"); if (targetHandle !== "input" && !String(targetHandle).startsWith("character:") && targetHandle !== "asset" && targetHandle !== "motion") throw new Error("Invalid target handle"); if (graph.edges.some((edge) => edge.source === source && edge.target === target && edge.targetHandle === targetHandle)) throw new Error("Nodes are already connected"); const edge = { id: `e-${source}-${target}-${Date.now()}`, source, target, sourceHandle, targetHandle, animated: true, style: { stroke: "#8994ff", strokeWidth: 2 } }; graph.edges.push(edge); return graph; }); return { edge: next.edges.at(-1), graph: next }; },
 		disconnect: ({ edgeId } = {}) => mutate((graph) => { if (!graph.edges.some((edge) => edge.id === edgeId)) throw new Error(`Unknown edge: ${edgeId}`); graph.edges = graph.edges.filter((edge) => edge.id !== edgeId); return graph; }),

--- a/test/verify-canvas-commands.mjs
+++ b/test/verify-canvas-commands.mjs
@@ -110,3 +110,29 @@ console.log("PASS canvas commands: all nine dispatch handlers, model/schema vali
 	assert.equal(g.nodes.find((node) => node.id === image.id).data.resultUrl, "data:image/png;base64,AA==", "the runner's node data is what gets published");
 	console.log("PASS run_workflow publishes the runner's node data");
 }
+
+// Issue #216: the agent sometimes pads node data keys with stray whitespace
+// ("prompt "). The command layer trims keys before validating and merging,
+// keeps strict unknown-key rejection on the trimmed key, and refuses edits
+// where trimming would collide two keys into one.
+{
+	const node = await ok("add_node", { type: "text", model: "text-generation", data: { " prompt ": "created" } });
+	const nid = node.node.id;
+	const target = () => graph.nodes.find((entry) => entry.id === nid);
+	assert.equal(target().data.prompt, "created", "a padded valid key on add_node is stored under its trimmed key");
+	assert.ok(!("prompt " in target().data), "the padded key itself is never stored");
+	await ok("update_node", { id: nid, data: { " temperature ": 0.9 } });
+	assert.equal(target().data.temperature, 0.9, "a padded valid key on update_node is stored under its trimmed key");
+	assert.ok(!("temperature " in target().data), "the padded key itself is never stored after update");
+	await ok("update_node", { id: nid, data: { formValues: { " temperature ": 0.7 } } });
+	assert.equal(target().data.temperature, 0.7, "a padded formValues key is merged into the node data top level");
+	assert.equal(target().data.formValues.temperature, 0.7, "a padded formValues key is stored under its trimmed key");
+	assert.ok(!("temperature " in target().data) && !("temperature " in target().data.formValues), "padded keys are absent from node data and formValues");
+	await bad("update_node", { id: nid, data: { " unknown_key ": true } }, /Unknown.*key/);
+	await bad("update_node", { id: nid, data: { formValues: { " unknown_key ": true } } }, /Unknown.*key/);
+	await bad("update_node", { id: nid, data: { "   ": true } }, /Unknown.*key/);
+	await bad("update_node", { id: nid, data: { prompt: "kept", " prompt ": "collides" } }, /collid|conflict/i);
+	assert.equal(target().data.prompt, "created", "a collision rejection leaves the stored prompt untouched");
+	await bad("add_node", { type: "text", model: "text-generation", data: { prompt: "a", " prompt ": "b" } }, /collid|conflict/i);
+	console.log("PASS canvas commands tolerate padded node data keys: trimmed, rejected when unknown, refused on collision");
+}


### PR DESCRIPTION
## Summary

Agent-emitted node data keys with surrounding whitespace are now trimmed at the canvas boundary before validation, so padded keys like `" foo "` resolve to `foo`. Unknown keys are still rejected by name, and if a trimmed key collides with another existing key the edit is refused rather than silently overwriting.

## Changes

- `src/workflow/canvas-commands.js`: trim whitespace around node data keys at the command dispatch boundary; reject trimmed-vs-existing key collisions; unchanged behaviour otherwise.
- `test/verify-canvas-commands.mjs`: new checks covering padded keys (trimmed and applied), unknown keys still rejected after trim, and collisions refused.

## Tests

Check 3 — `node test/verify-canvas-commands.mjs` (exit 0):

```
PASS canvas commands: all nine dispatch handlers, model/schema validation, rejected edits are atomic, output evaluation, focus, bounded undo
PASS canvas commands survive a store whose reads lag one render
PASS canvas commands: Scene source handles and upload node data
PASS run_workflow publishes the runner's node data
PASS canvas commands tolerate padded node data keys: trimmed, rejected when unknown, refused on collision
```

Check 5 — `npm run build && node tools/run-tests.mjs` (exit 0), final summary line:

```
PASS 165 Node verification files
```

Closes #216
