### PR TITLE
feat(project): resource manifest with embedded/external/missing status (#229)

### DIFF
--- a/src/project-resources.js
+++ b/src/project-resources.js
@@ -1,0 +1,276 @@
+/**
+ * Project resource manifest: everything a project points at, and whether the
+ * bytes are here.
+ *
+ * A `.cclayproject` is only portable when every picture, motion clip, pose
+ * and workflow output it names travels with it. This module answers "which
+ * ones do, which ones live on a server, and which ones are gone" from the
+ * documents already in memory. It is a runtime calculation: nothing here is
+ * written to the file, and nothing here decodes or hashes bytes.
+ *
+ * Statuses:
+ *   embedded  — the record is in `assets` / `motions` / `poseLibrary`, or the
+ *               workflow output is a data: URL that will be interned on save.
+ *   external  — reachable by URL only (a bridge take, an http(s) output).
+ *   missing   — nothing to load. An image that the browser still holds in
+ *               IndexedDB is flagged `stored: true` so the integrator can
+ *               offer to embed it instead of reporting it lost.
+ *
+ * Inputs are never trusted: a scene document mid-migration, a half-written
+ * library entry or a garbage id produce fewer items, never a throw.
+ */
+import { isAssetId } from "./scene-assets.js";
+
+/** Lineage fields on a scene object, in `assetUsageCounts` order: the card's
+ * rendered picture, the photograph it was cut from, and the selection mask. */
+const IMAGE_LINEAGE_FIELDS = Object.freeze(["assetId", "sourceAssetId", "matteAssetId"]);
+
+const STATUS_RANK = Object.freeze({ embedded: 2, external: 1, missing: 0 });
+
+function plainObject(value) {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value) {
+	return typeof value === "string" && value ? value : null;
+}
+
+/** Decoded size of a base64 string, without decoding it. */
+function base64ByteLength(text) {
+	const clean = text.replace(/\s+/g, "");
+	if (!clean) return 0;
+	const padding = clean.endsWith("==") ? 2 : clean.endsWith("=") ? 1 : 0;
+	return Math.max(0, Math.floor((clean.length * 3) / 4) - padding);
+}
+
+/** Byte count of a record's payload however it is held: a stored asset has
+ * an ArrayBuffer, a project file has base64, a motion record has a number. */
+function byteSize(value) {
+	if (typeof value === "number") return Number.isFinite(value) && value >= 0 ? value : null;
+	if (value instanceof ArrayBuffer) return value.byteLength;
+	if (ArrayBuffer.isView(value)) return value.byteLength;
+	if (typeof value === "string") return base64ByteLength(value);
+	return null;
+}
+
+function dataUrlByteLength(url) {
+	const comma = url.indexOf(",");
+	if (comma < 0) return 0;
+	const header = url.slice(0, comma);
+	const payload = url.slice(comma + 1);
+	return /;base64$/i.test(header) ? base64ByteLength(payload) : payload.length;
+}
+
+/** Records keyed by their id, from an array, a Map or an id-keyed object.
+ * The first record wins so a duplicated id cannot flip a status. */
+function recordsById(source, key) {
+	const map = new Map();
+	const add = (record, fallbackId) => {
+		const id = nonEmptyString(record?.[key]) ?? nonEmptyString(fallbackId);
+		if (id && !map.has(id)) map.set(id, plainObject(record) ? record : {});
+	};
+	if (source instanceof Map) for (const [id, record] of source) add(record, id);
+	else if (Array.isArray(source)) for (const record of source) add(record);
+	else if (plainObject(source)) for (const [id, record] of Object.entries(source)) add(record, id);
+	return map;
+}
+
+function idSet(source) {
+	const out = new Set();
+	const iterable = source instanceof Map ? source.keys() : source;
+	if (!iterable || typeof iterable === "string" || typeof iterable[Symbol.iterator] !== "function") return out;
+	for (const id of iterable) if (typeof id === "string") out.add(id);
+	return out;
+}
+
+function deepEqual(a, b) {
+	if (a === b) return true;
+	if (Array.isArray(a) || Array.isArray(b)) {
+		if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+		return a.every((value, index) => deepEqual(value, b[index]));
+	}
+	if (plainObject(a) && plainObject(b)) {
+		const keys = Object.keys(a);
+		if (keys.length !== Object.keys(b).length) return false;
+		return keys.every((key) => Object.hasOwn(b, key) && deepEqual(a[key], b[key]));
+	}
+	return false;
+}
+
+function scenesOf(scenesDocument) {
+	return Array.isArray(scenesDocument?.scenes) ? scenesDocument.scenes : [];
+}
+
+function objectsOf(scene) {
+	return Array.isArray(scene?.objects) ? scene.objects : [];
+}
+
+function charactersOf(scene) {
+	return Array.isArray(scene?.stage?.characters) ? scene.stage.characters : [];
+}
+
+/**
+ * One item per (kind, id). A second sighting of the same resource only adds
+ * a ref — unless it resolves BETTER (a character that carries a url for a
+ * motion another character names by id alone), in which case the status is
+ * upgraded so the manifest is not order-dependent.
+ */
+function collector(kind) {
+	const items = new Map();
+	return {
+		items,
+		note(id, resolution, ref) {
+			let item = items.get(id);
+			if (!item) {
+				item = { kind, id, status: "missing", refs: [] };
+				items.set(id, item);
+			}
+			if (STATUS_RANK[resolution.status] >= STATUS_RANK[item.status]) {
+				item.status = resolution.status;
+				if (Number.isFinite(resolution.bytes)) item.bytes = resolution.bytes;
+				if (resolution.url) item.url = resolution.url;
+			}
+			if (resolution.stored) item.stored = true;
+			if (ref) item.refs.push(ref);
+			return item;
+		},
+	};
+}
+
+function resolveImage(id, assetsById, storedIds) {
+	const stored = storedIds.has(id);
+	const asset = assetsById.get(id);
+	if (asset) return { status: "embedded", bytes: byteSize(asset.bytes), stored };
+	return { status: "missing", stored };
+}
+
+function resolveMotion(motionId, url, motionsById) {
+	const record = motionId ? motionsById.get(motionId) : null;
+	if (record) return { status: "embedded", bytes: byteSize(record.bytes) ?? byteSize(record.data) };
+	if (url) return { status: "external", url };
+	return { status: "missing" };
+}
+
+function defaultWorkflowOutputRefs() {
+	return [];
+}
+
+/**
+ * The manifest.
+ *
+ * `workflowOutputRefs(graph)` is injected rather than imported so this module
+ * does not depend on the workflow track landing first; without it, the
+ * workflow contributes nothing. Its contract: an array of
+ * `{ nodeId, field, value, kind: "data-url"|"http"|"asset-ref"|"blob"|"other" }`.
+ */
+export function resourceManifest(options) {
+	const {
+		scenesDocument,
+		workflow,
+		poseLibrary,
+		assets,
+		motions,
+		storedAssetIds,
+		workflowOutputRefs,
+	} = plainObject(options) ? options : {};
+
+	const assetsById = recordsById(assets, "id");
+	const motionsById = recordsById(motions, "motionId");
+	const storedIds = idSet(storedAssetIds);
+	const scenes = scenesOf(scenesDocument);
+
+	const images = collector("image");
+	const motionItems = collector("motion");
+	const poses = collector("pose");
+	const outputs = collector("workflow-output");
+
+	/* ---- images: every lineage id on every scene object ---- */
+	for (const scene of scenes) {
+		const sceneId = nonEmptyString(scene?.id) ?? undefined;
+		for (const object of objectsOf(scene)) {
+			if (!plainObject(object)) continue;
+			const objectId = nonEmptyString(object.id) ?? undefined;
+			for (const field of IMAGE_LINEAGE_FIELDS) {
+				const id = object[field];
+				if (!isAssetId(id)) continue;
+				images.note(id, resolveImage(id, assetsById, storedIds), { sceneId, objectId, field });
+			}
+		}
+	}
+
+	/* ---- motions: motionId (embedded) → url (external) → missing ---- */
+	for (const scene of scenes) {
+		const sceneId = nonEmptyString(scene?.id) ?? undefined;
+		for (const character of charactersOf(scene)) {
+			const ref = character?.motionRef;
+			if (!plainObject(ref)) continue;
+			const motionId = nonEmptyString(ref.motionId);
+			const url = nonEmptyString(ref.url);
+			const id = motionId ?? url;
+			if (!id) continue;
+			const characterId = nonEmptyString(character.id) ?? undefined;
+			motionItems.note(id, resolveMotion(motionId, url, motionsById), { sceneId, characterId, field: "motionRef" });
+		}
+	}
+
+	/* ---- poses: the library is embedded; a character wearing one is a ref ---- */
+	const library = [];
+	for (const entry of Array.isArray(poseLibrary) ? poseLibrary : []) {
+		if (!plainObject(entry) || !plainObject(entry.bones)) continue;
+		const id = nonEmptyString(entry.id);
+		if (!id || poses.items.has(id)) continue;
+		poses.note(id, { status: "embedded" });
+		library.push({ id, bones: entry.bones });
+	}
+	if (library.length) {
+		for (const scene of scenes) {
+			const sceneId = nonEmptyString(scene?.id) ?? undefined;
+			for (const character of charactersOf(scene)) {
+				const bones = character?.pose?.bones;
+				if (!plainObject(bones)) continue;
+				const match = library.find((entry) => deepEqual(entry.bones, bones));
+				if (!match) continue;
+				poses.note(match.id, { status: "embedded" }, { sceneId, characterId: nonEmptyString(character.id) ?? undefined, field: "pose" });
+			}
+		}
+	}
+
+	/* ---- workflow outputs: what a node is holding on to ---- */
+	const refs = (typeof workflowOutputRefs === "function" ? workflowOutputRefs : defaultWorkflowOutputRefs)(workflow);
+	for (const ref of Array.isArray(refs) ? refs : []) {
+		if (!plainObject(ref)) continue;
+		const nodeId = nonEmptyString(ref.nodeId);
+		const field = nonEmptyString(ref.field);
+		if (!nodeId || !field) continue;
+		const location = { nodeId, field };
+		const id = `${nodeId}:${field}`;
+		const { value } = ref;
+		if (ref.kind === "data-url" && typeof value === "string") {
+			outputs.note(id, { status: "embedded", bytes: dataUrlByteLength(value) }, location);
+		} else if (ref.kind === "http" && typeof value === "string") {
+			outputs.note(id, { status: "external", url: value }, location);
+		} else if (ref.kind === "asset-ref") {
+			// An interned output IS an image: the picture item gains the node as
+			// a ref, and the output mirrors its status without recounting bytes.
+			const assetId = typeof value === "string" ? value : value?.assetRef;
+			if (isAssetId(assetId)) {
+				const resolution = resolveImage(assetId, assetsById, storedIds);
+				images.note(assetId, resolution, location);
+				outputs.note(id, { status: resolution.status, stored: resolution.stored }, location);
+			} else {
+				outputs.note(id, { status: "missing" }, location);
+			}
+		} else {
+			// blob: URLs die with the page; anything else is unrecognisable.
+			outputs.note(id, { status: "missing", url: typeof value === "string" && !value.startsWith("data:") ? value : undefined }, location);
+		}
+	}
+
+	const items = [...images.items.values(), ...motionItems.items.values(), ...poses.items.values(), ...outputs.items.values()];
+	const totals = { embedded: 0, external: 0, missing: 0, bytes: 0 };
+	for (const item of items) {
+		totals[item.status] += 1;
+		if (Number.isFinite(item.bytes)) totals.bytes += item.bytes;
+	}
+	return { items, totals, missing: items.filter((item) => item.status === "missing") };
+}

--- a/test/verify-project-resources.mjs
+++ b/test/verify-project-resources.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+// The resource manifest is what tells a user whether a .cclayproject will
+// survive a new browser: every picture, clip, pose and workflow output the
+// project names, with a status that says where its bytes are. These checks
+// pin the classification rules and the lineage walk, and that a broken
+// document degrades to fewer items rather than a throw.
+
+import { resourceManifest } from "../src/project-resources.js";
+import { createCutoutObject } from "../src/scene-objects.js";
+import { createSceneDocument, createSceneStage } from "../src/scenes.js";
+
+let failures = 0;
+function expect(name, condition, detail = "") {
+	console.log(`${condition ? "PASS" : "FAIL"} ${name}${condition ? "" : ` — ${detail}`}`);
+	if (!condition) failures += 1;
+}
+
+const hex32 = (seed) => seed.repeat(32).slice(0, 32);
+const hex64 = (seed) => seed.repeat(64).slice(0, 64);
+const RENDER_ID = `img-${hex32("a")}`;
+const SOURCE_ID = `img-${hex32("b")}`;
+const MATTE_ID = `img-${hex32("c")}`;
+const STORED_ONLY_ID = `img-${hex32("d")}`;
+const EMBEDDED_MOTION = hex64("1");
+const MISSING_MOTION = hex64("2");
+const RECOVERABLE_MOTION = hex64("3");
+
+function asset(id, size) {
+	return { id, type: "image/png", width: 4, height: 4, name: `${id}.png`, bytes: new ArrayBuffer(size) };
+}
+
+const itemOf = (manifest, kind, id) => manifest.items.find((item) => item.kind === kind && item.id === id);
+
+/* ---------------------------------------------------------- images ---- */
+
+const cutout = createCutoutObject({ assetId: RENDER_ID, sourceAssetId: SOURCE_ID, matteAssetId: MATTE_ID, name: "Hero" });
+const storedOnly = createCutoutObject({ assetId: STORED_ONLY_ID, name: "Backdrop" }, [cutout]);
+const scenesDocument = createSceneDocument();
+const [scene] = scenesDocument.scenes;
+scene.objects = [cutout, storedOnly];
+
+const images = resourceManifest({
+	scenesDocument,
+	assets: [asset(RENDER_ID, 100), asset(SOURCE_ID, 250)],
+	storedAssetIds: [STORED_ONLY_ID, RENDER_ID],
+});
+const render = itemOf(images, "image", RENDER_ID);
+const source = itemOf(images, "image", SOURCE_ID);
+const matte = itemOf(images, "image", MATTE_ID);
+expect("all three lineage ids of a cutout become items", Boolean(render && source && matte), JSON.stringify(images.items.map((item) => item.id)));
+expect("the rendered picture is embedded with its size", render?.status === "embedded" && render.bytes === 100, JSON.stringify(render));
+expect("the photograph it came from is embedded", source?.status === "embedded" && source.bytes === 250, JSON.stringify(source));
+expect("the matte is missing when it is nowhere", matte?.status === "missing" && matte.stored !== true, JSON.stringify(matte));
+expect(
+	"each lineage field is a ref on the object",
+	render?.refs.length === 1 && render.refs[0].sceneId === scene.id && render.refs[0].objectId === cutout.id && render.refs[0].field === "assetId"
+		&& source?.refs[0]?.field === "sourceAssetId" && matte?.refs[0]?.field === "matteAssetId",
+	JSON.stringify([render?.refs, source?.refs, matte?.refs]),
+);
+const stored = itemOf(images, "image", STORED_ONLY_ID);
+expect("an image the browser still holds is missing but stored", stored?.status === "missing" && stored.stored === true, JSON.stringify(stored));
+expect("an embedded image that is also stored is just embedded", render?.status === "embedded" && render.stored === true, JSON.stringify(render));
+expect(
+	"a fresh cutout names its own picture as its source, once per field",
+	stored?.refs.length === 2 && stored.refs.map((ref) => ref.field).join() === "assetId,sourceAssetId",
+	JSON.stringify(stored?.refs),
+);
+
+const sharedDocument = createSceneDocument();
+sharedDocument.scenes[0].objects = [cutout];
+sharedDocument.scenes.push({ ...sharedDocument.scenes[0], id: "scene-2", name: "SCENE 02", objects: [{ ...cutout, id: "hero-copy" }] });
+const shared = itemOf(resourceManifest({ scenesDocument: sharedDocument, assets: [asset(RENDER_ID, 1)] }), "image", RENDER_ID);
+expect("the same picture on two scenes is one item with two refs", shared?.refs.length === 2 && shared.refs[1].sceneId === "scene-2" && shared.refs[1].objectId === "hero-copy", JSON.stringify(shared));
+
+expect(
+	"a malformed asset id on an object is not an item",
+	resourceManifest({ scenesDocument: { scenes: [{ id: "s", objects: [{ id: "o", assetId: "img-nope", sourceAssetId: 5, matteAssetId: null }] }] } }).items.length === 0,
+);
+expect(
+	"assets given as a Map or an id-keyed object resolve the same",
+	itemOf(resourceManifest({ scenesDocument, assets: new Map([[RENDER_ID, asset(RENDER_ID, 7)]]) }), "image", RENDER_ID)?.status === "embedded"
+		&& itemOf(resourceManifest({ scenesDocument, assets: { [RENDER_ID]: asset(RENDER_ID, 7) } }), "image", RENDER_ID)?.status === "embedded",
+);
+expect(
+	"base64 bytes from a project file still count",
+	itemOf(resourceManifest({ scenesDocument, assets: [{ ...asset(RENDER_ID, 0), bytes: "AAAA" }] }), "image", RENDER_ID)?.bytes === 3,
+);
+
+/* --------------------------------------------------------- motions ---- */
+
+const motionStage = createSceneStage({
+	characters: [
+		{ id: "char-a", motionRef: { url: "https://bridge/take-1.npz", prompt: "walk" } },
+		{ id: "char-b", motionRef: { url: "https://bridge/take-2.npz", prompt: "run" } },
+		{ id: "char-c", motionRef: { url: "https://bridge/take-3.npz", prompt: "jump" } },
+		{ id: "char-d", motionRef: { url: "https://bridge/take-4.npz", prompt: "sit" } },
+	],
+});
+// scenes.js does not carry motionId yet (that is another track); the manifest
+// reads the field straight off the character, so set it after normalisation.
+motionStage.characters[0].motionRef = { motionId: EMBEDDED_MOTION, prompt: "walk", rotationDeg: 0, anchorX: 0, anchorZ: 0 };
+motionStage.characters[2].motionRef = { motionId: MISSING_MOTION, prompt: "jump", rotationDeg: 0, anchorX: 0, anchorZ: 0 };
+motionStage.characters[3].motionRef = { motionId: RECOVERABLE_MOTION, url: "https://bridge/take-4.npz", prompt: "sit", rotationDeg: 0, anchorX: 0, anchorZ: 0 };
+const motionDocument = createSceneDocument();
+motionDocument.scenes[0].stage = motionStage;
+const motionRecord = { motionId: EMBEDDED_MOTION, encoding: "base64", data: "AAAA", bytes: 3, frames: 1, fps: 30 };
+
+const motions = resourceManifest({ scenesDocument: motionDocument, motions: [motionRecord] });
+const embeddedMotion = itemOf(motions, "motion", EMBEDDED_MOTION);
+const externalMotion = itemOf(motions, "motion", "https://bridge/take-2.npz");
+const missingMotion = itemOf(motions, "motion", MISSING_MOTION);
+const recoverableMotion = itemOf(motions, "motion", RECOVERABLE_MOTION);
+expect("a motionId found in motions is embedded", embeddedMotion?.status === "embedded" && embeddedMotion.bytes === 3, JSON.stringify(embeddedMotion));
+expect("a url-only motionRef is external and keeps the url", externalMotion?.status === "external" && externalMotion.url === "https://bridge/take-2.npz", JSON.stringify(externalMotion));
+expect(
+	"a motionId with no record and no url is missing",
+	missingMotion?.status === "missing",
+	JSON.stringify(missingMotion),
+);
+expect(
+	"a motionId with no record falls back to its url as external",
+	recoverableMotion?.status === "external" && recoverableMotion.url === "https://bridge/take-4.npz",
+	JSON.stringify(recoverableMotion),
+);
+expect(
+	"motion refs name the scene and the character",
+	embeddedMotion?.refs.length === 1 && embeddedMotion.refs[0].sceneId === motionDocument.scenes[0].id && embeddedMotion.refs[0].characterId === "char-a" && embeddedMotion.refs[0].field === "motionRef"
+		&& missingMotion?.refs.map((ref) => ref.characterId).join() === "char-c",
+	JSON.stringify([embeddedMotion?.refs, missingMotion?.refs]),
+);
+const upgraded = itemOf(resourceManifest({ scenesDocument: { scenes: [{ id: "s", objects: [], stage: { characters: [
+	{ id: "first", motionRef: { motionId: RECOVERABLE_MOTION } },
+	{ id: "second", motionRef: { motionId: RECOVERABLE_MOTION, url: "https://bridge/take-4.npz" } },
+] } }] } }), "motion", RECOVERABLE_MOTION);
+expect(
+	"a later sighting that carries a url upgrades the item, so order does not decide status",
+	upgraded?.status === "external" && upgraded.url === "https://bridge/take-4.npz" && upgraded.refs.map((ref) => ref.characterId).join() === "first,second",
+	JSON.stringify(upgraded),
+);
+expect(
+	"motions given as a Map keyed by motionId resolve too",
+	itemOf(resourceManifest({ scenesDocument: motionDocument, motions: new Map([[EMBEDDED_MOTION, motionRecord]]) }), "motion", EMBEDDED_MOTION)?.status === "embedded",
+);
+expect(
+	"a character without a motionRef contributes nothing",
+	resourceManifest({ scenesDocument: { scenes: [{ id: "s", objects: [], stage: { characters: [{ id: "a", motionRef: null }, { id: "b", motionRef: {} }, { id: "c" }] } }] } }).items.length === 0,
+);
+
+/* ----------------------------------------------------------- poses ---- */
+
+const wave = { id: "custom_1", label: "Wave", prompt: "waving", bones: { lArm: [1, 0, 0], lForeArm: [0, 0.5, 0] }, custom: true };
+const crouch = { id: "photo_1", label: "Crouch", prompt: "crouching", bones: { hips: [0.2, 0, 0] }, custom: true };
+const poseStage = createSceneStage({
+	characters: [
+		{ id: "char-a", pose: { id: "custom_1", label: "Wave", bones: { lArm: [1, 0, 0], lForeArm: [0, 0.5, 0] } } },
+		{ id: "char-b", pose: { id: "default", bones: { lArm: [1.5632, 0.1164, -0.2889] } } },
+		{ id: "char-c", pose: { id: "custom_1", bones: { lForeArm: [0, 0.5, 0], lArm: [1, 0, 0] } } },
+		{ id: "char-d", pose: null },
+	],
+});
+const poseDocument = createSceneDocument();
+poseDocument.scenes[0].stage = poseStage;
+const poses = resourceManifest({ scenesDocument: poseDocument, poseLibrary: [wave, crouch, { id: "broken" }, null, { id: "custom_1", bones: {} }] });
+const waveItem = itemOf(poses, "pose", "custom_1");
+const crouchItem = itemOf(poses, "pose", "photo_1");
+expect("every library pose is an embedded item", waveItem?.status === "embedded" && crouchItem?.status === "embedded", JSON.stringify(poses.items));
+expect("a library entry without bones is not a pose", !itemOf(poses, "pose", "broken") && poses.items.filter((item) => item.kind === "pose").length === 2);
+expect(
+	"a character whose bones deep-equal a library pose is a ref, key order aside",
+	waveItem?.refs.length === 2 && waveItem.refs.map((ref) => ref.characterId).join() === "char-a,char-c" && waveItem.refs.every((ref) => ref.field === "pose" && ref.sceneId === poseDocument.scenes[0].id),
+	JSON.stringify(waveItem?.refs),
+);
+expect("a character in a pose the library does not hold is not a ref", crouchItem?.refs.length === 0 && poses.items.every((item) => item.kind !== "pose" || item.refs.every((ref) => ref.characterId !== "char-b")));
+expect("a pose sharing an id but not bones is not matched", resourceManifest({ scenesDocument: poseDocument, poseLibrary: [{ ...wave, bones: { lArm: [9, 9, 9] } }] }).items[0].refs.length === 0);
+
+/* ------------------------------------------------- workflow outputs ---- */
+
+const workflow = { version: 1, nodes: [{ id: "n1" }], edges: [] };
+let receivedGraph = null;
+const workflowOutputRefs = (graph) => {
+	receivedGraph = graph;
+	return [
+		{ nodeId: "n1", field: "data.resultUrl", value: "data:image/png;base64,AAAA", kind: "data-url" },
+		{ nodeId: "n1", field: "data.videoUrl", value: "https://cdn/out.mp4", kind: "http" },
+		{ nodeId: "n2", field: "data.lastOutput.renderUrl", value: { assetRef: RENDER_ID }, kind: "asset-ref" },
+		{ nodeId: "n2", field: "data.fileUrl", value: "blob:https://app/abc", kind: "blob" },
+		{ nodeId: "n3", field: "data.outputs[0].value", value: { assetRef: "img-nope" }, kind: "asset-ref" },
+		{ nodeId: "", field: "data.resultUrl", value: "data:image/png;base64,AAAA", kind: "data-url" },
+		null,
+	];
+};
+const outputs = resourceManifest({ scenesDocument, workflow, assets: [asset(RENDER_ID, 5)], workflowOutputRefs });
+const outputItems = outputs.items.filter((item) => item.kind === "workflow-output");
+const byId = Object.fromEntries(outputItems.map((item) => [item.id, item]));
+expect("the injected walker receives the workflow graph", receivedGraph === workflow);
+expect("a data: URL output is embedded with its decoded size", byId["n1:data.resultUrl"]?.status === "embedded" && byId["n1:data.resultUrl"].bytes === 3, JSON.stringify(byId["n1:data.resultUrl"]));
+expect("an http output is external with its url", byId["n1:data.videoUrl"]?.status === "external" && byId["n1:data.videoUrl"].url === "https://cdn/out.mp4", JSON.stringify(byId["n1:data.videoUrl"]));
+expect("an interned output follows its image", byId["n2:data.lastOutput.renderUrl"]?.status === "embedded" && !("bytes" in byId["n2:data.lastOutput.renderUrl"]), JSON.stringify(byId["n2:data.lastOutput.renderUrl"]));
+expect(
+	"the interned output's node is a ref on the image item",
+	itemOf(outputs, "image", RENDER_ID)?.refs.some((ref) => ref.nodeId === "n2" && ref.field === "data.lastOutput.renderUrl"),
+	JSON.stringify(itemOf(outputs, "image", RENDER_ID)?.refs),
+);
+expect("a blob: URL is missing (it died with its page)", byId["n2:data.fileUrl"]?.status === "missing" && byId["n2:data.fileUrl"].url === "blob:https://app/abc", JSON.stringify(byId["n2:data.fileUrl"]));
+expect("an asset-ref to an unknown id is missing", byId["n3:data.outputs[0].value"]?.status === "missing", JSON.stringify(byId["n3:data.outputs[0].value"]));
+expect("refs without a node or that are not objects are skipped", outputItems.length === 5, JSON.stringify(Object.keys(byId)));
+expect("each output ref names its node and field", outputItems.every((item) => item.refs.length === 1 && item.refs[0].nodeId && item.refs[0].field));
+expect("without a walker the workflow contributes nothing", resourceManifest({ scenesDocument, workflow }).items.every((item) => item.kind !== "workflow-output"));
+expect("a walker returning garbage contributes nothing", resourceManifest({ scenesDocument, workflow, workflowOutputRefs: () => "nope" }).items.every((item) => item.kind !== "workflow-output"));
+
+/* ---------------------------------------------------------- totals ---- */
+
+const everything = resourceManifest({
+	scenesDocument: { version: 4, activeSceneId: "s1", scenes: [{ ...scene, stage: { ...motionStage, characters: [...motionStage.characters, ...poseStage.characters] } }] },
+	workflow,
+	poseLibrary: [wave, crouch],
+	assets: [asset(RENDER_ID, 100), asset(SOURCE_ID, 250)],
+	motions: [motionRecord],
+	storedAssetIds: [STORED_ONLY_ID],
+	workflowOutputRefs,
+});
+const counted = everything.items.reduce((sum, item) => {
+	sum[item.status] += 1;
+	return sum;
+}, { embedded: 0, external: 0, missing: 0 });
+expect(
+	"totals count every item exactly once by status",
+	everything.totals.embedded === counted.embedded && everything.totals.external === counted.external && everything.totals.missing === counted.missing
+		&& everything.totals.embedded + everything.totals.external + everything.totals.missing === everything.items.length,
+	JSON.stringify([everything.totals, counted]),
+);
+expect(
+	"the expected split: 2 images + 1 motion + 2 poses + 2 outputs embedded, 2 motions + 1 output external, 2 images + 1 motion + 2 outputs missing",
+	everything.totals.embedded === 7 && everything.totals.external === 3 && everything.totals.missing === 5,
+	JSON.stringify(everything.totals),
+);
+expect("bytes sum the embedded payloads", everything.totals.bytes === 100 + 250 + 3 + 3, String(everything.totals.bytes));
+expect(
+	"missing is the items whose status is missing, in item order",
+	everything.missing.length === 5 && everything.missing.every((item) => item.status === "missing")
+		&& everything.missing.map((item) => item.id).join() === `${MATTE_ID},${STORED_ONLY_ID},${MISSING_MOTION},n2:data.fileUrl,n3:data.outputs[0].value`,
+	JSON.stringify(everything.missing.map((item) => item.id)),
+);
+expect(
+	"items are grouped image, motion, pose, workflow-output",
+	everything.items.map((item) => item.kind).join() === "image,image,image,image,motion,motion,motion,motion,pose,pose,workflow-output,workflow-output,workflow-output,workflow-output,workflow-output",
+	everything.items.map((item) => item.kind).join(),
+);
+expect("every item has a unique (kind, id)", new Set(everything.items.map((item) => `${item.kind}\u0000${item.id}`)).size === everything.items.length);
+
+/* -------------------------------------------------- hostile input ---- */
+
+const empty = { items: [], totals: { embedded: 0, external: 0, missing: 0, bytes: 0 }, missing: [] };
+const hostile = [
+	undefined,
+	null,
+	"scenes",
+	42,
+	[],
+	{},
+	{ scenesDocument: null, workflow: null, poseLibrary: null, assets: null, motions: null, storedAssetIds: null },
+	{ scenesDocument: "x", workflow: 1, poseLibrary: "poses", assets: "assets", motions: 7, storedAssetIds: "img-1" },
+	{ scenesDocument: { scenes: "nope" }, poseLibrary: {}, assets: {}, motions: {}, storedAssetIds: {} },
+	{ scenesDocument: { scenes: [null, 1, "s", [], { id: 3, objects: null, stage: null }, { objects: [null, 1, "o", []], stage: { characters: [null, 1, "c", [], { pose: "x", motionRef: "y" }, { pose: { bones: "b" } }] } }] } },
+	{ scenesDocument, assets: [null, 1, "a", [], { id: RENDER_ID, bytes: NaN }, { bytes: new ArrayBuffer(2) }], motions: [null, { motionId: 5 }, { data: 1 }], poseLibrary: [1, "p", [], { id: 1, bones: {} }, { id: "x", bones: [] }] },
+	{ scenesDocument, workflowOutputRefs: "not a function" },
+	{ scenesDocument, workflowOutputRefs: () => null },
+	{ scenesDocument, workflowOutputRefs: () => [{ nodeId: "n", field: "f", kind: "data-url", value: 5 }, { nodeId: "n", field: "g", kind: "http", value: {} }, { nodeId: "n", field: "h", kind: "asset-ref", value: null }, { nodeId: "n", field: "i", kind: "weird" }] },
+];
+for (const [index, input] of hostile.entries()) {
+	let result = null;
+	let error = null;
+	try {
+		result = resourceManifest(input);
+	} catch (caught) {
+		error = caught;
+	}
+	const shaped = result && Array.isArray(result.items) && Array.isArray(result.missing) && result.totals
+		&& ["embedded", "external", "missing", "bytes"].every((key) => Number.isInteger(result.totals[key]) && result.totals[key] >= 0)
+		&& result.items.every((item) => ["image", "motion", "pose", "workflow-output"].includes(item.kind) && typeof item.id === "string" && ["embedded", "external", "missing"].includes(item.status) && Array.isArray(item.refs));
+	expect(`hostile input #${index} yields a well-formed manifest`, !error && shaped, error ? String(error.stack ?? error) : JSON.stringify(result));
+}
+expect("nothing at all is an empty manifest", JSON.stringify(resourceManifest()) === JSON.stringify(empty), JSON.stringify(resourceManifest()));
+expect(
+	"the manifest never mutates its inputs",
+	(() => {
+		const before = JSON.stringify([scenesDocument, [wave, crouch]]);
+		resourceManifest({ scenesDocument, poseLibrary: [wave, crouch], assets: [asset(RENDER_ID, 1)], storedAssetIds: [STORED_ONLY_ID] });
+		return JSON.stringify([scenesDocument, [wave, crouch]]) === before;
+	})(),
+);
+
+if (failures) process.exit(1);
+console.log("all project resource checks PASS");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -172,6 +172,7 @@ const NODE_FILES = [
 	"test/verify-number-field-scrub.mjs",
 	"test/verify-speed-envelope.mjs",
 	"test/verify-motion-resources.mjs",
+	"test/verify-project-resources.mjs",
 ];
 
 const BROWSER_FILES = [


### PR DESCRIPTION
Closes #229

## What

`src/project-resources.js` (new): `resourceManifest({ scenesDocument, workflow, poseLibrary, assets, motions, storedAssetIds?, workflowOutputRefs? })` — a pure runtime calculation, never written to the file. Returns `{ items, totals, missing }` in the shape fixed by the issue spec.

- **image**: every `assetId` / `sourceAssetId` / `matteAssetId` on every scene object, the same lineage walk as `assetUsageCounts`. In `assets` → `embedded` (+ `bytes`); only in `storedAssetIds` → `missing` + `stored: true`; neither → `missing`. `assets` / `motions` accept an array, a Map, or an id-keyed object.
- **motion**: `motionRef.motionId` ∈ motions → `embedded`; url only → `external` (+ `url`); otherwise `missing`. An item seen twice keeps one entry and accumulates refs; a later sighting that resolves better (e.g. carries a url) upgrades the status so the result is not order-dependent.
- **pose**: every `poseLibrary` entry is `embedded`; a `stage.characters[].pose.bones` that deep-equals a library entry (key order aside) is attached as a ref. No schema change.
- **workflow-output**: `workflowOutputRefs(graph)` is injected as an option (default: contributes nothing) so this track shares no file with track 4. `data-url` → embedded, `http` → external, `asset-ref` → mirrors the image item and adds the node as a ref on it, `blob`/other → missing.
- `totals` / `missing` derived from items. Hostile input (null, non-arrays, malformed ids, garbage walker) yields fewer items, never a throw; inputs are never mutated.

Items are grouped image → motion → pose → workflow-output; `(kind, id)` is unique.

`test/verify-project-resources.mjs` (new) covers every bullet in the issue's test list plus the upgrade rule, Map/object inputs, and 14 hostile-input shapes. One line appended to `NODE_FILES` in `tools/run-tests.mjs`.

Not touched: App.jsx, UI, scenes.js, scene-assets.js, project.js.

## Verification

```
$ node test/verify-project-resources.mjs
all project resource checks PASS

$ npm run build   # ok
$ node tools/run-tests.mjs
PASS 166 Node verification files
```

## Notes for the reviewer (no changes made)

- `node tools/run-tests.mjs` on a fresh worktree fails in `test/verify-agent-routes.mjs` with `Cannot find package 'ws' imported from mcp/live-hub.mjs` until `npm --prefix mcp ci` is run. `run-tests.mjs` already degrades the `mcp/` suites when those deps are missing, but `verify-agent-routes.mjs` lives under `test/` and imports the hub directly, so it is not covered by that guard. Pre-existing, unrelated to this PR.
- `scenes.js`'s `normalizeMotionRef` still drops a `motionRef` without a `url`, so a motionId-only ref does not survive `createCharacterEntry` today. The manifest reads the field straight off the character and handles both, so it is ready for the scenes track that adds `motionId`; the test sets `motionRef` after normalisation for that reason.
