### PR TITLE
feat(motion): motion-resources module, NPZ bytes retention, motionId-first restore (#228)

### DIFF
--- a/src/ardy/npz.js
+++ b/src/ardy/npz.js
@@ -593,5 +593,11 @@ export async function loadMotionFromUrl(url, { signal } = {}) {
 		throw new NpzError(`motion download is ${blob.size} bytes, over the ${MAX_ARCHIVE_BYTES} byte cap`);
 	}
 	const buffer = await blob.arrayBuffer();
-	return decodeMotionNpz(new Uint8Array(buffer));
+	const bytes = new Uint8Array(buffer);
+	const motion = await decodeMotionNpz(bytes);
+	// The validated archive rides along so a project save can embed the take
+	// (src/motion-resources.js) without a second download. Playback keeps
+	// reading the decoded arrays; nothing on that path looks at sourceBytes.
+	motion.sourceBytes = bytes;
+	return motion;
 }

--- a/src/motion-resources.js
+++ b/src/motion-resources.js
@@ -1,0 +1,177 @@
+/**
+ * Motion resources: a validated ARDY npz archive packaged so a `.cclayproject`
+ * can carry the take itself instead of a bridge URL that dies with the run.
+ *
+ * A record is content-addressed: `motionId` is the SHA-256 of the raw archive
+ * bytes, so a scene's `character.motionRef.motionId` names the exact bytes it
+ * was authored against. Decoding re-derives the hash and re-runs the full npz
+ * validation, so a tampered or truncated record is rejected before playback
+ * ever sees it. Every rejection is an NpzError carrying a machine-readable
+ * `code` (bad-base64 | length-mismatch | hash-mismatch | bad-npz | too-large).
+ *
+ * No React, no three.js, no fetch: this module runs identically in the
+ * browser and under Node (Web Crypto + atob/btoa are available in both).
+ */
+
+import { decodeMotionNpz, NpzError } from "./ardy/npz.js";
+
+/** Per-motion raw archive cap; matches the npz reader's download cap. */
+export const MOTION_MAX_BYTES = 192 * 1024 * 1024;
+
+const MOTION_ID_RE = /^[0-9a-f]{64}$/i;
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+function codedError(code, message) {
+	const error = new NpzError(message);
+	error.code = code;
+	return error;
+}
+
+function asBytes(value) {
+	if (value instanceof Uint8Array) return value;
+	if (value instanceof ArrayBuffer) return new Uint8Array(value);
+	if (ArrayBuffer.isView(value)) return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+	throw new TypeError("motion bytes must be a Uint8Array or ArrayBuffer");
+}
+
+/** Lowercase hex SHA-256 of raw bytes — the motionId of an archive. */
+export async function sha256Hex(value) {
+	const bytes = asBytes(value);
+	const subtle = globalThis.crypto?.subtle;
+	if (!subtle) throw new Error("Web Crypto SHA-256 is unavailable");
+	const digest = await subtle.digest("SHA-256", bytes);
+	let hex = "";
+	for (const byte of new Uint8Array(digest)) hex += byte.toString(16).padStart(2, "0");
+	return hex;
+}
+
+function bytesToBase64(bytes) {
+	let binary = "";
+	for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+		binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+	}
+	return btoa(binary);
+}
+
+function base64ToBytes(text) {
+	if (typeof text !== "string" || text.length % 4 !== 0 || !BASE64_RE.test(text)) {
+		throw codedError("bad-base64", "motion resource data is not valid base64");
+	}
+	let binary;
+	try {
+		binary = atob(text);
+	} catch {
+		throw codedError("bad-base64", "motion resource data is not valid base64");
+	}
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+	return bytes;
+}
+
+/** Decoded byte count of a base64 string, without decoding it. */
+function base64DecodedLength(text) {
+	let padding = 0;
+	if (text.endsWith("==")) padding = 2;
+	else if (text.endsWith("=")) padding = 1;
+	return (text.length / 4) * 3 - padding;
+}
+
+const META_KEYS = ["prompt", "sourceUrl", "personScale", "createdAt"];
+
+/**
+ * Validate an npz archive and package it as a project motion record:
+ * { motionId, encoding: "base64", data, bytes, frames, fps, name?, meta? }.
+ *
+ * `meta` may carry `name` (kept top-level) and prompt / sourceUrl /
+ * personScale / createdAt (kept under `meta`). personScale defaults to the
+ * value the archive itself carries so the record is self-describing.
+ */
+export async function encodeMotionResource(value, meta = {}) {
+	const bytes = asBytes(value);
+	if (bytes.byteLength > MOTION_MAX_BYTES) {
+		throw codedError("too-large", `motion resource is ${bytes.byteLength} bytes, over the ${MOTION_MAX_BYTES} byte cap`);
+	}
+	let motion;
+	try {
+		motion = await decodeMotionNpz(bytes);
+	} catch (error) {
+		if (error instanceof NpzError && !error.code) error.code = "bad-npz";
+		throw error;
+	}
+	const motionId = await sha256Hex(bytes);
+	const record = {
+		motionId,
+		encoding: "base64",
+		data: bytesToBase64(bytes),
+		bytes: bytes.byteLength,
+		frames: motion.frames,
+		fps: motion.fps,
+	};
+	const source = meta && typeof meta === "object" ? meta : {};
+	if (typeof source.name === "string" && source.name) record.name = source.name;
+	const extra = { personScale: motion.personScale };
+	for (const key of META_KEYS) {
+		if (source[key] !== undefined && source[key] !== null) extra[key] = source[key];
+	}
+	record.meta = extra;
+	return record;
+}
+
+/**
+ * Unpack a motion record back into a decoded motion. Checks, in order: size
+ * cap, base64 syntax, declared byte length, SHA-256 against motionId, then
+ * the full npz validation. Returns the decodeMotionNpz result plus
+ * { motionId, sourceBytes } — exactly what loadMotionFromUrl returns, so the
+ * restore path treats an embedded take and a downloaded one the same way.
+ */
+export async function decodeMotionResource(record) {
+	if (!record || typeof record !== "object") {
+		throw codedError("bad-base64", "motion resource must be an object with base64 data");
+	}
+	if (Number.isFinite(record.bytes) && record.bytes > MOTION_MAX_BYTES) {
+		throw codedError("too-large", `motion resource declares ${record.bytes} bytes, over the ${MOTION_MAX_BYTES} byte cap`);
+	}
+	if (record.encoding !== "base64" || typeof record.data !== "string") {
+		throw codedError("bad-base64", "motion resource must contain base64 data");
+	}
+	if (base64DecodedLength(record.data) > MOTION_MAX_BYTES) {
+		throw codedError("too-large", `motion resource data decodes past the ${MOTION_MAX_BYTES} byte cap`);
+	}
+	const bytes = base64ToBytes(record.data);
+	if (bytes.byteLength > MOTION_MAX_BYTES) {
+		throw codedError("too-large", `motion resource is ${bytes.byteLength} bytes, over the ${MOTION_MAX_BYTES} byte cap`);
+	}
+	if (!Number.isInteger(record.bytes) || record.bytes !== bytes.byteLength) {
+		throw codedError("length-mismatch", `motion resource declares ${record.bytes} bytes but carries ${bytes.byteLength}`);
+	}
+	const declaredId = typeof record.motionId === "string" && MOTION_ID_RE.test(record.motionId) ? record.motionId.toLowerCase() : null;
+	const motionId = await sha256Hex(bytes);
+	if (declaredId !== motionId) {
+		throw codedError("hash-mismatch", "motion resource bytes do not match its motionId");
+	}
+	let motion;
+	try {
+		motion = await decodeMotionNpz(bytes);
+	} catch (error) {
+		if (error instanceof NpzError && !error.code) error.code = "bad-npz";
+		throw error;
+	}
+	return { ...motion, motionId, sourceBytes: bytes };
+}
+
+/**
+ * Where a character's motion should come from on restore. Embedded bytes win
+ * over a URL: the URL is a bridge run that may be gone, the bytes are here.
+ *   { kind: "embedded", record } | { kind: "url", url } | { kind: "missing" }
+ */
+export function resolveMotionSource(motionRef, motionsById) {
+	if (!motionRef || typeof motionRef !== "object") return { kind: "missing" };
+	if (typeof motionRef.motionId === "string" && motionsById && typeof motionsById.get === "function") {
+		const record = motionsById.get(motionRef.motionId.toLowerCase());
+		if (record) return { kind: "embedded", record };
+	}
+	if (typeof motionRef.url === "string" && motionRef.url) return { kind: "url", url: motionRef.url };
+	return { kind: "missing" };
+}
+
+export { loadMotionFromUrl } from "./ardy/npz.js";

