### PR TITLE
feat(kimodo): hardware-aware install router for setup-on-box.sh (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ https://github.com/user-attachments/assets/1d0113e5-6922-443d-affc-1bdabc666247
 - Node.js 22.13 or newer
 - npm, or bun
 - A Chromium-based browser
-- An SSH-accessible NVIDIA machine running Kimodo, for motion generation — run `npm run kimodo:setup` once; the first setup downloads the Kimodo checkpoint and text-encoder stack. The same box runs GVHMR for video and photo mocap (`CCLAY_EXTRACT_BACKEND=gvhmr` is the default; there is no browser fallback).
+- A machine running Kimodo, for motion generation — run `npm run kimodo:setup` once; the installer detects the host and picks the best-supported backend (see the route table below), then downloads the matching checkpoint and text-encoder stack. An SSH-accessible NVIDIA box is the classic target; the same box runs GVHMR for video and photo mocap (`CCLAY_EXTRACT_BACKEND=gvhmr` is the default; there is no browser fallback).
 
 ## Quick start
 
@@ -82,17 +82,37 @@ That downloads the built studio and opens it at `http://127.0.0.1:5180/app/`. No
 
 A global install gives you `cclay`, the same command with less typing. Once a day the launcher checks npm for a newer release and prints a one-line notice after the studio is up; it stays quiet when you're current or offline. `cclay update` installs the latest release, and `--no-update-check` skips the check entirely.
 
-Motion generation uses Kimodo by default once you point it at an SSH-accessible NVIDIA machine:
+Motion generation uses Kimodo by default once you point it at a Kimodo host:
 
 ```bash
 CCLAY_KIMODO_HOST=user@your-gpu-box npx cozyclay
 ```
 
-Install the remote worker once:
+Install the worker once, on whichever machine should generate motion:
 
 ```bash
 CCLAY_KIMODO_HOST=user@your-gpu-box npm run kimodo:setup
+# or directly on the machine itself:
+bash tools/kimodo/setup-on-box.sh
 ```
+
+The installer is a router — it detects OS, architecture, RAM and CUDA, and installs the best-supported Kimodo variant for that host:
+
+| Host | Backend installed | Why |
+| --- | --- | --- |
+| macOS Apple Silicon, RAM > 32 GB | [kimodo-mlx](https://github.com/NomaDamas/kimodo-mlx) (MLX/Metal) | The 15 GB text encoder stays resident in unified memory: ~0.9 s warm generation vs ~37 s streaming on an M4 Max 64 GB |
+| macOS Apple Silicon, RAM ≤ 32 GB | [kimodo.cpp](https://github.com/localai-org/kimodo.cpp) + Metal (GGML) | Residency doesn't fit; streaming transformer layers from disk is the right trade |
+| Linux + working NVIDIA CUDA | [NVIDIA Kimodo](https://github.com/nv-tlabs/kimodo) (PyTorch) | Full CUDA acceleration with the upstream stack |
+| Other Unix, no CUDA | kimodo.cpp CPU (Vulkan when available) | Local GGML execution without a GPU |
+
+Inspect the route without changing anything — and override it when you know better:
+
+```bash
+bash tools/kimodo/setup-on-box.sh --dry-run
+bash tools/kimodo/setup-on-box.sh --backend kimodo.cpp-metal   # or CCLAY_KIMODO_BACKEND=...
+```
+
+The RAM threshold between the two macOS routes defaults to 32 GB (`CCLAY_KIMODO_MLX_MIN_RAM_GB`).
 
 ## AI control (MCP)
 

--- a/test/verify-kimodo-setup.mjs
+++ b/test/verify-kimodo-setup.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 const setup = readFileSync(new URL("../tools/kimodo/setup-on-box.sh", import.meta.url), "utf8");
 const wrapper = readFileSync(new URL("../tools/kimodo/setup-local.mjs", import.meta.url), "utf8");
@@ -28,4 +29,72 @@ assert.match(edit, /edit_range: \[plan\.startFrame, plan\.endFrame\]/);
 assert.match(edit, /history_range:/);
 assert.match(edit, /future_range:/);
 assert.doesNotMatch(edit, /edited_range/);
+// --- install router: the dry-run route table -------------------------------
+// The router picks a backend from detected OS/arch/RAM/CUDA; the detection
+// inputs are env-overridable so the whole table runs offline in a dry-run.
+const SCRIPT = new URL("../tools/kimodo/setup-on-box.sh", import.meta.url).pathname;
+
+function dryRun(env = {}, args = []) {
+	const clean = { ...process.env };
+	for (const key of Object.keys(clean)) {
+		if (key.startsWith("CCLAY_KIMODO_")) delete clean[key];
+	}
+	const r = spawnSync("bash", [SCRIPT, "--dry-run", ...args], {
+		env: { ...clean, ...env },
+		encoding: "utf8",
+	});
+	return { status: r.status, out: r.stdout + r.stderr };
+}
+
+const detect = (os, arch, ramGb, cuda) => ({
+	CCLAY_KIMODO_DETECT_OS: os,
+	CCLAY_KIMODO_DETECT_ARCH: arch,
+	CCLAY_KIMODO_DETECT_RAM_GB: String(ramGb),
+	CCLAY_KIMODO_DETECT_CUDA: String(cuda),
+});
+
+let r = dryRun(detect("Darwin", "arm64", 64, 0));
+assert.equal(r.status, 0, r.out);
+assert.match(r.out, /backend=kimodo-mlx/);
+assert.match(r.out, /NomaDamas\/kimodo-mlx\.git/);
+assert.match(r.out, /Llama-3-Kimodo-GGML/);
+
+// At or below the 32 GB threshold the encoder cannot stay resident: stream.
+r = dryRun(detect("Darwin", "arm64", 32, 0));
+assert.equal(r.status, 0, r.out);
+assert.match(r.out, /backend=kimodo\.cpp-metal/);
+assert.match(r.out, /KIMODO_ENABLE_METAL=ON/);
+assert.match(r.out, /0001-kimodo-ggml-metal\.patch/);
+r = dryRun(detect("Darwin", "arm64", 16, 0));
+assert.match(r.out, /backend=kimodo\.cpp-metal/);
+
+r = dryRun(detect("Linux", "x86_64", 128, 1));
+assert.equal(r.status, 0, r.out);
+assert.match(r.out, /backend=nvidia-cuda/);
+assert.match(r.out, /nv-tlabs\/kimodo\.git/);
+
+r = dryRun(detect("Linux", "x86_64", 128, 0));
+assert.equal(r.status, 0, r.out);
+assert.match(r.out, /backend=kimodo\.cpp-cpu/);
+assert.match(r.out, /localai-org\/kimodo\.cpp\.git/);
+assert.doesNotMatch(r.out, /nv-tlabs/);
+
+// An Intel Mac has no MLX/Metal path: the GGML CPU build is the route.
+r = dryRun(detect("Darwin", "x86_64", 64, 0));
+assert.match(r.out, /backend=kimodo\.cpp-cpu/);
+
+// Explicit backend beats detection; a bad one is rejected by name.
+r = dryRun({ ...detect("Linux", "x86_64", 128, 1), CCLAY_KIMODO_BACKEND: "kimodo-mlx" });
+assert.match(r.out, /backend=kimodo-mlx/);
+r = dryRun(detect("Darwin", "arm64", 64, 0), ["--backend", "nvidia-cuda"]);
+assert.match(r.out, /backend=nvidia-cuda/);
+r = dryRun(detect("Darwin", "arm64", 64, 0), ["--backend", "kimodo-turbo"]);
+assert.equal(r.status, 1);
+assert.match(r.out, /unknown backend: kimodo-turbo/);
+
+// An OS with no supported route refuses with a hint instead of guessing.
+r = dryRun(detect("SunOS", "i86pc", 64, 0));
+assert.equal(r.status, 1);
+assert.match(r.out, /unsupported OS: SunOS/);
+
 console.log("OK verify-kimodo-setup");

--- a/tools/kimodo/setup-on-box.sh
+++ b/tools/kimodo/setup-on-box.sh
@@ -1,18 +1,50 @@
 #!/usr/bin/env bash
-# Provision Kimodo on a Linux/NVIDIA host used by CozyClay.
-# Run directly on the host, or through setup-local.mjs.
+# Provision the best-supported Kimodo runtime for the host this script runs on.
+# Run directly on the host, or through setup-local.mjs (which pipes it over ssh).
+#
+# The installer is a router: it detects OS / architecture / RAM / CUDA and
+# installs one of four backends, best first:
+#
+#   kimodo-mlx        macOS arm64 with > 32 GB RAM — MLX/Metal port with the
+#                     15 GB LLM2Vec encoder resident in unified memory
+#                     (measured 0.93 s warm E2E vs 37 s kimodo.cpp Metal on an
+#                     M4 Max 64 GB; see NomaDamas/kimodo-mlx README benchmarks).
+#   kimodo.cpp-metal  macOS arm64 with <= 32 GB RAM — GGML build streaming
+#                     transformer layers from disk; residency is the wrong
+#                     trade when the encoder cannot stay in memory.
+#   nvidia-cuda       Linux with a working NVIDIA GPU — the upstream PyTorch
+#                     Kimodo stack (nv-tlabs/kimodo), fully CUDA accelerated.
+#   kimodo.cpp-cpu    any other Unix — GGML CPU build, Vulkan when available.
+#
+# Detection can be overridden for tests and dry-runs:
+#   CCLAY_KIMODO_DETECT_OS, CCLAY_KIMODO_DETECT_ARCH,
+#   CCLAY_KIMODO_DETECT_RAM_GB, CCLAY_KIMODO_DETECT_CUDA (0|1)
+# The route itself is overridden with --backend or CCLAY_KIMODO_BACKEND.
 set -euo pipefail
 
 KIMODO_DIR="${CCLAY_KIMODO_REMOTE_DIR:-$HOME/.cozyclay/kimodo}"
 VENV_DIR="${CCLAY_KIMODO_VENV_DIR:-$HOME/.cozyclay/kimodo-venv}"
+MLX_DIR="${CCLAY_KIMODO_MLX_DIR:-$HOME/.cozyclay/kimodo-mlx}"
+MLX_VENV_DIR="${CCLAY_KIMODO_MLX_VENV_DIR:-$HOME/.cozyclay/kimodo-mlx-venv}"
+CPP_DIR="${CCLAY_KIMODO_CPP_DIR:-$HOME/.cozyclay/kimodo.cpp}"
+CPP_VENV_DIR="${CCLAY_KIMODO_CPP_VENV_DIR:-$HOME/.cozyclay/kimodo-cpp-venv}"
+# kimodo.cpp ref the Metal patch in NomaDamas/kimodo-mlx is known to apply to.
+CPP_METAL_REF="${CCLAY_KIMODO_CPP_METAL_REF:-568b0253}"
+MLX_MIN_RAM_GB="${CCLAY_KIMODO_MLX_MIN_RAM_GB:-32}"
+CPP_VULKAN="${CCLAY_KIMODO_CPP_VULKAN:-auto}"
 MODEL="${CCLAY_KIMODO_MODEL:-Kimodo-SOMA-RP-v1.1}"
+BACKEND="${CCLAY_KIMODO_BACKEND:-auto}"
 DRY_RUN=0
 
 usage() {
   cat <<'EOF'
-Usage: setup-on-box.sh [--kimodo-dir DIR] [--venv DIR] [--model NAME] [--dry-run]
+Usage: setup-on-box.sh [--backend NAME] [--kimodo-dir DIR] [--venv DIR]
+                       [--model NAME] [--dry-run]
 
-Installs the Kimodo runtime and prefetches its motion and text-encoder models.
+Detects the host and installs the best-supported Kimodo backend:
+kimodo-mlx, kimodo.cpp-metal, nvidia-cuda, or kimodo.cpp-cpu.
+--backend (or CCLAY_KIMODO_BACKEND) forces a route; --dry-run prints the
+detected route and every command without changing the host.
 HF_TOKEN may be present in the environment for Hugging Face access; it is never
 printed by this script.
 EOF
@@ -26,6 +58,7 @@ run() {
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --backend) [ "$#" -ge 2 ] || die "--backend needs a value"; BACKEND="$2"; shift 2 ;;
     --kimodo-dir) [ "$#" -ge 2 ] || die "--kimodo-dir needs a value"; KIMODO_DIR="$2"; shift 2 ;;
     --venv) [ "$#" -ge 2 ] || die "--venv needs a value"; VENV_DIR="$2"; shift 2 ;;
     --model) [ "$#" -ge 2 ] || die "--model needs a value"; MODEL="$2"; shift 2 ;;
@@ -35,37 +68,95 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+# --- host detection -------------------------------------------------------
+
+detect_os() {
+  if [ -n "${CCLAY_KIMODO_DETECT_OS:-}" ]; then printf '%s' "$CCLAY_KIMODO_DETECT_OS"; else uname -s; fi
+}
+detect_arch() {
+  if [ -n "${CCLAY_KIMODO_DETECT_ARCH:-}" ]; then printf '%s' "$CCLAY_KIMODO_DETECT_ARCH"; else uname -m; fi
+}
+detect_ram_gb() {
+  if [ -n "${CCLAY_KIMODO_DETECT_RAM_GB:-}" ]; then printf '%s' "$CCLAY_KIMODO_DETECT_RAM_GB"; return; fi
+  local bytes=""
+  case "$(detect_os)" in
+    Darwin) bytes=$(sysctl -n hw.memsize 2>/dev/null || true) ;;
+    Linux) bytes=$(awk '/^MemTotal:/ {print $2 * 1024}' /proc/meminfo 2>/dev/null || true) ;;
+  esac
+  [ -n "$bytes" ] || { printf '0'; return; }
+  printf '%s' $(( bytes / 1073741824 ))
+}
+detect_cuda() {
+  if [ -n "${CCLAY_KIMODO_DETECT_CUDA:-}" ]; then printf '%s' "$CCLAY_KIMODO_DETECT_CUDA"; return; fi
+  if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then printf '1'; else printf '0'; fi
+}
+
+route_backend() {
+  case "$BACKEND" in
+    auto) ;;
+    kimodo-mlx|kimodo.cpp-metal|nvidia-cuda|kimodo.cpp-cpu) printf '%s' "$BACKEND"; return ;;
+    *) die "unknown backend: $BACKEND (expected kimodo-mlx, kimodo.cpp-metal, nvidia-cuda, kimodo.cpp-cpu, or auto)" ;;
+  esac
+  local os arch ram cuda
+  os=$(detect_os); arch=$(detect_arch); ram=$(detect_ram_gb); cuda=$(detect_cuda)
+  case "$os" in
+    Darwin)
+      case "$arch" in
+        arm64)
+          # > 32 GB keeps the 15 GB encoder resident; at or below it, stream.
+          if [ "$ram" -gt "$MLX_MIN_RAM_GB" ]; then printf 'kimodo-mlx'; else printf 'kimodo.cpp-metal'; fi
+          ;;
+        *) printf 'kimodo.cpp-cpu' ;;
+      esac
+      ;;
+    Linux)
+      if [ "$cuda" = "1" ]; then printf 'nvidia-cuda'; else printf 'kimodo.cpp-cpu'; fi
+      ;;
+    *) die "unsupported OS: $os (use --backend to force a route, or run inside WSL on Windows)" ;;
+  esac
+}
+
+OS=$(detect_os); ARCH=$(detect_arch); RAM_GB=$(detect_ram_gb); CUDA=$(detect_cuda)
+BACKEND=$(route_backend)
+
 if [ "$DRY_RUN" -eq 1 ]; then
   log "dry run; no files, packages, or models will be changed"
