### PR TITLE
feat(project): v4 resources manifest with embedded motions (#227)

### DIFF
--- a/src/project.js
+++ b/src/project.js
@@ -3,9 +3,10 @@
  *
  * A project is ONE file (`.cclayproject`, JSON) holding the full authoring
  * state: the scene document (scenes + cast + animation layers), the
- * workspace layout, and the custom pose library. Editor preferences
- * (theme, locale) deliberately stay OUT — they belong to the operator, not
- * the project.
+ * workspace layout, the custom pose library, the workflow graph, and the
+ * embedded resources (images + motions) the scenes point at. Editor
+ * preferences (theme, locale) deliberately stay OUT — they belong to the
+ * operator, not the project.
  *
  * Files are read/written with the File System Access API when available,
  * with a plain download/upload fallback. The last-used handle is kept in
@@ -14,15 +15,22 @@
  */
 
 import { SCENES_VERSION } from "./scenes.js";
-import { ASSET_MAX_SOURCE_BYTES, assetIdForBytes, normalizeAsset, referencedAssetIds } from "./scene-assets.js";
+import { ASSET_MAX_SOURCE_BYTES, assetIdForBytes, isAssetId, normalizeAsset, referencedAssetIds } from "./scene-assets.js";
 
-export const PROJECT_VERSION = 3;
+export const PROJECT_VERSION = 4;
 export const PROJECT_EXTENSION = ".cclayproject";
 export const WORKFLOW_VERSION = 1;
 export const WORKFLOW_STORAGE_KEY = "cozyclay.workflow.v1";
 const IDB_NAME = "cozyclay.project-handle.v1";
 const IDB_STORE = "kv";
 const IDB_KEY = "lastProjectHandle";
+
+// Embedded resources are bounded: the file is JSON, so every raw byte costs
+// 4/3 on disk and the whole file has to fit in one string on the way in.
+export const MOTION_MAX_BYTES = 192 * 1024 * 1024;
+export const PROJECT_MAX_RESOURCE_BYTES = 256 * 1024 * 1024;
+// A motion id is the SHA-256 of the raw NPZ bytes (see motion-resources.js).
+const MOTION_ID_PATTERN = /^[0-9a-f]{64}$/i;
 
 /* ---------------------------- workflow graph --------------------------- */
 
@@ -164,22 +172,45 @@ function bytesToBase64(bytes) {
 	return btoa(binary);
 }
 
-function base64ToBytes(value) {
-	if (typeof value !== "string" || value.length < 4 || value.length % 4 || value.length > Math.ceil(ASSET_MAX_SOURCE_BYTES / 3) * 4) return null;
-	for (let index = 0; index < value.length; index += 1) {
+/**
+ * Structural check of a base64 payload without decoding it: character set,
+ * padding, and the byte length the string implies. Returns `{ bytes }` or
+ * `{ code }` with a problem code.
+ */
+function base64Shape(value, limit) {
+	if (typeof value !== "string" || value.length < 4 || value.length % 4) return { code: "bad-base64" };
+	if (value.length > Math.ceil(limit / 3) * 4) return { code: "too-large" };
+	const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+	for (let index = 0; index < value.length - padding; index += 1) {
 		const code = value.charCodeAt(index);
 		const base64Character = (code >= 65 && code <= 90) || (code >= 97 && code <= 122) || (code >= 48 && code <= 57) || code === 43 || code === 47;
-		if (!base64Character && code !== 61) return null;
-		if (code === 61 && index < value.length - 2) return null;
+		if (!base64Character) return { code: "bad-base64" };
 	}
+	const bytes = (value.length / 4) * 3 - padding;
+	return bytes > limit ? { code: "too-large" } : { bytes };
+}
+
+/** Decode a base64 payload. Returns `{ buffer }` or `{ code }`. */
+function base64ToBytes(value, limit) {
+	const shape = base64Shape(value, limit);
+	if (shape.code) return shape;
 	try {
 		const binary = atob(value);
 		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-		if (bytes.byteLength > ASSET_MAX_SOURCE_BYTES || bytesToBase64(bytes) !== value) return null;
-		return bytes.buffer;
+		// Only the canonical encoding is accepted so a payload has one spelling.
+		if (bytesToBase64(bytes) !== value) return { code: "bad-base64" };
+		return { buffer: bytes.buffer };
 	} catch {
-		return null;
+		return { code: "bad-base64" };
 	}
+}
+
+function resourcesTooLarge(bytes, limit, what) {
+	const error = new Error(`${what} (${bytes} bytes) exceeds the ${limit}-byte limit.`);
+	error.code = "resources-too-large";
+	error.bytes = bytes;
+	error.limit = limit;
+	return error;
 }
 
 function embeddedAsset(record) {
@@ -188,7 +219,44 @@ function embeddedAsset(record) {
 	if (!asset || asset.bytes.byteLength > ASSET_MAX_SOURCE_BYTES) return null;
 	// Base64 keeps JSON's asset payload unambiguous; a data URL would duplicate
 	// MIME metadata already carried by `type` and force every reader to strip it.
-	return { ...asset, bytes: bytesToBase64(asset.bytes) };
+	return { record: { ...asset, bytes: bytesToBase64(asset.bytes) }, bytes: asset.bytes.byteLength };
+}
+
+/** The optional motion fields carried verbatim; frames/fps come from the
+ * encoder (motion-resources.js), never from decoding the NPZ here. */
+function motionDetails(record) {
+	return {
+		...(Number.isInteger(record.frames) && record.frames >= 0 ? { frames: record.frames } : {}),
+		...(Number.isFinite(record.fps) && record.fps > 0 ? { fps: record.fps } : {}),
+		...(typeof record.name === "string" && record.name.trim() ? { name: record.name } : {}),
+		...(plainRecord(record.meta) ? { meta: jsonValue(record.meta) } : {}),
+	};
+}
+
+function motionId(value) {
+	return typeof value === "string" && MOTION_ID_PATTERN.test(value) ? value.toLowerCase() : null;
+}
+
+/**
+ * Validate a motion record for embedding. Accepts the encoded shape
+ * (`encoding: "base64"`, `data`) and raw `bytes` (ArrayBuffer or view); the
+ * payload is encoded later, once the size budget is known to hold.
+ */
+function embeddedMotion(record) {
+	if (!record || typeof record !== "object") return null;
+	const id = motionId(record.motionId);
+	if (!id) return null;
+	const raw = asArrayBuffer(record.bytes);
+	if (raw) {
+		if (!raw.byteLength) return null;
+		if (raw.byteLength > MOTION_MAX_BYTES) throw resourcesTooLarge(raw.byteLength, MOTION_MAX_BYTES, `Motion ${id}`);
+		return { motionId: id, bytes: raw.byteLength, raw, details: motionDetails(record) };
+	}
+	if (record.encoding !== "base64") return null;
+	const shape = base64Shape(record.data, MOTION_MAX_BYTES);
+	if (shape.code === "too-large") throw resourcesTooLarge((record.data.length / 4) * 3, MOTION_MAX_BYTES, `Motion ${id}`);
+	if (shape.code || (record.bytes !== undefined && record.bytes !== shape.bytes)) return null;
+	return { motionId: id, bytes: shape.bytes, data: record.data, details: motionDetails(record) };
 }
 
 /** Verify that an embedded record still belongs at its content-addressed id. */
@@ -202,33 +270,117 @@ export async function verifyEmbeddedAsset(record, subtle) {
 	}
 }
 
-function readEmbeddedAssets(value) {
+const PROBLEM_DETAILS = {
+	"bad-id": "its id is not a content address",
+	duplicate: "the same id appears earlier in the file",
+	"bad-encoding": "its encoding is not base64",
+	"bad-base64": "its payload is not valid base64",
+	"length-mismatch": "its payload does not match the recorded byte length",
+	"too-large": "its payload exceeds the size limit",
+	"bad-record": "its metadata is incomplete",
+};
+
+function readEmbeddedAssets(value, report) {
 	const assets = [];
-	const warnings = [];
-	if (!Array.isArray(value)) return { assets, warnings };
+	if (!Array.isArray(value)) return assets;
+	const seen = new Set();
 	for (const entry of value) {
-		const bytes = base64ToBytes(entry?.bytes);
-		const asset = bytes && normalizeAsset({ ...entry, bytes });
-		if (!asset || asset.bytes.byteLength > ASSET_MAX_SOURCE_BYTES) {
-			warnings.push("Skipped an invalid embedded asset.");
+		const id = typeof entry?.id === "string" ? entry.id : null;
+		if (!isAssetId(id)) {
+			report("image", id, "bad-id");
 			continue;
 		}
+		if (seen.has(id)) {
+			report("image", id, "duplicate");
+			continue;
+		}
+		const decoded = base64ToBytes(entry.bytes, ASSET_MAX_SOURCE_BYTES);
+		if (decoded.code) {
+			report("image", id, decoded.code);
+			continue;
+		}
+		const asset = normalizeAsset({ ...entry, bytes: decoded.buffer });
+		if (!asset) {
+			report("image", id, "bad-record");
+			continue;
+		}
+		seen.add(id);
 		assets.push(asset);
 	}
-	return { assets, warnings };
+	return assets;
 }
 
-export function createProjectDocument({ scenesDocument, workspaceLayout, customPoses, name, assets, savedAt, workflow }) {
+/** Motion records are returned in their encoded shape; decoding and hash
+ * verification belong to motion-resources.js. */
+function readEmbeddedMotions(value, report) {
+	const motions = [];
+	if (!Array.isArray(value)) return motions;
+	const seen = new Set();
+	for (const entry of value) {
+		const id = motionId(entry?.motionId);
+		if (!id) {
+			report("motion", typeof entry?.motionId === "string" ? entry.motionId : null, "bad-id");
+			continue;
+		}
+		if (seen.has(id)) {
+			report("motion", id, "duplicate");
+			continue;
+		}
+		if (entry.encoding !== "base64") {
+			report("motion", id, "bad-encoding");
+			continue;
+		}
+		const shape = base64Shape(entry.data, MOTION_MAX_BYTES);
+		if (shape.code) {
+			report("motion", id, shape.code);
+			continue;
+		}
+		if (entry.bytes !== shape.bytes) {
+			report("motion", id, "length-mismatch");
+			continue;
+		}
+		seen.add(id);
+		motions.push({ motionId: id, encoding: "base64", data: entry.data, bytes: shape.bytes, ...motionDetails(entry) });
+	}
+	return motions;
+}
+
+/**
+ * Build the v4 envelope. Images are embedded only when a scene references
+ * them; motions are embedded as given (deduped by motionId, first record
+ * wins) because the caller already knows which ones the scenes use. Throws
+ * `resources-too-large` when one motion or the whole manifest exceeds its
+ * budget.
+ */
+export function createProjectDocument({ scenesDocument, workspaceLayout, customPoses, name, assets, motions, savedAt, workflow }) {
 	const assetRecords = new Map();
 	for (const record of Array.isArray(assets) ? assets : []) {
 		const asset = embeddedAsset(record);
-		if (asset) assetRecords.set(asset.id, asset);
+		if (asset) assetRecords.set(asset.record.id, asset);
 	}
 	const embeddedAssets = [];
+	let resourceBytes = 0;
 	for (const id of referencedAssetIds(scenesDocument?.scenes)) {
 		const asset = assetRecords.get(id);
-		if (asset) embeddedAssets.push(asset);
+		if (!asset) continue;
+		embeddedAssets.push(asset.record);
+		resourceBytes += asset.bytes;
 	}
+	const motionRecords = new Map();
+	for (const record of Array.isArray(motions) ? motions : []) {
+		const motion = embeddedMotion(record);
+		if (!motion || motionRecords.has(motion.motionId)) continue;
+		motionRecords.set(motion.motionId, motion);
+		resourceBytes += motion.bytes;
+	}
+	if (resourceBytes > PROJECT_MAX_RESOURCE_BYTES) throw resourcesTooLarge(resourceBytes, PROJECT_MAX_RESOURCE_BYTES, "Embedded resources");
+	const embeddedMotions = [...motionRecords.values()].map(({ motionId: id, bytes, raw, data, details }) => ({
+		motionId: id,
+		encoding: "base64",
+		data: data ?? bytesToBase64(raw),
+		bytes,
+		...details,
+	}));
 	return {
 		app: "cozyclay",
 		kind: "project",
@@ -238,12 +390,18 @@ export function createProjectDocument({ scenesDocument, workspaceLayout, customP
 		scenes: scenesDocument,
 		workspace: workspaceLayout ?? null,
 		poseLibrary: Array.isArray(customPoses) ? customPoses : [],
-		assets: embeddedAssets,
 		workflow: normalizeWorkflowGraph(workflow),
+		resources: { assets: embeddedAssets, motions: embeddedMotions },
 	};
 }
 
-/** Parse + validate a project file. Returns { ok, reason?, project? }. */
+/**
+ * Parse + validate a project file. Returns { ok, reason?, warnings?,
+ * problems?, project? }. Invalid embedded records are skipped, each one
+ * reported as a warning string and a `{ kind, id, code, message }` problem.
+ * v2/v3 files carry images at the top-level `assets`; v4 moves everything
+ * under `resources`. Older files are read as-is, never rewritten.
+ */
 export function readProjectDocument(raw) {
 	let parsed;
 	try {
@@ -259,11 +417,21 @@ export function readProjectDocument(raw) {
 	if (!scenes || typeof scenes !== "object" || scenes.version > SCENES_VERSION || !Array.isArray(scenes.scenes)) {
 		return { ok: false, reason: "scenes-invalid" };
 	}
-	const embedded = parsed.version >= 2 ? readEmbeddedAssets(parsed.assets) : { assets: [], warnings: [] };
+	const warnings = [];
+	const problems = [];
+	const report = (kind, id, code) => {
+		const message = `Skipped embedded ${kind} ${id ?? "(no id)"}: ${PROBLEM_DETAILS[code]}.`;
+		problems.push({ kind, id, code, message });
+		warnings.push(message);
+	};
+	const assetRecords = parsed.version >= 4 ? parsed.resources?.assets : parsed.version >= 2 ? parsed.assets : undefined;
+	const assets = readEmbeddedAssets(assetRecords, report);
+	const motions = parsed.version >= 4 ? readEmbeddedMotions(parsed.resources?.motions, report) : [];
 	const workflow = normalizeWorkflowGraph(parsed.workflow);
 	return {
 		ok: true,
-		warnings: embedded.warnings,
+		warnings,
+		problems,
 		project: {
 			name: typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : "Untitled",
 			savedAt: Number.isFinite(parsed.savedAt) && parsed.savedAt > 0 ? parsed.savedAt : null,
@@ -272,7 +440,8 @@ export function readProjectDocument(raw) {
 			customPoses: Array.isArray(parsed.poseLibrary)
 				? parsed.poseLibrary.filter((p) => p && typeof p === "object" && typeof p.id === "string" && p.bones && typeof p.bones === "object")
 				: [],
-			assets: embedded.assets,
+			assets,
+			motions,
 			workflow,
 		},
 	};

--- a/test/verify-project.mjs
+++ b/test/verify-project.mjs
@@ -12,6 +12,8 @@ import {
 	isWorkflowGraph,
 	PROJECT_VERSION,
 	PROJECT_EXTENSION,
+	MOTION_MAX_BYTES,
+	PROJECT_MAX_RESOURCE_BYTES,
 } from "../src/project.js";
 import { createSceneDocument, createSceneStage, SCENES_VERSION } from "../src/scenes.js";
 import { ASSET_MAX_SOURCE_BYTES, assetIdForBytes, referencedAssetIds } from "../src/scene-assets.js";
@@ -100,15 +102,17 @@ const fakeAssets = [
 	{ id: orphanAssetId, type: "image/png", width: 80, height: 60, name: "orphan.png", bytes: orphanBytes },
 ];
 const assetDocument = createProjectDocument({ scenesDocument: assetScenesDocument, assets: fakeAssets });
-const embeddedAssetIds = assetDocument.assets.map((asset) => asset.id).sort();
+const embeddedAssetIds = assetDocument.resources.assets.map((asset) => asset.id).sort();
 assert.deepEqual(embeddedAssetIds, [...referencedAssetIds(assetScenesDocument.scenes)].sort(), "only the matted cutout asset closure is embedded");
 assert.equal(assetDocument.version, PROJECT_VERSION, "asset-bearing documents use the current envelope version");
-assert.ok(assetDocument.assets.every((asset) => typeof asset.bytes === "string" && !asset.bytes.startsWith("data:")), "asset bytes are bare base64");
+assert.equal("assets" in assetDocument, false, "v4 documents carry images only under resources, never at the top level");
+assert.ok(assetDocument.resources.assets.every((asset) => typeof asset.bytes === "string" && !asset.bytes.startsWith("data:")), "asset bytes are bare base64");
 const parsedAssets = readProjectDocument(JSON.stringify(assetDocument));
 assert.equal(parsedAssets.ok, true);
+assert.deepEqual(parsedAssets.problems, [], "a clean document reports no resource problems");
 assert.deepEqual(
 	parsedAssets.project.assets.map(({ id: assetId, type, width, height, name, bytes }) => ({ assetId, type, width, height, name, bytes: [...new Uint8Array(bytes)] })),
-	assetDocument.assets.map(({ id: assetId, type, width, height, name, bytes }) => ({
+	assetDocument.resources.assets.map(({ id: assetId, type, width, height, name, bytes }) => ({
 		assetId,
 		type,
 		width,
@@ -145,21 +149,133 @@ assert.equal(unnamed.project.name, "Untitled");
 const dirtyPoses = readProjectDocument(JSON.stringify({ ...doc, poseLibrary: [{ id: "ok", bones: {} }, { nope: true }, null, { id: 3, bones: {} }] }));
 assert.equal(dirtyPoses.project.customPoses.length, 1, "pose library entries without id+bones are dropped");
 
-const { assets: _v2Assets, ...v1Document } = { ...doc, version: 1 };
+const { resources: _v4Resources, ...v1Document } = { ...doc, version: 1 };
 const parsedV1 = readProjectDocument(JSON.stringify(v1Document));
 assert.equal(parsedV1.ok, true, "v1 documents without assets remain readable");
 assert.deepEqual(parsedV1.project.assets, [], "v1 documents produce no assets to hydrate");
+assert.deepEqual(parsedV1.project.motions, [], "pre-v4 documents produce no motions to hydrate");
 const malformedAssets = readProjectDocument(JSON.stringify({
 	...assetDocument,
-	assets: [
-		{ ...assetDocument.assets[0], id: "junk" },
-		{ ...assetDocument.assets[1], bytes: "not base64!" },
-		{ ...assetDocument.assets[2], bytes: "A".repeat(Math.ceil((ASSET_MAX_SOURCE_BYTES + 1) / 3) * 4) },
-	],
+	resources: {
+		...assetDocument.resources,
+		assets: [
+			{ ...assetDocument.resources.assets[0], id: "junk" },
+			{ ...assetDocument.resources.assets[1], bytes: "not base64!" },
+			{ ...assetDocument.resources.assets[2], bytes: "A".repeat(Math.ceil((ASSET_MAX_SOURCE_BYTES + 1) / 3) * 4) },
+			assetDocument.resources.assets[0],
+			assetDocument.resources.assets[0],
+		],
+	},
 }));
 assert.equal(malformedAssets.ok, true, "malformed embedded assets never reject a project");
-assert.deepEqual(malformedAssets.project.assets, [], "malformed embedded assets are skipped");
-assert.equal(malformedAssets.warnings.length, 3, "each skipped embedded asset is warned about");
+assert.deepEqual(malformedAssets.project.assets.map((asset) => asset.id), [assetDocument.resources.assets[0].id], "malformed and repeated embedded assets are skipped");
+assert.equal(malformedAssets.warnings.length, 4, "each skipped embedded asset is warned about");
+assert.deepEqual(
+	malformedAssets.problems.map(({ kind, id, code }) => ({ kind, id, code })),
+	[
+		{ kind: "image", id: "junk", code: "bad-id" },
+		{ kind: "image", id: assetDocument.resources.assets[1].id, code: "bad-base64" },
+		{ kind: "image", id: assetDocument.resources.assets[2].id, code: "too-large" },
+		{ kind: "image", id: assetDocument.resources.assets[0].id, code: "duplicate" },
+	],
+	"each skipped embedded asset is reported as a structured problem",
+);
+assert.ok(malformedAssets.problems.every((problem) => typeof problem.message === "string" && problem.message), "every problem carries a message");
+
+// --- v3 compatibility: top-level assets ------------------------------------
+const { resources: v3Resources, ...v3Document } = { ...assetDocument, version: 3, assets: assetDocument.resources.assets };
+const parsedV3 = readProjectDocument(JSON.stringify(v3Document));
+assert.equal(parsedV3.ok, true, "v3 documents with top-level assets remain readable");
+assert.deepEqual(parsedV3.project.assets.map((asset) => asset.id).sort(), v3Resources.assets.map((asset) => asset.id).sort(), "v3 top-level assets hydrate as before");
+assert.deepEqual(parsedV3.project.motions, [], "v3 documents have no motions");
+const v4IgnoresTopLevel = readProjectDocument(JSON.stringify({ ...assetDocument, resources: { assets: [], motions: [] }, assets: assetDocument.resources.assets }));
+assert.deepEqual(v4IgnoresTopLevel.project.assets, [], "a v4 document reads images from resources only");
+
+// --- v4 resources manifest: embedded motions (#227) ------------------------
+const walkBytes = new Uint8Array(Array.from({ length: 300 }, (_, index) => (index * 37 + 11) & 0xff));
+const walkId = "a".repeat(64);
+const runId = "b".repeat(64);
+const walkMeta = { prompt: "walk forward", sourceUrl: "https://example.test/walk.npz", personScale: 1.02, createdAt: 1700000000000 };
+const motionDocument = createProjectDocument({
+	scenesDocument,
+	motions: [
+		{ motionId: walkId, bytes: walkBytes, frames: 30, fps: 24, name: "walk", meta: walkMeta },
+		{ motionId: walkId.toUpperCase(), bytes: walkBytes.buffer, frames: 30, fps: 24, name: "walk (duplicate)" },
+		{ motionId: runId, encoding: "base64", data: Buffer.from([1, 2, 3, 4, 5]).toString("base64"), bytes: 5, frames: 2, fps: 30 },
+		{ motionId: "not-a-hash", bytes: walkBytes },
+		{ motionId: "c".repeat(64), encoding: "base64", data: "not base64!" },
+		{ motionId: "d".repeat(64), bytes: new Uint8Array(0) },
+	],
+});
+assert.equal(motionDocument.version, PROJECT_VERSION);
+assert.equal("assets" in motionDocument, false, "motion-bearing documents keep the v4 layout");
+assert.deepEqual(motionDocument.resources.assets, [], "no scene images means no embedded assets");
+assert.deepEqual(motionDocument.resources.motions.map((motion) => motion.motionId), [walkId, runId], "motions are deduped by motionId and invalid records are dropped");
+const [walkRecord, runRecord] = motionDocument.resources.motions;
+assert.equal(walkRecord.encoding, "base64");
+assert.equal(walkRecord.bytes, walkBytes.byteLength, "the record carries the raw byte length");
+assert.equal(walkRecord.name, "walk", "the first record for a motionId wins");
+assert.deepEqual({ frames: walkRecord.frames, fps: walkRecord.fps, meta: walkRecord.meta }, { frames: 30, fps: 24, meta: walkMeta }, "frames/fps/meta are carried verbatim");
+assert.deepEqual([...Buffer.from(walkRecord.data, "base64")], [...walkBytes], "raw bytes are stored as base64");
+assert.deepEqual({ ...runRecord }, { motionId: runId, encoding: "base64", data: Buffer.from([1, 2, 3, 4, 5]).toString("base64"), bytes: 5, frames: 2, fps: 30 }, "pre-encoded records are stored as given");
+const motionRoundTrip = readProjectDocument(JSON.stringify(motionDocument));
+assert.equal(motionRoundTrip.ok, true);
+assert.deepEqual(motionRoundTrip.warnings, [], "a clean v4 document reads without warnings");
+assert.deepEqual(motionRoundTrip.project.motions, motionDocument.resources.motions, "motion records round-trip through the file");
+assert.deepEqual([...Buffer.from(motionRoundTrip.project.motions[0].data, "base64")], [...walkBytes], "motion bytes round-trip byte-for-byte");
+
+const badMotions = readProjectDocument(JSON.stringify({
+	...motionDocument,
+	resources: {
+		...motionDocument.resources,
+		motions: [
+			{ ...walkRecord, motionId: "bad" },
+			{ ...walkRecord, data: "not base64!" },
+			{ ...walkRecord, data: "QUJD", bytes: 4 },
+			{ ...walkRecord, encoding: "gzip" },
+			walkRecord,
+			walkRecord,
+			"junk",
+		],
+	},
+}));
+assert.equal(badMotions.ok, true, "malformed embedded motions never reject a project");
+assert.deepEqual(badMotions.project.motions.map((motion) => motion.motionId), [walkId], "malformed and repeated motions are skipped");
+assert.deepEqual(
+	badMotions.problems.map(({ kind, id, code }) => ({ kind, id, code })),
+	[
+		{ kind: "motion", id: "bad", code: "bad-id" },
+		{ kind: "motion", id: walkId, code: "bad-base64" },
+		{ kind: "motion", id: walkId, code: "length-mismatch" },
+		{ kind: "motion", id: walkId, code: "bad-encoding" },
+		{ kind: "motion", id: walkId, code: "duplicate" },
+		{ kind: "motion", id: null, code: "bad-id" },
+	],
+	"each skipped motion is reported with its structural problem",
+);
+assert.equal(badMotions.warnings.length, badMotions.problems.length, "every problem is also a warning string");
+assert.ok(badMotions.warnings.every((warning) => typeof warning === "string" && warning.includes("motion")), "motion warnings are human-readable strings");
+
+// Size budgets: one motion is capped by MOTION_MAX_BYTES, the manifest as a
+// whole by PROJECT_MAX_RESOURCE_BYTES. Both checks fire before any base64
+// encoding, so the buffers can be allocated without being touched.
+assert.ok(MOTION_MAX_BYTES < PROJECT_MAX_RESOURCE_BYTES, "a single motion never exhausts the manifest budget alone");
+assert.throws(
+	() => createProjectDocument({ scenesDocument, motions: [{ motionId: walkId, bytes: new ArrayBuffer(MOTION_MAX_BYTES + 1) }] }),
+	(error) => error instanceof Error && error.code === "resources-too-large" && error.bytes === MOTION_MAX_BYTES + 1 && error.limit === MOTION_MAX_BYTES,
+	"a motion over MOTION_MAX_BYTES throws resources-too-large",
+);
+const halfBudget = Math.ceil(PROJECT_MAX_RESOURCE_BYTES / 2) + 1;
+assert.throws(
+	() => createProjectDocument({ scenesDocument, motions: [{ motionId: walkId, bytes: new ArrayBuffer(halfBudget) }, { motionId: runId, bytes: new ArrayBuffer(halfBudget) }] }),
+	(error) => error instanceof Error && error.code === "resources-too-large" && error.bytes === halfBudget * 2 && error.limit === PROJECT_MAX_RESOURCE_BYTES,
+	"motions that together exceed PROJECT_MAX_RESOURCE_BYTES throw resources-too-large",
+);
+assert.throws(
+	() => createProjectDocument({ scenesDocument, motions: [{ motionId: walkId, encoding: "base64", data: "A".repeat(Math.ceil((MOTION_MAX_BYTES + 3) / 3) * 4) }] }),
+	(error) => error instanceof Error && error.code === "resources-too-large" && error.limit === MOTION_MAX_BYTES,
+	"an oversized pre-encoded motion throws resources-too-large",
+);
 
 // --- handle re-authorization (#51) -----------------------------------------
 // Chromium demotes a persisted handle's permission to "prompt" on the next


### PR DESCRIPTION
Closes #227 — track 1 of the resource-packaging plan.

## What changed

**`src/project.js`**
- `PROJECT_VERSION = 4`; new exports `MOTION_MAX_BYTES` (192 MiB) and `PROJECT_MAX_RESOURCE_BYTES` (256 MiB).
- `createProjectDocument({ ..., assets, motions })` writes `resources: { assets, motions }`. The top-level `assets` key is gone from v4 output (no double-embedding).
- Motions: accepts the encoded shape (`encoding: "base64"`, `data`) and raw `bytes` (ArrayBuffer / typed array); normalizes to base64, dedupes by `motionId` (first record wins), carries `frames`/`fps`/`name`/`meta` verbatim. Invalid records (bad id, empty, non-base64 data) are dropped silently at save time, matching how invalid asset records were already handled.
- Size budgets are enforced on raw byte counts before any base64 encoding: one motion > `MOTION_MAX_BYTES` or the sum of assets+motions > `PROJECT_MAX_RESOURCE_BYTES` throws an `Error` with `code = "resources-too-large"`, `bytes`, `limit`.
- `readProjectDocument`: reads `parsed.assets` for v2/v3 and `parsed.resources.*` for v4 (a v4 file's top-level `assets` is ignored). Returns `project.motions` in encoded shape. Adds `problems: [{ kind: "image"|"motion", id, code, message }]` next to the existing `warnings` strings; codes: `bad-id`, `duplicate`, `bad-encoding`, `bad-base64`, `length-mismatch`, `too-large`, `bad-record`. Assets are now also deduped by id on read.
- Only structural checks live here (id regex, base64 shape + canonical spelling, arithmetic byte length vs `bytes`, dedupe). No SHA-256, no NPZ decode — that stays with `motion-resources.js`.

**`test/verify-project.mjs`** — new coverage per the issue:
- motion bytes round-trip byte-for-byte (raw input and pre-encoded input)
- same `motionId` twice (incl. case-insensitive) → stored once
- corrupt base64 / bad motionId / bad encoding / length mismatch / duplicate / non-object → skipped + warning + structured problem
- single-motion and aggregate limits → `resources-too-large` with `bytes`/`limit`
- v3 document (top-level `assets`) still reads; v4 document has no top-level `assets`; v1 still reads
- existing asset tests moved to `resources.assets` and extended with `problems` assertions

No other files touched. `App.jsx`, `mcp/tool-handlers.mjs`, `playground.js` keep working unchanged: they only pass `assets`/read `project.assets`, and the mcp `save_project` path (no assets/motions) now emits `resources: { assets: [], motions: [] }`.

## Tests

```
$ node test/verify-project.mjs
embedded asset round-trip and compatibility checks PASS
all project file checks PASS

$ node tools/run-tests.mjs
TEST MANIFEST scope=all runnable=165 total=193
...
PASS 165 Node verification files
```

## Notes for the integrator / other tracks

- **Read-time behaviour change for images**: a duplicate asset id in a file is now skipped with a `duplicate` problem (previously the second copy was hydrated again). Harmless for existing files (the writer never emitted duplicates), flagged for awareness.
- **Fresh worktree gotcha (not a code issue)**: `node tools/run-tests.mjs` fails on a clean checkout until `npm run build` (dist/ for `verify-demo-pages`) and `npm --prefix mcp ci` (`ws` for `verify-agent-routes`) have been run. Same failures on `main`; `npm test` covers the build but not the mcp install.
- `readProjectDocument` still returns `warnings` as before, so `rehydrateProjectAssets` in App.jsx needs no change for this track; the integrator can switch to `problems` when wiring the resource status UI.