### PR TITLE
fix(mcp): keep the verify hard-link sentinel on the clone filesystem (#224)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __pycache__/
 
 # MCP server local install
 mcp/node_modules/
+/.verify-outside-*/
 .omo/ulw-loop/
 
 # agent scratch

--- a/mcp/verify.mjs
+++ b/mcp/verify.mjs
@@ -229,7 +229,6 @@ check("prompt carries both subjects", prompt.includes("detective") && prompt.inc
 const file = new URL("./.verify-project.cclayproject", import.meta.url).pathname;
 const symlink = new URL("./.verify-project-link.cclayproject", import.meta.url).pathname;
 const hardlink = new URL("./.verify-project-hardlink.cclayproject", import.meta.url).pathname;
-const outside = `/tmp/cozyclay-verify-outside-${process.pid}.cclayproject`;
 const fs = await import("node:fs/promises");
 await call("save_project", { path: file, name: "Verify" });
 check("save refuses implicit overwrite", (await call("save_project", { path: file })).startsWith("Could not write"), "overwrite unexpectedly succeeded");
@@ -241,17 +240,29 @@ await import("node:fs/promises").then((fs) => fs.unlink(file).catch(() => {}));
 
 check("outside project root is rejected", (await call("open_project", { path: "/tmp/nope.cclayproject" })).includes("direct children of configured project root"));
 check("wrong extension is rejected", (await call("open_project", { path: "/etc/hosts" })).includes("must end in .cclayproject"));
-await fs.writeFile(outside, "outside sentinel", { mode: 0o600 });
-await fs.symlink(outside, symlink);
-check("open refuses final symlink", (await call("open_project", { path: symlink })).startsWith("Could not read"), "symlink open unexpectedly succeeded");
-check("save refuses final symlink", (await call("save_project", { path: symlink, overwrite: true })).startsWith("Could not write"), "symlink overwrite unexpectedly succeeded");
-check("symlink target remains byte-identical", await fs.readFile(outside, "utf8") === "outside sentinel");
-await fs.unlink(symlink);
-await fs.link(outside, hardlink);
-check("open refuses external hard link", (await call("open_project", { path: hardlink })).startsWith("Could not read"), "hard-link open unexpectedly succeeded");
-check("save refuses external hard link", (await call("save_project", { path: hardlink, overwrite: true })).startsWith("Could not write"), "hard-link overwrite unexpectedly succeeded");
-check("hard-link target remains byte-identical", await fs.readFile(outside, "utf8") === "outside sentinel");
-await Promise.all([fs.unlink(hardlink).catch(() => {}), fs.unlink(outside).catch(() => {})]);
+// Stay outside the configured project root (mcp/), but on the clone's filesystem:
+// a system temp directory may be on another volume, where hard links fail with EXDEV.
+const outsideDir = await fs.mkdtemp(new URL("../.verify-outside-", import.meta.url));
+try {
+	const outside = `${outsideDir}/sentinel.cclayproject`;
+	await fs.writeFile(outside, "outside sentinel", { mode: 0o600 });
+	await fs.symlink(outside, symlink);
+	check("open refuses final symlink", (await call("open_project", { path: symlink })).startsWith("Could not read"), "symlink open unexpectedly succeeded");
+	check("save refuses final symlink", (await call("save_project", { path: symlink, overwrite: true })).startsWith("Could not write"), "symlink overwrite unexpectedly succeeded");
+	check("symlink target remains byte-identical", await fs.readFile(outside, "utf8") === "outside sentinel");
+	await fs.unlink(symlink);
+	await fs.link(outside, hardlink);
+	check("external hard-link fixture has two links", (await fs.stat(hardlink)).nlink === 2);
+	check("open refuses external hard link", (await call("open_project", { path: hardlink })).startsWith("Could not read"), "hard-link open unexpectedly succeeded");
+	check("save refuses external hard link", (await call("save_project", { path: hardlink, overwrite: true })).startsWith("Could not write"), "hard-link overwrite unexpectedly succeeded");
+	check("hard-link target remains byte-identical", await fs.readFile(outside, "utf8") === "outside sentinel");
+} finally {
+	await Promise.all([
+		fs.rm(symlink, { force: true }),
+		fs.rm(hardlink, { force: true }),
+		fs.rm(outsideDir, { recursive: true, force: true }),
+	]);
+}
 
 /* --------------------------------- result -------------------------------- */
 


### PR DESCRIPTION
## Problem

At the starting HEAD (`ec25443`), `mcp/verify.mjs` creates its external sentinel using the literal `/tmp/cozyclay-verify-outside-${process.pid}.cclayproject`, not `os.tmpdir()`. It then hard-links that file into the clone's `mcp/` directory. A clone on another filesystem fails with `EXDEV` before executing either hard-link refusal check.

The verifier explicitly sets `COZYCLAY_PROJECT_ROOT` to its own `mcp/` directory. The server restricts project files to that directory's direct children and rejects inodes with multiple links.

## Fix

- Create a unique `.verify-outside-*` directory in the repository root with `fs.mkdtemp(new URL("../.verify-outside-", import.meta.url))`. The sentinel stays outside the configured `mcp/` project root but on the clone's filesystem.
- Preserve both symlink and hard-link refusal checks and the byte-identical sentinel checks. Add a fixture check that `fs.stat(hardlink).nlink === 2`; no copy fallback or skipped checks.
- Remove both link paths and the temporary directory in `finally`, including failure paths. Cleanup errors are not swallowed.
- Ignore only the root-level `/.verify-outside-*/` directory pattern.

## Evidence

### RED: unmodified HEAD on a separate HFS+ RAM disk

A full detached checkout and its dependencies fit on a 512 MiB RAM disk mounted at `/Volumes/cclay-tmp`; `/tmp` remained on the host APFS data volume. This ran before any source edit:

```text
25 tools registered
420 framing combinations checked
Error: EXDEV: cross-device link not permitted, link '/tmp/cozyclay-verify-outside-13911.cclayproject' -> '/Volumes/cclay-tmp/wt/mcp/.verify-project-hardlink.cclayproject'
  code: 'EXDEV',
exit=1
```

### GREEN: the same cross-volume checkout

Temporary PASS logging in the RAM-disk copy exposed the existing check results; it is not part of this commit. The fixture assertion directly checks `nlink === 2`.

```text
25 tools registered
420 framing combinations checked
PASS  external hard-link fixture has two links
PASS  open refuses external hard link
PASS  save refuses external hard link
PASS  hard-link target remains byte-identical

all checks passed
exit=0
```

After removing the temporary logging, the byte-identical committed verifier also passed on the RAM disk:

```text
25 tools registered
420 framing combinations checked

all checks passed
exit=0
```

### Same-filesystem regression and cleanup

`node mcp/verify.mjs` in `/Users/yun/CozyClay-wt/224`:

```text
25 tools registered
420 framing combinations checked

all checks passed
exit=0
ls: .verify-outside-*: No such file or directory
ls: mcp/.verify-*: No such file or directory
No mcp/.verify-* or repo-root .verify-outside-* leftovers.
```

Additional external fault injection threw immediately after each real filesystem operation, without replacing its behavior. Every run failed as intended and cleaned up:

```text
writeFile failure cleanup: no sentinel directory or link leftovers (exit=1)
symlink failure cleanup: no sentinel directory or link leftovers (exit=1)
link failure cleanup: no sentinel directory or link leftovers (exit=1)
```

### Full suite, run once

`npm test` (includes the production build):

```text
PASS 165 Node verification files
exit=0
```

JavaScript LSP diagnostics, `node --check mcp/verify.mjs`, and `git diff --check` passed. `.gitignore` has no configured language server; `git check-ignore` verified the narrow pattern.

Closes #224