-else
-  command -v git >/dev/null 2>&1 || die "git is required"
-  command -v python3 >/dev/null 2>&1 || die "python3 is required"
-  command -v nvidia-smi >/dev/null 2>&1 || die "an NVIDIA CUDA host is required (nvidia-smi not found)"
-  nvidia-smi >/dev/null 2>&1 || die "nvidia-smi cannot access the GPU"
 fi
+log "detected: os=$OS arch=$ARCH ram=${RAM_GB}GB cuda=$CUDA"
+log "backend=$BACKEND"
 
-if [ ! -e "$KIMODO_DIR/.git" ]; then
-  mkdir -p "$(dirname "$KIMODO_DIR")"
-  run git clone --depth 1 https://github.com/nv-tlabs/kimodo.git "$KIMODO_DIR"
-else
-  log "Kimodo checkout already exists at $KIMODO_DIR"
-fi
+# --- backends ---------------------------------------------------------------
 
-if [ ! -x "$VENV_DIR/bin/python" ]; then
-  run python3 -m venv "$VENV_DIR"
-else
-  log "Python environment already exists at $VENV_DIR"
-fi
+install_nvidia_cuda() {
+  if [ "$DRY_RUN" -ne 1 ]; then
+    command -v git >/dev/null 2>&1 || die "git is required"
+    command -v python3 >/dev/null 2>&1 || die "python3 is required"
+    command -v nvidia-smi >/dev/null 2>&1 || die "an NVIDIA CUDA host is required (nvidia-smi not found)"
+    nvidia-smi >/dev/null 2>&1 || die "nvidia-smi cannot access the GPU"
+  fi
 
-PY="$VENV_DIR/bin/python"
-run "$PY" -m pip install --upgrade pip
-run "$PY" -m pip install torch
-run "$PY" -m pip install -e "$KIMODO_DIR" llm2vec
+  if [ ! -e "$KIMODO_DIR/.git" ]; then
+    mkdir -p "$(dirname "$KIMODO_DIR")"
+    run git clone --depth 1 https://github.com/nv-tlabs/kimodo.git "$KIMODO_DIR"
+  else
+    log "Kimodo checkout already exists at $KIMODO_DIR"
+  fi
 
-if [ "$DRY_RUN" -eq 1 ]; then
-  log "would prefetch model $MODEL and LLM2Vec encoder assets"
-else
-  "$PY" - "$MODEL" <<'PY'
+  if [ ! -x "$VENV_DIR/bin/python" ]; then
+    run python3 -m venv "$VENV_DIR"
+  else
+    log "Python environment already exists at $VENV_DIR"
+  fi
+
+  PY="$VENV_DIR/bin/python"
+  run "$PY" -m pip install --upgrade pip
+  run "$PY" -m pip install torch
+  run "$PY" -m pip install -e "$KIMODO_DIR" llm2vec
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "would prefetch model $MODEL and LLM2Vec encoder assets"
+  else
+    "$PY" - "$MODEL" <<'PY'
 import sys
 from huggingface_hub import snapshot_download
 model = sys.argv[1]
@@ -75,9 +166,124 @@ snapshot_download(repo_id="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp")
 snapshot_download(repo_id="McGill-NLP/LLM2Vec-Meta-Llama-3-8B-Instruct-mntp-supervised")
 print("model and encoder assets ready")
 PY
-fi
+  fi
+
+  log "export CCLAY_MOTION_BACKEND=kimodo"
+  log "export CCLAY_KIMODO_HOST=<this host>"
+  log "Kimodo model: $MODEL"
+}
+
+install_kimodo_mlx() {
+  if [ "$DRY_RUN" -ne 1 ]; then
+    command -v git >/dev/null 2>&1 || die "git is required"
+    command -v python3 >/dev/null 2>&1 || die "python3 is required"
+  fi
+
+  if [ ! -e "$MLX_DIR/.git" ]; then
+    mkdir -p "$(dirname "$MLX_DIR")"
+    run git clone --depth 1 https://github.com/NomaDamas/kimodo-mlx.git "$MLX_DIR"
+  else
+    log "kimodo-mlx checkout already exists at $MLX_DIR"
+  fi
+
+  if [ ! -x "$MLX_VENV_DIR/bin/python" ]; then
+    if command -v uv >/dev/null 2>&1; then
+      run uv venv --python 3.12 "$MLX_VENV_DIR"
+    else
+      run python3 -m venv "$MLX_VENV_DIR"
+    fi
+  else
+    log "Python environment already exists at $MLX_VENV_DIR"
+  fi
+
+  PY="$MLX_VENV_DIR/bin/python"
+  HF="$MLX_VENV_DIR/bin/hf"
+  run "$PY" -m pip install --upgrade pip
+  run "$PY" -m pip install -e "$MLX_DIR" huggingface_hub
+
+  run "$HF" download "nvidia/$MODEL" --local-dir "$MLX_DIR/models/$(printf '%s' "$MODEL" | sed 's/^Kimodo-/nvidia-/' | tr 'A-Z' 'a-z')"
+  run "$HF" download LocalAI-io/Llama-3-Kimodo-GGML --local-dir "$MLX_DIR/models/llm2vec-text-bundle"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "would run: $PY -m kimodo_mlx diagnose (expect mlx-metal)"
+  else
+    "$PY" -m kimodo_mlx diagnose || die "kimodo-mlx diagnose failed; see $MLX_DIR/README.md"
+  fi
+
+  log "kimodo-mlx ready: $PY -m kimodo_mlx generate --prompt \"walk forward\" --frames 30 --steps 10"
+}
+
+install_kimodo_cpp() {
+  local accel="$1" # metal | cpu
+  if [ "$DRY_RUN" -ne 1 ]; then
+    command -v git >/dev/null 2>&1 || die "git is required"
+    command -v cmake >/dev/null 2>&1 || die "cmake is required (CMake 3.25+)"
+    command -v python3 >/dev/null 2>&1 || die "python3 is required"
+  fi
+
+  if [ ! -e "$CPP_DIR/.git" ]; then
+    mkdir -p "$(dirname "$CPP_DIR")"
+    run git clone --depth 1 https://github.com/localai-org/kimodo.cpp.git "$CPP_DIR"
+  else
+    log "kimodo.cpp checkout already exists at $CPP_DIR"
+  fi
+  run git -C "$CPP_DIR" submodule update --init --recursive
+
+  local build_dir="$CPP_DIR/build-$accel"
+  if [ "$accel" = "metal" ]; then
+    # The GGML Metal wiring lives in a patch maintained with the kimodo-mlx
+    # port; apply it onto the ref it was written against.
+    if [ ! -e "$MLX_DIR/.git" ]; then
+      mkdir -p "$(dirname "$MLX_DIR")"
+      run git clone --depth 1 https://github.com/NomaDamas/kimodo-mlx.git "$MLX_DIR"
+    fi
+    run git -C "$CPP_DIR" fetch --depth 1 origin "$CPP_METAL_REF"
+    run git -C "$CPP_DIR" checkout FETCH_HEAD
+    if [ "$DRY_RUN" -eq 1 ]; then
+      printf '+ '; printf '%q ' git -C "$CPP_DIR" apply "$MLX_DIR/patches/0001-kimodo-ggml-metal.patch"; printf '\n'
+    else
+      if git -C "$CPP_DIR" apply --check "$MLX_DIR/patches/0001-kimodo-ggml-metal.patch" 2>/dev/null; then
+        git -C "$CPP_DIR" apply "$MLX_DIR/patches/0001-kimodo-ggml-metal.patch"
+      else
+        log "Metal patch already applied (or checkout dirty); continuing"
+      fi
+    fi
+    run cmake -S "$CPP_DIR" -B "$build_dir" \
+      -DKIMODO_ENABLE_VULKAN=OFF -DKIMODO_ENABLE_METAL=ON -DKIMODO_BUILD_TESTS=OFF
+  else
+    local vulkan="$CPP_VULKAN"
+    if [ "$vulkan" = "auto" ]; then
+      if pkg-config --exists vulkan 2>/dev/null || [ -f /usr/include/vulkan/vulkan.h ]; then
+        vulkan=ON
+      else
+        vulkan=OFF
+      fi
+    fi
+    log "kimodo.cpp CPU build: vulkan=$vulkan"
+    run cmake -S "$CPP_DIR" -B "$build_dir" \
+      -DKIMODO_ENABLE_VULKAN="$vulkan" -DKIMODO_BUILD_TESTS=OFF
+  fi
+  run cmake --build "$build_dir" --parallel
+
+  # GGUF weights come from the LocalAI-io org through the upstream script,
+  # which needs the hf CLI; keep it in a small dedicated venv.
+  if [ ! -x "$CPP_VENV_DIR/bin/hf" ]; then
+    run python3 -m venv "$CPP_VENV_DIR"
+    run "$CPP_VENV_DIR/bin/python" -m pip install --upgrade pip huggingface_hub
+  fi
+  local cpp_model
+  cpp_model=$(printf '%s' "$MODEL" | sed 's/^Kimodo-//' | tr 'A-Z' 'a-z')
+  run env "PATH=$CPP_VENV_DIR/bin:$PATH" bash "$CPP_DIR/scripts/download_gguf_weights.sh" \
+    --output "$CPP_DIR" --model "$cpp_model"
+
+  log "kimodo.cpp ($accel) ready: build at $build_dir, GGUF weights under $CPP_DIR"
+}
+
+case "$BACKEND" in
+  nvidia-cuda) install_nvidia_cuda ;;
+  kimodo-mlx) install_kimodo_mlx ;;
+  kimodo.cpp-metal) install_kimodo_cpp metal ;;
+  kimodo.cpp-cpu) install_kimodo_cpp cpu ;;
+esac
 
 log "ready"
