### PR TITLE
fix(workflow): Scene node Play drives the live previs and links to a Video node (#218)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3684,6 +3684,14 @@ export default function App() {
 			setTlPlaying(command.playing);
 		}
 	}), []);
+	// The Workflow Scene node's frame slider used to guess the take length, so
+	// its own preview clock ran on past the end of a shorter shot (#218). The
+	// embed announces the take it actually holds — on load and whenever the
+	// scene or its length changes — and the node follows it.
+	useEffect(() => {
+		if (!embedMode) return;
+		window.parent.postMessage({ type: "cozyclay:scene-timeline", activeSceneId, frameCount: tlFrameCount, fps: tlFps }, "*");
+	}, [embedMode, activeSceneId, tlFrameCount, tlFps]);
 
 	// Commands are a sequential transport boundary, while React commits on a
 	// later turn. Keep its read model current synchronously so the next frame

--- a/src/workflow/CozySceneNode.jsx
+++ b/src/workflow/CozySceneNode.jsx
@@ -7,6 +7,7 @@ import {
 	normalizeCozySceneData,
 	nextSceneFrame,
 	sceneInputSpecs,
+	sceneTimelinePatch,
 } from "./cozy-scene-node.js";
 import { publishScenePlayback } from "./scene-asset-sync.js";
 import "./cozy-scene-node.css";
@@ -35,7 +36,7 @@ function callbackFrom(data, prop) {
 	return typeof prop === "function" ? prop : typeof data[prop] === "function" ? data[prop] : null;
 }
 
-export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, selected = false, HandleComponent = null, onDataChange = null, onRun = null, onOpenScene = null }) {
+export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, selected = false, HandleComponent = null, onDataChange = null, onRun = null, onOpenScene = null, onVideo = null }) {
 	const data = useMemo(() => normalizeCozySceneData(rawData), [rawData]);
 	const Handle = HandleComponent || rawData.Handle || BridgeHandle;
 	// Explicit component callbacks win over generic node data callbacks. This
@@ -44,6 +45,7 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 	const change = onDataChange || callbackFrom(rawData, "onDataChange");
 	const run = onRun || callbackFrom(rawData, "onRun");
 	const openScene = onOpenScene || callbackFrom(rawData, "onOpenScene");
+	const sendToVideo = onVideo || callbackFrom(rawData, "onVideo");
 	// The pack export is a one-shot side trip, not graph state: it never has to
 	// survive a reload or reach the workflow runner, so it stays on the node.
 	const [pack, setPack] = useState({ pending: false, message: "", error: "" });
@@ -88,6 +90,19 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 		return () => window.clearTimeout(timer);
 	}, [data.controls.playing, data.frame, data.frameCount]);
 