--- a/src/scenes.js
+++ b/src/scenes.js
@@ -168,15 +168,28 @@ export function createCharacterEntry(source = null, index = 0) {
 	};
 }
 
+const MOTION_ID_RE = /^[0-9a-f]{64}$/i;
+
+// A motionRef names its take by content (motionId: SHA-256 of the npz, kept
+// in the project's embedded motions) and/or by location (url: a bridge run,
+// which is what pre-motionId documents carry). Either one alone is a valid
+// ref; the restore path prefers the embedded bytes when both are present.
 function normalizeMotionRef(ref) {
-	if (!plainObject(ref) || typeof ref.url !== "string" || !ref.url) return null;
-	const normalized = {
-		url: ref.url,
+	if (!plainObject(ref)) return null;
+	const motionId = typeof ref.motionId === "string" && MOTION_ID_RE.test(ref.motionId) ? ref.motionId.toLowerCase() : null;
+	const url = typeof ref.url === "string" && ref.url ? ref.url : null;
+	if (!motionId && !url) return null;
+	const normalized = {};
+	// Field order matters only for byte-stable serialization; a url-only ref
+	// keeps the exact legacy shape (url first, no motionId key).
+	if (motionId) normalized.motionId = motionId;
+	if (url) normalized.url = url;
+	Object.assign(normalized, {
 		prompt: typeof ref.prompt === "string" ? ref.prompt : "",
 		rotationDeg: Number.isFinite(ref.rotationDeg) ? ref.rotationDeg : 0,
 		anchorX: Number.isFinite(ref.anchorX) ? ref.anchorX : 0,
 		anchorZ: Number.isFinite(ref.anchorZ) ? ref.anchorZ : 0,
-	};
+	});
 	// Scene calibration is deliberately metadata on the lightweight motionRef,
 	// never an NPZ member.  Keep it optional so old documents retain their exact
 	// shape, while preserving the calibration produced by the extraction/load

--- a/test/verify-motion-resources.mjs
+++ b/test/verify-motion-resources.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * verify-motion-resources: an ARDY npz packaged as a project motion record
+ * round-trips byte-for-byte, is content-addressed by SHA-256, rejects every
+ * tampered form with a specific code, and decodes to a playable motion
+ * without a bridge or a URL.
+ */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import {
+	MOTION_MAX_BYTES,
+	decodeMotionResource,
+	encodeMotionResource,
+	resolveMotionSource,
+	sha256Hex,
+} from "../src/motion-resources.js";
+import { NpzError, decodeMotionNpz } from "../src/ardy/npz.js";
+
+const fixturePath = new URL("../public/demo/walk-then-stop.npz", import.meta.url);
+const bytes = new Uint8Array(readFileSync(fixturePath));
+const expectedId = createHash("sha256").update(bytes).digest("hex");
+const reference = await decodeMotionNpz(bytes);
+
+async function rejectsWithCode(promise, code) {
+	let caught = null;
+	try {
+		await promise;
+	} catch (error) {
+		caught = error;
+	}
+	assert.ok(caught instanceof NpzError, `${code}: rejection must be an NpzError, got ${caught?.constructor?.name ?? "nothing"}`);
+	assert.equal(caught.code, code, `${code}: error.code (${caught.message})`);
+	return caught;
+}
+
+// --- hashing -----------------------------------------------------------------
+assert.equal(await sha256Hex(bytes), expectedId, "sha256Hex matches node:crypto");
+assert.equal(await sha256Hex(bytes.buffer), expectedId, "sha256Hex accepts an ArrayBuffer");
+assert.match(await sha256Hex(new Uint8Array(0)), /^[0-9a-f]{64}$/, "digest is 64 lowercase hex");
+
+// --- encode ------------------------------------------------------------------
+const record = await encodeMotionResource(bytes, { name: "walk then stop", prompt: "walks then stops", sourceUrl: "/ardy/motions/run-1.npz" });
+assert.equal(record.motionId, expectedId, "motionId is the SHA-256 of the raw archive");
+assert.equal(record.encoding, "base64");
+assert.equal(record.bytes, bytes.byteLength, "bytes records the raw length");
+assert.equal(record.frames, reference.frames, "frames comes from the npz");
+assert.equal(record.fps, reference.fps, "fps comes from the npz");
+assert.equal(record.name, "walk then stop");
+assert.deepEqual(record.meta, { personScale: reference.personScale, prompt: "walks then stops", sourceUrl: "/ardy/motions/run-1.npz" }, "meta keeps only spec fields plus the archive's own personScale");
+assert.equal(Buffer.from(record.data, "base64").toString("base64"), record.data, "data is canonical base64");
+assert.deepEqual(Object.keys(record), ["motionId", "encoding", "data", "bytes", "frames", "fps", "name", "meta"], "record has the spec'd shape and nothing else");
+const bare = await encodeMotionResource(bytes);
+assert.equal(bare.name, undefined, "no name unless one was given");
+assert.deepEqual(bare.meta, { personScale: reference.personScale }, "meta without caller fields is just personScale");
+assert.equal(JSON.parse(JSON.stringify(record)).data, record.data, "record is plain JSON");
+
+// --- decode round trip -------------------------------------------------------
+const restored = await decodeMotionResource(record);
+assert.ok(restored.sourceBytes instanceof Uint8Array, "sourceBytes is a Uint8Array");
+assert.equal(restored.sourceBytes.byteLength, bytes.byteLength);
+assert.ok(Buffer.from(restored.sourceBytes).equals(Buffer.from(bytes)), "embedded bytes round-trip exactly");
+assert.equal(restored.motionId, expectedId, "decoded motion carries its motionId");
+assert.equal(restored.frames, reference.frames, "frames decoded from the record alone");
+assert.equal(restored.fps, reference.fps, "fps decoded from the record alone");
+assert.ok(restored.rotMats instanceof Float32Array && restored.rotMats.length === reference.rotMats.length, "rotMats decoded from the record alone");
+assert.ok(restored.rootPos instanceof Float32Array && restored.rootPos.length === reference.frames * 3, "rootPos decoded from the record alone");
+assert.ok(restored.posedJoints instanceof Float32Array && restored.posedJoints.length === reference.posedJoints.length, "posedJoints decoded");
+assert.equal(restored.personScale, reference.personScale);
+assert.deepEqual(Array.from(restored.rotMats.subarray(0, 9)), Array.from(reference.rotMats.subarray(0, 9)), "first matrix matches a direct decode");
+// A JSON round trip (what a .cclayproject actually is) is enough on its own.
+const reparsed = await decodeMotionResource(JSON.parse(JSON.stringify(record)));
+assert.equal(reparsed.motionId, expectedId, "decode works from parsed JSON");
+// Uppercase ids are still the same content.
+const upper = await decodeMotionResource({ ...record, motionId: record.motionId.toUpperCase() });
+assert.equal(upper.motionId, expectedId, "motionId normalizes to lowercase");
+
+// --- rejections --------------------------------------------------------------
+await rejectsWithCode(decodeMotionResource({ ...record, motionId: "0".repeat(64) }), "hash-mismatch");
+await rejectsWithCode(decodeMotionResource({ ...record, motionId: "not-a-hash" }), "hash-mismatch");
+await rejectsWithCode(decodeMotionResource({ ...record, motionId: undefined }), "hash-mismatch");
+await rejectsWithCode(decodeMotionResource({ ...record, data: `${record.data.slice(0, -2)}!!` }), "bad-base64");
+await rejectsWithCode(decodeMotionResource({ ...record, data: record.data.slice(0, -1) }), "bad-base64");
+await rejectsWithCode(decodeMotionResource({ ...record, data: 42 }), "bad-base64");
+await rejectsWithCode(decodeMotionResource({ ...record, encoding: "hex" }), "bad-base64");
+await rejectsWithCode(decodeMotionResource(null), "bad-base64");
+await rejectsWithCode(decodeMotionResource({ ...record, bytes: record.bytes + 1 }), "length-mismatch");
+await rejectsWithCode(decodeMotionResource({ ...record, bytes: undefined }), "length-mismatch");
+await rejectsWithCode(decodeMotionResource({ ...record, bytes: MOTION_MAX_BYTES + 1 }), "too-large");
+// Oversized data is refused from its base64 length before any decode work.
+const hugeData = "A".repeat(Math.ceil((MOTION_MAX_BYTES + 3) / 3) * 4);
+await rejectsWithCode(decodeMotionResource({ ...record, bytes: 1, data: hugeData }), "too-large");
+await rejectsWithCode(encodeMotionResource(new Uint8Array(MOTION_MAX_BYTES + 1)), "too-large");
+// Bytes whose hash matches but that are not a motion npz: the npz reader's
+// own error, tagged bad-npz.
+const junk = new TextEncoder().encode("not a zip archive at all");
+const junkRecord = { motionId: await sha256Hex(junk), encoding: "base64", data: Buffer.from(junk).toString("base64"), bytes: junk.byteLength, frames: 1, fps: 24 };
+const junkError = await rejectsWithCode(decodeMotionResource(junkRecord), "bad-npz");
+assert.match(junkError.message, /End of Central Directory/, "bad-npz keeps the reader's specific message");
+await rejectsWithCode(encodeMotionResource(junk), "bad-npz");
+// A truncated archive: hash is recomputed over the truncated bytes, so it is
+// the npz layer that catches it.
+const truncated = bytes.subarray(0, bytes.byteLength - 64);
+await rejectsWithCode(decodeMotionResource({ motionId: await sha256Hex(truncated), encoding: "base64", data: Buffer.from(truncated).toString("base64"), bytes: truncated.byteLength }), "bad-npz");
+
+// --- resolveMotionSource ------------------------------------------------------
+const motionsById = new Map([[record.motionId, record]]);
+assert.deepEqual(resolveMotionSource({ motionId: record.motionId, url: "/ardy/motions/gone.npz" }, motionsById), { kind: "embedded", record }, "embedded wins over url");
+assert.deepEqual(resolveMotionSource({ motionId: record.motionId.toUpperCase() }, motionsById), { kind: "embedded", record }, "lookup is case-insensitive");
+assert.deepEqual(resolveMotionSource({ motionId: "f".repeat(64), url: "/ardy/motions/run.npz" }, motionsById), { kind: "url", url: "/ardy/motions/run.npz" }, "unknown motionId falls back to url");
+assert.deepEqual(resolveMotionSource({ url: "/ardy/motions/run.npz" }, motionsById), { kind: "url", url: "/ardy/motions/run.npz" }, "url-only ref");
+assert.deepEqual(resolveMotionSource({ motionId: "f".repeat(64) }, motionsById), { kind: "missing" }, "unknown motionId without url is missing");
+assert.deepEqual(resolveMotionSource({ motionId: record.motionId }, new Map()), { kind: "missing" }, "no motions at all is missing");
+assert.deepEqual(resolveMotionSource({ motionId: record.motionId }, undefined), { kind: "missing" }, "no map at all is missing");
+assert.deepEqual(resolveMotionSource(null, motionsById), { kind: "missing" }, "no ref is missing");
+assert.deepEqual(resolveMotionSource({ prompt: "walk" }, motionsById), { kind: "missing" }, "ref without id or url is missing");
+
+console.log("verify-motion-resources: ok");

--- a/test/verify-scenes.mjs
+++ b/test/verify-scenes.mjs
@@ -23,6 +23,7 @@ import {
 	serializeSceneDocument,
 	takeAnchor,
 } from "../src/scenes.js";
+import { resolveMotionSource } from "../src/motion-resources.js";
 
 let scenes = [];
 scenes = addScene(scenes);
@@ -255,6 +256,43 @@ assert.equal(calibratedEntry.motionRef.calibration.offsetX, 0.4, "mutating the s
 const clampedCalibration = createCharacterEntry({ motionRef: { url: "/ardy/motions/clamped.npz", calibration: { scale: 99, yawDeg: 540, offsetX: 101 } } }).motionRef.calibration;
 assert.deepEqual(clampedCalibration, { scale: 10, yawDeg: -180, offsetX: 100, offsetY: 0, offsetZ: 0 }, "persisted calibration uses the bounded scene envelope");
 assert.equal(createCharacterEntry({ motionRef: { url: "/ardy/motions/legacy.npz" } }).motionRef.calibration, undefined, "legacy motion refs remain free of calibration fields");
+
+// A motionRef names its take by content (motionId, embedded in the project)
+// and/or by location (url, a bridge run). Either alone is enough; a legacy
+// url-only ref keeps its exact shape so v4 documents stay byte-stable.
+const motionId = "a3f1".repeat(16);
+const legacyRef = createCharacterEntry({ motionRef: { url: "/ardy/motions/legacy.npz", prompt: "walks", rotationDeg: 90, anchorX: 1, anchorZ: -2 } }).motionRef;
+assert.deepEqual(legacyRef, { url: "/ardy/motions/legacy.npz", prompt: "walks", rotationDeg: 90, anchorX: 1, anchorZ: -2 }, "url-only motionRef normalizes without a motionId key");
+assert.deepEqual(Object.keys(legacyRef), ["url", "prompt", "rotationDeg", "anchorX", "anchorZ"], "legacy motionRef key order is untouched");
+const embeddedRef = createCharacterEntry({ motionRef: { motionId, prompt: "walks" } }).motionRef;
+assert.deepEqual(embeddedRef, { motionId, prompt: "walks", rotationDeg: 0, anchorX: 0, anchorZ: 0 }, "motionId-only motionRef is valid without a url");
+const bothRef = createCharacterEntry({ motionRef: { motionId: motionId.toUpperCase(), url: "/ardy/motions/both.npz", calibration: { scale: 1.1 } } }).motionRef;
+assert.equal(bothRef.motionId, motionId, "motionId normalizes to lowercase");
+assert.equal(bothRef.url, "/ardy/motions/both.npz", "url is kept next to motionId");
+assert.deepEqual(Object.keys(bothRef), ["motionId", "url", "prompt", "rotationDeg", "anchorX", "anchorZ", "calibration"], "motionId leads when both are present");
+assert.equal(createCharacterEntry({ motionRef: { prompt: "walks" } }).motionRef, null, "neither motionId nor url is not a motionRef");
+assert.equal(createCharacterEntry({ motionRef: { motionId: "not-a-hash" } }).motionRef, null, "a malformed motionId alone is not a motionRef");
+assert.equal(createCharacterEntry({ motionRef: { motionId: motionId.slice(0, 63) } }).motionRef, null, "a short motionId alone is not a motionRef");
+assert.deepEqual(createCharacterEntry({ motionRef: { motionId: "not-a-hash", url: "/ardy/motions/x.npz" } }).motionRef, { url: "/ardy/motions/x.npz", prompt: "", rotationDeg: 0, anchorX: 0, anchorZ: 0 }, "a malformed motionId is dropped, the url survives");
+const refRoundTrip = readSceneDocument(serializeSceneDocument({
+	version: SCENES_VERSION,
+	activeSceneId: "s-ref",
+	scenes: [{ id: "s-ref", name: "Ref", objects: [], shotDocument: null, stage: createSceneStage({ characters: [{ id: "char-a", motionRef: { motionId } }, { id: "char-b", motionRef: { url: "/ardy/motions/b.npz" } }] }) }],
+}));
+assert.equal(refRoundTrip.status, "valid", "motionId refs do not bump SCENES_VERSION");
+const refStage = createSceneStage(refRoundTrip.document.scenes[0].stage);
+assert.equal(refStage.characters[0].motionRef.motionId, motionId, "motionId survives save and reload");
+assert.equal(refStage.characters[1].motionRef.url, "/ardy/motions/b.npz", "url refs survive save and reload");
+
+// Restore priority: embedded bytes win over a bridge url, and a ref that
+// resolves to neither is reported as missing rather than guessed.
+const embeddedRecord = { motionId, encoding: "base64", data: "", bytes: 0, frames: 1, fps: 24 };
+const motionsById = new Map([[motionId, embeddedRecord]]);
+assert.deepEqual(resolveMotionSource(bothRef, motionsById), { kind: "embedded", record: embeddedRecord }, "embedded beats url");
+assert.deepEqual(resolveMotionSource(bothRef, new Map()), { kind: "url", url: "/ardy/motions/both.npz" }, "url when the motion is not embedded");
+assert.deepEqual(resolveMotionSource(legacyRef, motionsById), { kind: "url", url: "/ardy/motions/legacy.npz" }, "legacy url-only ref resolves to url");
+assert.deepEqual(resolveMotionSource(embeddedRef, new Map()), { kind: "missing" }, "motionId without embedded bytes or url is missing");
+assert.deepEqual(resolveMotionSource(null, motionsById), { kind: "missing" }, "no ref is missing");
 const staturedStage = createSceneStage({ characters: [{ id: "char-a", scale: 1.18 }, { id: "char-b" }] });
 assert.equal(staturedStage.characters[0].scale, 1.18, "a stored stature survives the stage envelope");
 assert.equal(staturedStage.characters[1].scale, 1, "a cast member without a take stays canonical");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -171,6 +171,7 @@ const NODE_FILES = [
 	"test/verify-object-path.mjs",
 	"test/verify-number-field-scrub.mjs",
 	"test/verify-speed-envelope.mjs",
+	"test/verify-motion-resources.mjs",
 ];
 
 const BROWSER_FILES = [


### PR DESCRIPTION
Closes #228. Track 2 of the resource-packaging plan: a motion npz can be packaged into a `.cclayproject` motion record and restored from it without the bridge, and a `character.motionRef` can name its take by content (`motionId`) as well as by URL.

## What changed

- `src/ardy/npz.js`: `loadMotionFromUrl` now attaches `sourceBytes` (the validated `Uint8Array`) to its result. Playback path unchanged; only the return object gained a field.
- `src/motion-resources.js` (new): `sha256Hex`, `encodeMotionResource`, `decodeMotionResource`, `resolveMotionSource`, `MOTION_MAX_BYTES` (192 MiB), plus a re-export of `loadMotionFromUrl`. Decode checks size cap, base64 syntax, declared length, SHA-256 vs `motionId`, then full npz validation; every rejection is an `NpzError` with `code` in `bad-base64 | length-mismatch | hash-mismatch | bad-npz | too-large`.
- `src/scenes.js` `normalizeMotionRef`: accepts `motionId` (64 hex, lowercased). Either `motionId` or `url` alone is valid; neither -> `null`. A url-only ref keeps its exact legacy key shape (no `motionId` key is added). `SCENES_VERSION` stays 4.
- App.jsx untouched (wiring is the integrator issue).

## Tests

- `test/verify-motion-resources.mjs` (new, registered in `tools/run-tests.mjs` `NODE_FILES`): encode -> decode byte-identical on `public/demo/walk-then-stop.npz`; `motionId` equals `node:crypto` sha256; each error code exercised (hash mismatch, bad base64, length mismatch, too-large via declared bytes / base64 length / encode input, bad-npz on junk and truncated bytes); frames/fps/rotMats/rootPos/posedJoints come out of `decodeMotionResource` alone with no URL or bridge; `resolveMotionSource` priority.
- `test/verify-scenes.mjs`: motionId-only / url-only / both normalization, lowercase normalization, malformed motionId dropped while url survives, save+reload with status `valid` (no version bump), `resolveMotionSource` embedded -> url -> missing on normalized refs.

```
node test/verify-motion-resources.mjs   -> verify-motion-resources: ok
node test/verify-scenes.mjs             -> all scene document checks PASS
node tools/run-tests.mjs                -> PASS 166 Node verification files
```

## Notes for the integrator / out of scope

- `encodeMotionResource` always writes `meta.personScale` from the archive (so a record is self-describing); caller-supplied `prompt` / `sourceUrl` / `createdAt` / `personScale` go under `meta`, `name` stays top-level, matching the v4 spec.
- A fresh worktree needs `npm --prefix mcp ci` before `node tools/run-tests.mjs` passes (`test/verify-agent-routes.mjs` imports `mcp/live-hub.mjs` -> `ws`). Pre-existing, not touched here.
- `src/workflow/scene-asset-sync.js` builds a motionRef by spreading the old ref and forcing `url`; once the integrator embeds motions it will need to decide whether a new bridge url should clear a stale `motionId`. Not changed here.