-log "export CCLAY_MOTION_BACKEND=kimodo"
-log "export CCLAY_KIMODO_HOST=<this host>"
-log "Kimodo model: $MODEL"


### PR DESCRIPTION
## What

`tools/kimodo/setup-on-box.sh` is now an install router: it detects OS / architecture / RAM / CUDA and installs the best-supported Kimodo variant for the host, instead of assuming Linux + NVIDIA unconditionally.

| Host | Backend installed | Why |
| --- | --- | --- |
| macOS arm64, RAM > 32 GB | [kimodo-mlx](https://github.com/NomaDamas/kimodo-mlx) (MLX/Metal) | 15 GB LLM2Vec encoder stays resident in unified memory — measured ~0.9 s warm vs ~37 s kimodo.cpp Metal on M4 Max 64 GB |
| macOS arm64, RAM ≤ 32 GB | [kimodo.cpp](https://github.com/localai-org/kimodo.cpp) + Metal | Residency does not fit; GGML streams layers from disk |
| Linux + working CUDA | [nv-tlabs/kimodo](https://github.com/nv-tlabs/kimodo) PyTorch (existing path, byte-identical) | Full CUDA acceleration |
| Other Unix, no CUDA | kimodo.cpp CPU (Vulkan when available) | Local GGML execution without a GPU |

- Route override: `--backend` / `CCLAY_KIMODO_BACKEND`; threshold: `CCLAY_KIMODO_MLX_MIN_RAM_GB` (default 32)
- Detection override for tests/dry-runs: `CCLAY_KIMODO_DETECT_{OS,ARCH,RAM_GB,CUDA}`
- Unknown OS refuses with a hint instead of guessing
- README documents the route table

## Evidence

- Route table dry-runs (all PASS): 64 GB Mac → `backend=kimodo-mlx`; 32 GB boundary + 16 GB → `kimodo.cpp-metal` (Metal patch + flags); Linux+CUDA → unchanged nv-tlabs sequence; Linux-no-CUDA → `kimodo.cpp-cpu`; override beats detection; SunOS exits 1 with a hint.
- `node test/verify-kimodo-setup.mjs` → `OK verify-kimodo-setup` (now executes the route table offline via forced detection).
- `bash -n` + `shellcheck -S warning` clean.
- On-device measurement (M4 Max 64 GB): `kimodo_mlx diagnose` → `backend_selected: mlx-metal`, `neural_engine_used: false`; 16f/8-step generation 46.6 s cold / 37.6 s page-cache-warm, deterministic output sha — anchors the >32 GB route rationale (residency is the win; at ≤32 GB streaming is the right trade).
- `node tools/run-tests.mjs` green (see note below).

## Test-environment notes (pre-existing, not from this diff)

Two environment gaps surfaced while running the suite on a fresh clone; neither is touched by this change (3 files: installer, its test, README):

1. Root `npm ci` does not install `mcp/node_modules`, so `test/verify-agent-routes.mjs` fails with `ERR_MODULE_NOT_FOUND: 'ws'` (imported by `mcp/live-hub.mjs`). Run `npm --prefix mcp ci` once before `npm test`.
2. `mcp/verify.mjs` hard-links a sentinel from `os.tmpdir()` into the repo; on a cross-volume clone (`/Volumes/SSD1` vs `/tmp`) `fs.link` throws EXDEV and the suite stops. Filed separately as #224. For this run: `TMPDIR=/Volumes/SSD1/1/tmp-cozyclay npm test` (same filesystem — the external-hard-link refusal check still exercises the same server path).