+	// The take length belongs to the scene, not to this node: the embed says how
+	// long it is, so the slider and the local clock stop where the previs does.
+	useEffect(() => {
+		const onMessage = (event) => {
+			const frame = document.querySelector(`[data-node-id="${CSS.escape(id)}"] iframe`);
+			if (!frame || event.source !== frame.contentWindow) return;
+			const patch = sceneTimelinePatch(data, event.data);
+			if (patch) emit(patch, { syncPlayback: false });
+		};
+		window.addEventListener("message", onMessage);
+		return () => window.removeEventListener("message", onMessage);
+	}, [id, data]);
+
 	const handleProps = (spec, type, position) => ({
 		 type,
 		 position,
@@ -110,8 +125,12 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 			</header>
 
 			<section className="cozy-scene-preview" aria-label="3D scene preview">
-				{data.preview === "render" && data.lastOutput?.renderUrl ? <img className="cozy-scene-render" src={data.lastOutput.renderUrl} alt="Captured scene frame" /> : <SceneViewport />}
-			{data.preview === "render" && <div className="cozy-scene-preview-copy"><strong>Rendered frame</strong><span>{data.statusMessage || "Open Studio to edit the scene"}</span></div>}
+				{/* The live previs is never swapped out for the capture: a render is a
+				    still, and replacing the frame with it left Play ticking a counter
+				    over a dead picture (#218). The capture rides along as a thumbnail. */}
+				<SceneViewport />
+				{data.preview === "render" && data.lastOutput?.renderUrl && <figure className="cozy-scene-render-thumb"><img src={data.lastOutput.renderUrl} alt="Captured scene frame" /><figcaption>Last render</figcaption></figure>}
+				{data.preview === "render" && <div className="cozy-scene-preview-copy"><strong>Live previs</strong><span>{data.statusMessage || "Open Studio to edit the scene"}</span></div>}
 			</section>
 
 			<section className="cozy-scene-controls" aria-label="Scene controls">
@@ -126,6 +145,10 @@ export default function CozySceneNode({ id = "cozy-scene", data: rawData = {}, s
 					<button type="button" onClick={() => emit({ controls: { camera: { yaw: data.controls.camera.yaw - 15 } } })} aria-label="Orbit camera left">◀</button>
 					<span>Camera {Math.round(data.controls.camera.yaw)}° / {Math.round(data.controls.camera.pitch)}°</span>
 					<button type="button" onClick={() => emit({ controls: { camera: { yaw: data.controls.camera.yaw + 15 } } })} aria-label="Orbit camera right">▶</button>
+				</div>
+				<div className="cozy-scene-handoff">
+					<button type="button" className="cozy-scene-video" onClick={() => sendToVideo?.({ id, data })} title="Add a Video node fed by this scene's render">→ Video</button>
+					<p className="cozy-scene-hint">Play to check the previs, then send render → Video to generate a clip.</p>
 				</div>
 			</section>
 

--- a/src/workflow/WorkflowBuilder.jsx
+++ b/src/workflow/WorkflowBuilder.jsx
@@ -14,7 +14,7 @@ import { Toaster, toast } from "react-hot-toast";
 import { loadWorkflowGraph, normalizeWorkflowGraph, storeWorkflowGraph, WORKFLOW_STORAGE_KEY } from "../project.js";
 import AgentPanel from "./AgentPanel.jsx";
 import CozySceneNode from "./CozySceneNode.jsx";
-import { normalizeCozySceneData, sceneConnectionAllowed, toCozySceneRunRequest } from "./cozy-scene-node.js";
+import { applyCozyScenePatch, normalizeCozySceneData, sceneConnectionAllowed, toCozySceneRunRequest } from "./cozy-scene-node.js";
 import { activeSceneCharacters, characterHandleId, characterIdFromHandle, normalizeMotionInputData, motionInputOutput } from "./motion-input.js";
 import { DEFAULT_NODE_SCHEMAS, defaultFormValues, schemaCategoryForType, schemaModelEntries, schemaProperties } from "./node-schema.js";
 import { executeLocalWorkflowGraph } from "./local-workflow.js";
@@ -249,7 +249,7 @@ function ShotPromptNodeType(props) {
 const NODE_TYPES = { text: TextNode, image: ImageNode, video: VideoNode, audio: AudioNode, api: ApiNode, "video-combiner": VideoCombinerNode, upload: UploadNode, concat: ConcatNode, "motion-input": MotionInputNode, "shot-prompt": ShotPromptNodeType };
 
 function SceneNodeType({ data, ...props }) {
-	return <CozySceneNode {...props} data={data} HandleComponent={Handle} onDataChange={data.onSceneChange} onRun={data.onSceneRun} onOpenScene={() => window.open("/app/", "_blank", "noopener,noreferrer")} />;
+	return <CozySceneNode {...props} data={data} HandleComponent={Handle} onDataChange={data.onSceneChange} onRun={data.onSceneRun} onVideo={data.onSceneVideo} onOpenScene={() => window.open("/app/", "_blank", "noopener,noreferrer")} />;
 }
 
 const FLOW_NODE_TYPES = { ...NODE_TYPES, scene: SceneNodeType };
@@ -271,12 +271,17 @@ export default function WorkflowBuilder() {
 	useEffect(() => { graphRef.current = graph; }, [graph]);
 
 	const updateNode = useCallback((id, patch) => setNodes((current) => current.map((node) => node.id === id ? { ...node, data: { ...node.data, ...patch } } : node)), [setNodes]);
-	const updateScene = useCallback(({ id, patch, data }) => {
-		// CozySceneNode already applies nested patches (camera/playing) against
-		// its normalized envelope. Store that complete envelope so a later control
-		// change cannot shallow-replace sibling controls and reset them.
-		updateNode(id, data || patch);
-	}, [updateNode]);
+	const updateScene = useCallback(({ id, patch }) => setNodes((current) => current.map((node) => {
+		if (node.id !== id) return node;
+		// The patch is applied here, against the node's freshest data, rather than
+		// stored as the envelope the caller normalized: the Scene node ticks its
+		// preview clock at 24fps from a render-old snapshot, and writing that whole
+		// snapshot threw away anything that landed in between — the take length the
+		// embed announces, for one (#218). Nested control/camera patches still
+		// merge, which is why the envelope was passed in the first place; keys the
+		// Scene envelope does not know (outputs, resultUrl) ride through untouched.
+		return { ...node, data: { ...node.data, ...patch, ...applyCozyScenePatch(node.data, patch) } };
+	})), [setNodes]);
 	const flowRef = useRef(null);
 	const addNode = useCallback((type, model = null, { position: at, data } = {}) => {
 		const id = `${type}-${Date.now()}`;
@@ -551,6 +556,16 @@ export default function WorkflowBuilder() {
 		try { const frame = await captureSceneFrame(id); updateScene({ id, patch: { status: "complete", statusMessage: "Captured framing PNG", preview: "render", lastOutput: { renderUrl: frame.dataUrl, sceneUrl: "/app/", jobId: null, meta: frame.meta ?? null, references: Array.isArray(frame.references) ? frame.references : [] }, outputs: [{ value: frame.dataUrl }], resultUrl: frame.dataUrl } }); toast.success("Scene frame captured"); }
 		catch (error) { updateScene({ id, patch: { status: "error", errorMsg: error.message, statusMessage: error.message } }); }
 	}, [updateScene]);
+	// The previs is a step, not a destination: this is the one click from the
+	// staged shot to the clip it is meant to become, wired render -> input so the
+	// next Run hands the captured frame straight to the video model.
+	const sendSceneToVideo = useCallback(({ id }) => {
+		const scene = nodes.find((entry) => entry.id === id);
+		const origin = scene?.position || { x: 0, y: 0 };
+		const videoId = addNode("video", { id: "video-generation", name: "Video generation" }, { position: { x: origin.x + 380, y: origin.y } });
+		setEdges((current) => addEdge({ id: `e-${id}-${videoId}`, source: id, target: videoId, sourceHandle: "render", targetHandle: "input", animated: true, style: { stroke: "#8994ff", strokeWidth: 2 } }, current));
+		toast.success("Video node connected to the Scene render");
+	}, [addNode, nodes, setEdges]);
 
 	const decoratedNodes = useMemo(() => nodes.map((node) => ({
 		...node,
@@ -562,11 +577,11 @@ export default function WorkflowBuilder() {
 			...(node.type === "scene" ? { characters: sceneCharacters, sceneId: sceneContext.id, sceneName: sceneContext.name } : {}),
 			onChange: updateNode,
 			onModelChange: changeModel,
-			...(node.type === "scene" ? { onSceneChange: updateScene, onSceneRun: runScene } : { onRun: runWorkflow }),
+			...(node.type === "scene" ? { onSceneChange: updateScene, onSceneRun: runScene, onSceneVideo: sendSceneToVideo } : { onRun: runWorkflow }),
 			...(node.type === "upload" ? { onUpload: uploadFile } : {}),
 			...(node.type === "image" ? { onUseAsReference: useVersionAsReference } : {}),
 		},
-	})), [changeModel, nodeSchemas, nodes, runScene, runWorkflow, sceneCharacters, sceneContext, updateNode, updateScene, uploadFile, useVersionAsReference]);
+	})), [changeModel, nodeSchemas, nodes, runScene, runWorkflow, sceneCharacters, sceneContext, sendSceneToVideo, updateNode, updateScene, uploadFile, useVersionAsReference]);
 
 	const exportGraph = useCallback(() => { const blob = new Blob([JSON.stringify(graph, null, 2)], { type: "application/json" }); const url = URL.createObjectURL(blob); const anchor = document.createElement("a"); anchor.href = url; anchor.download = "cozyclay-workflow.json"; anchor.click(); URL.revokeObjectURL(url); toast.success("Workflow exported"); }, [graph]);
 	const onConnect = useCallback((params) => {

--- a/src/workflow/cozy-scene-node.css
+++ b/src/workflow/cozy-scene-node.css
@@ -28,16 +28,27 @@
 .cozy-scene-live-frame { position: absolute; top: 0; left: 0; width: 200%; height: 200%; transform: scale(.5); transform-origin: 0 0; border: 0; background: #111722; }
 .cozy-scene-world-image { position: absolute; inset: 0; background-image: url("/media/cozyclay-demo-poster.jpg"); background-position: left center; background-repeat: no-repeat; background-size: auto 250%; filter: saturate(.78) brightness(.82); }
 .cozy-scene-world-tint { position: absolute; inset: 0; background: linear-gradient(180deg, rgba(9, 15, 22, .04), rgba(9, 15, 22, .62)); pointer-events: none; }
-.cozy-scene-render { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; background: #111722; }
+/* The captured frame is evidence of the last Run, not the preview itself: it
+ * sits in the corner of the live previs so Play still has something to move. */
+.cozy-scene-render-thumb { position: absolute; bottom: 8px; left: 8px; width: 76px; margin: 0; overflow: hidden; border: 1px solid #3c4b5d; border-radius: 5px; background: #111722; box-shadow: 0 4px 10px rgba(0, 0, 0, .34); }
+.cozy-scene-render-thumb img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+.cozy-scene-render-thumb figcaption { padding: 2px 5px; color: #9eb0c2; font-size: 9px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; background: rgba(18, 23, 34, .86); }
 .cozy-scene-grid { position: absolute; inset: 45% -25% -55%; transform: perspective(80px) rotateX(58deg); background: repeating-linear-gradient(90deg, transparent 0 19px, rgba(133, 180, 218, .18) 20px 21px), repeating-linear-gradient(0deg, transparent 0 17px, rgba(133, 180, 218, .14) 18px 19px); }
 .cozy-scene-stage-mark { position: absolute; top: 25px; left: 50%; width: 78px; height: 78px; transform: translateX(-50%) rotate(45deg); border: 2px solid rgba(180, 215, 241, .72); border-radius: 8px; background: rgba(121, 183, 232, .18); }
 .cozy-scene-stage-mark span { position: absolute; width: 8px; height: 8px; border: 1px solid #c3e5ff; border-radius: 50%; background: #527c9d; }.cozy-scene-stage-mark span:nth-child(1) { top: -5px; left: -5px; }.cozy-scene-stage-mark span:nth-child(2) { top: -5px; right: -5px; }.cozy-scene-stage-mark span:nth-child(3) { right: -5px; bottom: -5px; }
-.cozy-scene-preview-copy { position: absolute; right: 10px; bottom: 8px; display: grid; gap: 1px; color: #d7e4ef; text-align: right; }.cozy-scene-preview-copy span { color: #9eb0c2; font-size: 10px; }
-.cozy-scene-controls { display: grid; gap: 8px; padding: 11px 13px 9px; }.cozy-scene-control-row { display: flex; gap: 6px; }.cozy-scene-button, .cozy-scene-send, .cozy-scene-run, .cozy-scene-camera-row button { padding: 5px 8px; border: 1px solid #465668; border-radius: 5px; color: #d8e5f0; background: #2c3846; font: inherit; cursor: pointer; }.cozy-scene-button:hover, .cozy-scene-camera-row button:hover { background: #344658; }.cozy-scene-run { margin-left: auto; border-color: #5f96c3; background: #35658c; }.cozy-scene-run:disabled, .cozy-scene-send:disabled { cursor: wait; opacity: .7; }
+/* The copy now sits over a live render instead of a dimmed still, so it needs
+ * its own scrim to stay readable when the shot points at a bright set. */
+.cozy-scene-preview-copy { position: absolute; right: 8px; bottom: 8px; display: grid; gap: 1px; padding: 4px 7px; border-radius: 5px; background: rgba(18, 23, 34, .78); color: #d7e4ef; text-align: right; }.cozy-scene-preview-copy strong { font-size: 11px; }.cozy-scene-preview-copy span { color: #9eb0c2; font-size: 10px; }
+.cozy-scene-controls { display: grid; gap: 8px; padding: 11px 13px 9px; }.cozy-scene-control-row { display: flex; gap: 6px; }.cozy-scene-button, .cozy-scene-send, .cozy-scene-video, .cozy-scene-run, .cozy-scene-camera-row button { padding: 5px 8px; border: 1px solid #465668; border-radius: 5px; color: #d8e5f0; background: #2c3846; font: inherit; cursor: pointer; }.cozy-scene-button:hover, .cozy-scene-camera-row button:hover { background: #344658; }.cozy-scene-run { margin-left: auto; border-color: #5f96c3; background: #35658c; }.cozy-scene-run:disabled, .cozy-scene-send:disabled { cursor: wait; opacity: .7; }
 /* "Send to AI" hands the shot off rather than rendering it: same control
  * weight as Play/Open Studio, tinted with the node's accent so the export
  * reads as the secondary action next to the primary Run. */
 .cozy-scene-send { border-color: #4d6c88; color: #cfe6f8; background: #2a4256; }.cozy-scene-send:hover:not(:disabled) { background: #33506a; }
+/* The previs exists to become a clip, so the hand-off carries the same accent
+ * as "Send to AI" and keeps its own row with the line that explains it. */
+.cozy-scene-handoff { display: flex; align-items: center; gap: 8px; }
+.cozy-scene-video { flex: none; border-color: #4d6c88; color: #cfe6f8; background: #2a4256; }.cozy-scene-video:hover { background: #33506a; }
+.cozy-scene-hint { margin: 0; color: #8799aa; font-size: 10px; line-height: 1.3; }
 .cozy-scene-frame-control { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 7px; color: #acbbc9; font-size: 10px; }.cozy-scene-frame-control input { width: 100%; accent-color: #79b7e8; }.cozy-scene-frame-control output { min-width: 40px; color: #dce7f1; font-family: ui-monospace, monospace; text-align: right; }
 .cozy-scene-camera-row { display: flex; align-items: center; justify-content: center; gap: 8px; color: #9eafbf; font-size: 10px; }.cozy-scene-camera-row button { padding: 2px 7px; }
 .cozy-scene-node-footer { border-top: 1px solid #33404e; color: #8799aa; font-size: 10px; }.cozy-scene-node-footer span + span { margin-left: auto; }

--- a/src/workflow/cozy-scene-node.js
+++ b/src/workflow/cozy-scene-node.js
@@ -78,6 +78,28 @@ export function sceneInputsFromEdges(edges, sceneNodeId) {
 	return { assetInputs, motionInputs };
 }
 
+/** The embedded Studio announces the take it holds under this message type. */
+export const SCENE_TIMELINE_MESSAGE = "cozyclay:scene-timeline";
+
+/**
+ * Turn an embed timeline announcement into the patch it implies for a node.
+ *
+ * Returns null when the message is not one of ours, carries no usable length,
+ * or already matches the node: the caller can then skip the state write, which
+ * keeps a chatty embed from re-rendering the canvas on every frame.
+ */
+export function sceneTimelinePatch(data, message) {
+	if (!message || typeof message !== "object" || message.type !== SCENE_TIMELINE_MESSAGE) return null;
+	const announced = Number(message.frameCount);
+	if (!Number.isFinite(announced) || announced < 1) return null;
+	const current = normalizeCozySceneData(data);
+	const frameCount = Math.round(announced);
+	if (frameCount === current.frameCount) return null;
+	// A shorter take must also pull the playhead back inside it, or the slider
+	// would report a frame the previs cannot show.
+	return { frameCount, frame: Math.min(current.frame, frameCount - 1) };
+}
+
 export const COZY_SCENE_OUTPUTS = Object.freeze([
 	{ id: "render", label: "Render", kind: "render" },
 	{ id: "scene", label: "Scene", kind: "scene" },

--- a/test/qa-scene-playback-browser.mjs
+++ b/test/qa-scene-playback-browser.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// Browser contract for Play on the Workflow Scene node (#218). The reported
+// bug is that a Scene node which has already been rendered shows a still frame
+// and a ticking counter while nothing on screen moves, so the assertions here
+// are pixels, not state: the node preview has to change between two captures
+// while it is playing, and has to be byte-identical between two captures once
+// it is paused — before a Run and, the part that regressed, after one. The run
+// finishes on the hand-off the previs exists for: the Scene node's "→ Video"
+// control has to add a Video node and wire the render output into it.
+//
+// Run: `CCLAY_KIMODO_HOST= COZYCLAY_LIVE_PORT=5399 npm run dev -- --port 5398`
+// in one shell, then
+// `QA_URL=http://127.0.0.1:5398/workflow/ CDP_PORT=9418 node tools/qa-browser.mjs -- node test/qa-scene-playback-browser.mjs`
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+
+const cdpPort = Number(process.env.CDP_PORT || 9418);
+const out = process.env.QA_OUT || "/tmp/scene-playback-qa";
+const targets = await (await fetch(`http://127.0.0.1:${cdpPort}/json`)).json();
+const page = targets.find((target) => target.type === "page" && target.url.includes("/workflow/")) || targets.find((target) => target.type === "page");
+assert.ok(page, "workflow page is not open");
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let seq = 0;
+const pending = new Map();
+ws.onmessage = (event) => {
+	const message = JSON.parse(event.data);
+	if (!message.id || !pending.has(message.id)) return;
+	const item = pending.get(message.id);
+	pending.delete(message.id);
+	if (message.error) item.reject(new Error(JSON.stringify(message.error)));
+	else item.resolve(message.result);
+};
+const send = (method, params = {}) => new Promise((resolve, reject) => { const id = ++seq; pending.set(id, { resolve, reject }); ws.send(JSON.stringify({ id, method, params })); });
+const evaluate = async (expression, timeoutMs = 180000) => {
+	const result = await send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true, timeout: timeoutMs });
+	if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || "browser evaluation failed");
+	return result.result?.value;
+};
+const waitFor = async (label, probe, timeoutMs = 90000) => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const value = await probe().catch(() => null);
+		if (value) return value;
+		await new Promise((resolve) => setTimeout(resolve, 120));
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+};
+const rectOf = (selector) => evaluate(`(() => { const el = document.querySelector(${JSON.stringify(selector)}); if (!el) return null; const r = el.getBoundingClientRect(); return { x: r.left, y: r.top, width: r.width, height: r.height }; })()`);
+const clickSelector = async (selector) => {
+	const rect = await rectOf(selector);
+	assert.ok(rect && rect.width > 0, `no element matches ${selector}`);
+	const x = Math.round(rect.x + rect.width / 2);
+	const y = Math.round(rect.y + rect.height / 2);
+	for (const type of ["mousePressed", "mouseReleased"]) await send("Input.dispatchMouseEvent", { type, x, y, button: "left", clickCount: 1, buttons: type === "mousePressed" ? 1 : 0 });
+};
+// The preview element, not the whole page: a full-page capture also carries the
+// frame readout and the toast layer, both of which change while playing and
+// would make "the picture moved" pass without a single moving pixel.
+const capturePreview = async () => {
+	const rect = await rectOf(".cozy-scene-node .cozy-scene-preview");
+	assert.ok(rect && rect.width > 0, "the Scene node has no preview element");
+	const shot = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: false, clip: { x: rect.x, y: rect.y, width: rect.width, height: rect.height, scale: 1 } });
+	return Buffer.from(shot.data, "base64");
+};
+// The studio's QA hook is rebuilt on tlFrame, so the playhead it reports is
+// live; its `playing` flag is a snapshot from an older render and is not. Both
+// waits below therefore read motion off the playhead itself.
+const embedState = () => evaluate(`(() => {
+	const frame = document.querySelector('.cozy-scene-node iframe');
+	const live = frame && frame.contentWindow && frame.contentWindow.__cozyclay;
+	return live ? { frame: live.tlFrame, frameCount: live.frameCount } : null;
+})()`);
+const playhead = async () => (await embedState())?.frame ?? null;
+const rolling = async (label) => {
+	const start = await playhead();
+	return waitFor(label, async () => {
+		const frame = await playhead();
+		return frame !== null && frame !== start ? frame : null;
+	}, 20000);
+};
+const settled = async () => {
+	// Pause is asserted on identical bytes, so the capture pair must start after
+	// everything in the frame has stopped: the same playhead twice in a row, the
+	// node's own transport reporting paused, and no studio toast still on screen
+	// (those come and go on their own and are not the preview moving).
+	let previous = null;
+	return waitFor("the embedded Studio to settle on a paused frame", async () => {
+		const quiet = await evaluate(`(() => {
+			const button = document.querySelector('.cozy-scene-node .cozy-scene-button');
+			const embedded = document.querySelector('.cozy-scene-node iframe');
+			const inner = embedded && embedded.contentDocument;
+			return !!inner && button.getAttribute('aria-pressed') === 'false' && !inner.querySelector('.toast');
+		})()`);
+		const frame = await playhead();
+		if (!quiet || frame === null) { previous = null; return null; }
+		const stable = previous !== null && previous === frame;
+		previous = frame;
+		return stable ? { frame } : null;
+	});
+};
+const after = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+await mkdir(out, { recursive: true });
+
+// A four-second camera move: the previs has to have something to show, and the
+// take is deliberately not 120 frames, so the node's frame readout can only be
+// right if it follows the embed instead of the old placeholder length.
+const sceneDocument = {
+	version: 4,
+	activeSceneId: "scene-playback-qa",
+	scenes: [{
+		id: "scene-playback-qa",
+		name: "PLAYBACK QA",
+		objects: [],
+		shotDocument: {
+			version: 4,
+			frameCount: 96,
+			shots: [{
+				id: "playback-qa-shot",
+				name: "Playback QA orbit",
+				startFrame: 0,
+				endFrame: 95,
+				camera: { mode: "keys" },
+				cameraKeys: [
+					{ id: "playback-qa-key-a", frame: 0, framing: { pos: { x: -2.4, y: 1.7, z: 4.2 }, yaw: 0.5, pitch: -0.08, fovDeg: 45 } },
+					{ id: "playback-qa-key-b", frame: 95, framing: { pos: { x: 2.4, y: 1.4, z: 2.1 }, yaw: -0.6, pitch: -0.16, fovDeg: 32 } },
+				],
+			}],
+			waypoints: [],
+		},
+		stage: {
+			characters: [{ id: "char-a", model: "y-bot-tpose", x: 0, z: 0, rot: 0, hidden: false, pose: null, subject: "a person" }],
+			hasCharSheet: false,
+			shotAspect: "16:9",
+		},
+	}],
+};
+const graph = {
+	version: 1,
+	nodes: [{ id: "scene-qa", type: "scene", position: { x: 120, y: 120 }, data: { label: "CozyClay Scene", sceneName: "CozyClay Scene", status: "idle", preview: "scene" } }],
+	edges: [],
+};
+
+await evaluate(`(() => {
+	localStorage.setItem("cozyclay.locale", "en");
+	localStorage.setItem("cozyclay.project-session.v1", JSON.stringify({ name: "QA", updatedAt: Date.now() }));
+	localStorage.setItem("cozyclay.scenes.v4", ${JSON.stringify(JSON.stringify(sceneDocument))});
+	localStorage.setItem("cozyclay.workflow.v1", ${JSON.stringify(JSON.stringify(graph))});
+})(), true`);
+// Reload on the seeded storage, and wait for the document the assertions run
+// against rather than racing the navigation with a poll.
+await send("Page.enable");
+const reloaded = new Promise((resolve) => {
+	const onMessage = (event) => {
+		if (JSON.parse(event.data).method !== "Page.loadEventFired") return;
+		ws.removeEventListener("message", onMessage);
+		resolve();
+	};
+	ws.addEventListener("message", onMessage);
+});
+await send("Page.reload", { ignoreCache: true });
+await reloaded;
+
+await waitFor("the workflow canvas", () => evaluate("!!document.querySelector('.react-flow__node')"));
+const hasScene = await waitFor("the canvas to settle", () => evaluate("document.querySelector('.cozy-scene-node') ? 'scene' : 'none'"), 20000);
+if (hasScene === "none") {
+	await clickSelector(".workflow-canvas-panel button");
+	await waitFor("a Scene node on the canvas", () => evaluate("!!document.querySelector('.cozy-scene-node')"));
+	console.log("PASS the canvas had no Scene node, so one was added");
+}
+await waitFor("the node's embedded Studio", () => evaluate(`(() => {
+	const frame = document.querySelector('.cozy-scene-node iframe');
+	const live = frame && frame.contentWindow && frame.contentWindow.__cozyclay;
+	return !!(live && live.rigA);
+})()`));
+console.log(`PASS the Scene node came up with its embedded Studio (${JSON.stringify(await embedState())})`);
+
+// The take is the embed's, not a guess: the seeded shot is 96 frames and the
+// studio stretches it to fit the cast's motion, so the only length the node can
+// report correctly is the one the embed announces.
+const timeline = await waitFor("the frame readout to follow the embedded take", async () => {
+	const state = await embedState();
+	const text = await evaluate("document.querySelector('.cozy-scene-node .cozy-scene-frame-control output').textContent");
+	return state && text === `0/${state.frameCount - 1}` ? { text, frameCount: state.frameCount } : null;
+}, 30000);
+assert.notEqual(timeline.frameCount, 120, "the embedded take must differ from the node's placeholder length for this to prove anything");
+console.log(`PASS the frame readout matches the embedded take: ${timeline.text}`);
+
+// 1. Play before a Run: the un-rendered node has always shown the live embed,
+// so this is the reference behaviour the rendered node has to match.
+await clickSelector(".cozy-scene-node .cozy-scene-button");
+await rolling("the embed to start playing");
+const beforeA = await capturePreview();
+await after(400);
+const beforeB = await capturePreview();
+await writeFile(`${out}/before-run-playing-a.png`, beforeA);
+await writeFile(`${out}/before-run-playing-b.png`, beforeB);
+assert.ok(!beforeA.equals(beforeB), "the preview has to move while playing before a Run");
+console.log(`PASS Play animates the preview before a Run (${beforeA.length} vs ${beforeB.length} bytes)`);
+await clickSelector(".cozy-scene-node .cozy-scene-button");
+await settled();
+
+// 2. Run: the node captures a framing PNG and reports it as its render.
+await clickSelector(".cozy-scene-node .cozy-scene-run");
+const status = await waitFor("the render to complete", async () => {
+	const text = await evaluate("document.querySelector('.cozy-scene-node .cozy-scene-node-status').textContent");
+	return text === "Render complete" ? text : null;
+});
+console.log(`PASS Run reports: ${JSON.stringify(status)}`);
+assert.ok(await evaluate("!!document.querySelector('.cozy-scene-node iframe')"), "the live previs stays mounted after a Run");
+assert.ok(await evaluate("!!document.querySelector('.cozy-scene-node .cozy-scene-render-thumb')"), "the captured frame is shown next to the live previs");
+console.log("PASS after a Run the node keeps the live previs and shows the captured frame beside it");
+
+// 3. Play after a Run: this is #218 — same pixels moving, same node.
+await clickSelector(".cozy-scene-node .cozy-scene-button");
+await rolling("the embed to start playing again");
+const playingA = await capturePreview();
+await after(400);
+const playingB = await capturePreview();
+await writeFile(`${out}/playing-a.png`, playingA);
+await writeFile(`${out}/playing-b.png`, playingB);
+assert.ok(!playingA.equals(playingB), "the rendered node's preview has to move while playing (#218)");
+console.log(`PASS Play animates the preview after a Run (${playingA.length} vs ${playingB.length} bytes)`);
+
+// 4. Pause: the same two captures have to come back identical.
+await clickSelector(".cozy-scene-node .cozy-scene-button");
+const paused = await settled();
+const pausedA = await capturePreview();
+await after(400);
+const pausedB = await capturePreview();
+await writeFile(`${out}/paused.png`, pausedA);
+assert.ok(pausedA.equals(pausedB), "a paused preview must not move");
+console.log(`PASS Pause stops the preview at frame ${paused.frame} (${pausedA.length} identical bytes)`);
+
+// 5. The hand-off the previs exists for.
+const before = await evaluate("({ nodes: document.querySelectorAll('.react-flow__node').length, edges: document.querySelectorAll('.react-flow__edge').length })");
+await clickSelector(".cozy-scene-node .cozy-scene-video");
+const linked = await waitFor("the new Video node and its edge", async () => {
+	const now = await evaluate("({ nodes: document.querySelectorAll('.react-flow__node').length, edges: document.querySelectorAll('.react-flow__edge').length, video: document.querySelectorAll('.workflow-node-video').length })");
+	return now.nodes === before.nodes + 1 && now.edges === before.edges + 1 ? now : null;
+});
+assert.ok(linked.video >= 1, "the added node is a Video node");
+// The drawn edge is only half the claim: the saved graph has to carry the
+// render -> input wiring a later Run reads.
+const saved = await waitFor("the wired graph to be saved", async () => {
+	const graphJson = await evaluate("localStorage.getItem('cozyclay.workflow.v1')");
+	const parsed = JSON.parse(graphJson || "{}");
+	const edge = (parsed.edges || [])[0];
+	return edge ? { edge, video: (parsed.nodes || []).find((node) => node.id === edge.target) } : null;
+}, 15000);
+assert.equal(saved.edge.sourceHandle, "render", "the edge leaves the Scene node's render output");
+assert.equal(saved.edge.targetHandle, "input", "the edge enters the Video node's input");
+assert.equal(saved.video?.type, "video", "the connected node is a Video node");
+console.log(`PASS → Video added a Video node and connected it (${JSON.stringify({ ...linked, edge: `${saved.edge.source}:${saved.edge.sourceHandle} -> ${saved.edge.target}:${saved.edge.targetHandle}` })})`);
+await writeFile(`${out}/video-node.png`, Buffer.from((await send("Page.captureScreenshot", { format: "png" })).data, "base64"));
+
+console.log(`PASS qa-scene-playback-browser: ${out}/{before-run-playing-a,before-run-playing-b,playing-a,playing-b,paused,video-node}.png`);
+ws.close();
+process.exit(0);

--- a/test/verify-cozy-scene-node.mjs
+++ b/test/verify-cozy-scene-node.mjs
@@ -14,6 +14,8 @@ import {
 	sceneInputSpecs,
 	sceneInputsFromEdges,
 	sceneConnectionAllowed,
+	sceneTimelinePatch,
+	SCENE_TIMELINE_MESSAGE,
 	toCozySceneRunRequest,
 } from "../src/workflow/cozy-scene-node.js";
 
@@ -25,6 +27,19 @@ assert.match(componentSource, /publishScenePlayback/);
 assert.match(componentSource, /window\.setTimeout/);
 assert.match(previewStyle, /cozy-scene-live-frame/);
 assert.doesNotMatch(componentSource, /<boxGeometry/);
+// #218: a finished render is a thumbnail beside the live previs, never a still
+// image in place of it — Play has to have something left to move.
+assert.doesNotMatch(componentSource, /className="cozy-scene-render"/);
+assert.match(componentSource, /cozy-scene-render-thumb/);
+assert.match(previewStyle, /\.cozy-scene-render-thumb/);
+assert.match(componentSource, /sceneTimelinePatch/);
+assert.match(componentSource, /className="cozy-scene-video"/);
+assert.match(componentSource, /cozy-scene-hint/);
+{
+	const builder = readFileSync(new URL("../src/workflow/WorkflowBuilder.jsx", import.meta.url), "utf8");
+	assert.match(builder, /onSceneVideo: sendSceneToVideo/, "the Scene node reaches the builder's Video action through decorated data");
+	assert.match(builder, /sourceHandle: "render", targetHandle: "input"/, "the added Video node is fed by the Scene render output");
+}
 
 const defaults = normalizeCozySceneData({ sceneName: 42, frame: "bad", controls: { camera: { yaw: "35" } } });
 assert.equal(defaults.type, COZY_SCENE_NODE_TYPE);
@@ -48,6 +63,16 @@ assert.deepEqual(sceneInputsFromEdges([
 	assetInputs: ["image-1"],
 	motionInputs: [{ source: "motion-1", handle: "character:char-a", characterId: "char-a" }],
 });
+
+// The take length comes from the embedded Studio, so the slider and the node's
+// own preview clock stop where the previs does (#218).
+assert.equal(SCENE_TIMELINE_MESSAGE, "cozyclay:scene-timeline");
+assert.deepEqual(sceneTimelinePatch({ frameCount: 120, frame: 110 }, { type: SCENE_TIMELINE_MESSAGE, frameCount: 96 }), { frameCount: 96, frame: 95 });
+assert.deepEqual(sceneTimelinePatch({ frameCount: 120, frame: 10 }, { type: SCENE_TIMELINE_MESSAGE, frameCount: 240 }), { frameCount: 240, frame: 10 });
+assert.equal(sceneTimelinePatch({ frameCount: 96 }, { type: SCENE_TIMELINE_MESSAGE, frameCount: 96 }), null, "an unchanged length writes no state");
+assert.equal(sceneTimelinePatch({ frameCount: 96 }, { type: "cozyclay:capture-framing-result", frameCount: 12 }), null, "other frame messages are ignored");
+assert.equal(sceneTimelinePatch({ frameCount: 96 }, { type: SCENE_TIMELINE_MESSAGE, frameCount: 0 }), null, "an empty take is not a length");
+assert.equal(sceneTimelinePatch({ frameCount: 96 }, null), null);
 
 const changed = applyCozyScenePatch(defaults, { frame: 14, controls: { playing: true, camera: { pitch: -8 } }, assetInputs: ["asset-1"] });
 assert.equal(changed.frame, 14);
@@ -80,5 +105,6 @@ console.log("cozy scene node adapter checks passed");
 	const app = readFileSync(new URL("../src/App.jsx", import.meta.url), "utf8");
 	assert.match(app, /useState\(embedMode\)/, "lookThroughShot defaults to the embed mode");
 	assert.match(app, /if \(!lookThroughShot \|\| embedMode\) return undefined;/, "Escape does not leave the shot view inside the embed");
+	assert.match(app, /type: "cozyclay:scene-timeline", activeSceneId, frameCount: tlFrameCount/, "the embed announces the take length the Scene node reads");
 	console.log("PASS embedded Studio previews through the shot camera");
 }

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -193,6 +193,7 @@ const BROWSER_FILES = [
 	"test/qa-keyframe-pack-browser.mjs",
 	"test/qa-preview-browser.mjs",
 	"test/qa-reference-slots-browser.mjs",
+	"test/qa-scene-playback-browser.mjs",
 	"test/qa-scene-switcher-browser.mjs",
 	"test/qa-send-to-ai-browser.mjs",
 	"test/qa-view-menu-browser.mjs",
@@ -201,7 +202,7 @@ const BROWSER_FILES = [
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-agent-view-toggle-browser.mjs", "test/qa-camera-tutorial-browser.mjs", "test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-agent-view-toggle-browser.mjs", "test/qa-camera-tutorial-browser.mjs", "test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-playback-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
# Summary

After a Run, the Scene node replaced its live embed preview with the static captured PNG, so pressing Play had nothing left to animate: the preview clock only ticked while the embed was showing, and the frame slider guessed the take length, running past the end of a shorter shot. The Scene node now keeps the live previs alive after a Run (the captured frame is shown beside it as "LAST RENDER"), the embed announces the take it actually holds (scene id, frame count, fps) on load and whenever the scene or its length changes, and the node follows that announcement, so Play animates the real previs before and after a Run, and Pause freezes it frame-accurately. `-> Video` now also adds a Video node wired to the Scene node's render output.

# Changes

- `src/App.jsx` — embed mode now posts a `cozyclay:scene-timeline` message with the active scene id, frame count and fps on load and whenever the scene or its length changes.
- `src/workflow/CozySceneNode.jsx` — keeps the live previs running after a Run (captured frame shown beside it), subscribes to the embed's scene-timeline announcement instead of guessing take length, and adds the `-> Video` action that creates a Video node connected to the Scene node's render output.
- `src/workflow/WorkflowBuilder.jsx` — wires the new Scene→Video node creation and edge connection.
- `src/workflow/cozy-scene-node.js` — adapter/schema updates for the scene-timeline state and Video link.
- `src/workflow/cozy-scene-node.css` — styles for the kept-live previs + "LAST RENDER" capture card layout.
- `test/qa-scene-playback-browser.mjs` — browser QA script: Play animates before and after a Run, Pause freezes frame-identical output, `-> Video` adds and connects a Video node.
- `test/verify-cozy-scene-node.mjs` — node adapter checks, including that the embedded Studio previews through the shot camera.
- `tools/run-tests.mjs` — registers the new verification files in the node test suite.

# QA evidence

QA script (`QA_OUT=/tmp/scene-playback-qa-verify QA_URL=http://127.0.0.1:5396/workflow/ CDP_PORT=9416 node tools/qa-browser.mjs -- node test/qa-scene-playback-browser.mjs`, exit 0) stdout:

```
PASS the Scene node came up with its embedded Studio ({"frame":0,"frameCount":96})
PASS the frame readout matches the embedded take: 0/95
PASS Play animates the preview before a Run (30680 vs 30507 bytes)
PASS Run reports: "Render complete"
PASS after a Run the node keeps the live previs and shows the captured frame beside it
PASS Play animates the preview after a Run (40551 vs 40366 bytes)
PASS Pause stops the preview at frame 30 (40227 identical bytes)
PASS → Video added a Video node and connected it ({"nodes":2,"edges":1,"video":1,"edge":"scene-qa:render -> video-1789074024524:input"})
PASS qa-scene-playback-browser: /tmp/scene-playback-qa-verify/{before-run-playing-a,before-run-playing-b,playing-a,playing-b,paused,video-node}.png
```

Screenshots (all under `/tmp/scene-playback-qa-verify/`):

- `playing-a.png` / `playing-b.png` — the Scene node preview mid-playback after a Run: a real 3D previs (floor grid and horizon) with a "Live previs / Captured framing PNG" overlay and a "LAST RENDER" capture card beside it; the camera has visibly moved between the two frames, so the live preview is animating.
- `paused.png` — the same live previs frozen when Play is paused: the preview shows the 3D scene held at the paused frame.
- `video-node.png` — the full workflow canvas after clicking `-> Video`: the "PLAYBACK QA" Scene node (badge "Render complete") with a new Video node on the canvas, connected to the Scene node's render output by a dashed edge (toast: "Video node connected to the Scene render").

# Tests

`node test/verify-cozy-scene-node.mjs` (exit 0):

```
cozy scene node adapter checks passed
PASS embedded Studio previews through the shot camera
```

`npm run build && node tools/run-tests.mjs` (exit 0), final summary line:

```
PASS 165 Node verification files
```

Closes #218
