### PR TITLE
feat(workflow): intern workflow outputs as project assets + ResourceStatus/SaveBlockedDialog UI (#230)

### DIFF
--- a/src/resource-status.jsx
+++ b/src/resource-status.jsx
@@ -1,0 +1,174 @@
+/**
+ * Resource status UI (#230): what a `.cclayproject` will and will not carry.
+ *
+ * Both components are pure functions of their props. The manifest comes from
+ * `resourceManifest()` in project-resources.js; the save-blocked reasons come
+ * from the save path (a `resources-too-large` error from createProjectDocument
+ * or the manifest's missing list). Neither component reads App state, so the
+ * integrator decides where they mount.
+ */
+import { ko } from "./locale.js";
+
+const STATUSES = Object.freeze(["embedded", "external", "missing"]);
+
+const KIND_LABELS = {
+	image: () => ko("Image", "이미지"),
+	motion: () => ko("Motion", "모션"),
+	pose: () => ko("Pose", "포즈"),
+	"workflow-output": () => ko("Workflow output", "워크플로 출력"),
+};
+
+/** The per-item vocabulary: where this resource lives right now. */
+export function resourceStatusLabel(item) {
+	if (item?.status === "embedded") return ko("In project file", "프로젝트 파일에 포함됨");
+	if (item?.status === "external") return ko("External URL", "외부 URL");
+	if (item?.stored) return ko("Browser-only copy", "브라우저 임시 저장");
+	return ko("Missing", "누락");
+}
+
+export function resourceKindLabel(kind) {
+	return KIND_LABELS[kind]?.() ?? String(kind ?? "");
+}
+
+/** One reference location, readable: `scene-a / obj-1 · assetId`. */
+export function resourceRefLabel(ref) {
+	if (!ref || typeof ref !== "object") return "";
+	const where = [ref.sceneId, ref.objectId, ref.characterId, ref.nodeId].filter((part) => typeof part === "string" && part).join(" / ");
+	return where && ref.field ? `${where} · ${ref.field}` : where || ref.field || "";
+}
+
+export function formatMiB(bytes) {
+	if (!Number.isFinite(bytes) || bytes < 0) return "";
+	const mib = bytes / (1024 * 1024);
+	return `${mib >= 100 ? mib.toFixed(0) : mib.toFixed(1)} MiB`;
+}
+
+function itemsOf(manifest) {
+	return Array.isArray(manifest?.items) ? manifest.items.filter((item) => item && typeof item === "object") : [];
+}
+
+function totalsOf(manifest, items) {
+	const totals = { embedded: 0, external: 0, missing: 0, bytes: 0 };
+	for (const item of items) {
+		if (STATUSES.includes(item.status)) totals[item.status] += 1;
+		if (Number.isFinite(item.bytes)) totals.bytes += item.bytes;
+	}
+	const given = manifest?.totals;
+	if (given && typeof given === "object") {
+		for (const key of Object.keys(totals)) if (Number.isFinite(given[key])) totals[key] = given[key];
+	}
+	return totals;
+}
+
+function missingOf(manifest, items) {
+	return Array.isArray(manifest?.missing) ? manifest.missing.filter((item) => item && typeof item === "object") : items.filter((item) => item.status === "missing");
+}
+
+function itemKey(item, index) {
+	return `${item.kind ?? "?"}:${item.id ?? index}`;
+}
+
+function ResourceItem({ item, index, onSelect }) {
+	const status = STATUSES.includes(item.status) ? item.status : "missing";
+	const refs = Array.isArray(item.refs) ? item.refs.map(resourceRefLabel).filter(Boolean) : [];
+	const body = (
+		<>
+			<span className="resource-status-kind">{resourceKindLabel(item.kind)}</span>
+			<code className="resource-status-id">{item.id}</code>
+			<span className={`resource-status-state is-${status}${item.stored ? " is-stored" : ""}`}>{resourceStatusLabel(item)}</span>
+			{item.status === "external" && item.url ? <span className="resource-status-url" title={item.url}>{item.url}</span> : null}
+			{refs.length ? <span className="resource-status-refs">{refs.join(", ")}</span> : null}
+		</>
+	);
+	return (
+		<li className={`resource-status-item is-${status}`} data-kind={item.kind} data-id={item.id} data-status={status} data-stored={item.stored ? "true" : undefined}>
+			{onSelect ? <button type="button" className="resource-status-select" onClick={() => onSelect(item, index)}>{body}</button> : body}
+		</li>
+	);
+}
+
+/**
+ * Counts plus, unless `compact`, every resource with its location. Missing
+ * resources sort first: they are the reason to open this panel.
+ */
+export function ResourceStatus({ manifest, compact = false, onSelect }) {
+	const items = itemsOf(manifest);
+	const totals = totalsOf(manifest, items);
+	const missing = missingOf(manifest, items);
+	const ordered = [...items].sort((a, b) => Number(b.status === "missing") - Number(a.status === "missing"));
+	const className = ["resource-status", compact ? "is-compact" : "", missing.length ? "has-missing" : ""].filter(Boolean).join(" ");
+	return (
+		<section className={className} aria-label={ko("Project resources", "프로젝트 자원")} data-missing-count={missing.length}>
+			<dl className="resource-status-totals">
+				<div className="resource-status-total is-embedded"><dt>{ko("In project file", "프로젝트 파일에 포함됨")}</dt><dd data-total="embedded">{totals.embedded}</dd></div>
+				<div className="resource-status-total is-external"><dt>{ko("External URL", "외부 URL")}</dt><dd data-total="external">{totals.external}</dd></div>
+				<div className="resource-status-total is-missing"><dt>{ko("Missing", "누락")}</dt><dd data-total="missing">{totals.missing}</dd></div>
+				{totals.bytes > 0 ? <div className="resource-status-total is-bytes"><dt>{ko("Size", "용량")}</dt><dd data-total="bytes">{formatMiB(totals.bytes)}</dd></div> : null}
+			</dl>
+			{missing.length ? <p className="resource-status-warning" role="status">{ko(`${missing.length} resource${missing.length === 1 ? "" : "s"} will not travel with this project file.`, `${missing.length}개 자원이 프로젝트 파일에 담기지 않습니다.`)}</p> : null}
+			{!compact && ordered.length ? (
+				<ul className="resource-status-items">
+					{ordered.map((item, index) => <ResourceItem key={itemKey(item, index)} item={item} index={index} onSelect={onSelect} />)}
+				</ul>
+			) : null}
+			{compact && missing.length ? (
+				<ul className="resource-status-items is-missing-only" aria-label={ko("Missing resources", "누락된 자원")}>
+					{missing.map((item, index) => <ResourceItem key={itemKey(item, index)} item={item} index={index} onSelect={onSelect} />)}
+				</ul>
+			) : null}
+		</section>
+	);
+}
+
+function reasonBody(reason) {
+	if (reason?.code === "resources-too-large") {
+		return (
+			<>
+				<strong>{ko("The project file would be too large.", "프로젝트 파일이 너무 큽니다.")}</strong>
+				<span className="save-blocked-size" data-bytes={reason.bytes} data-limit={reason.limit}>
+					{ko(`${formatMiB(reason.bytes)} of embedded resources; the limit is ${formatMiB(reason.limit)}.`, `내장 자원 ${formatMiB(reason.bytes)}, 한도 ${formatMiB(reason.limit)}.`)}
+				</span>
+			</>
+		);
+	}
+	if (reason?.code === "missing-resources") {
+		const items = Array.isArray(reason.items) ? reason.items.filter((item) => item && typeof item === "object") : [];
+		return (
+			<>
+				<strong>{ko(`${items.length} resource${items.length === 1 ? " is" : "s are"} missing.`, `${items.length}개 자원이 누락되었습니다.`)}</strong>
+				<ul className="save-blocked-missing">
+					{items.map((item, index) => <ResourceItem key={itemKey(item, index)} item={item} index={index} />)}
+				</ul>
+			</>
+		);
+	}
+	return <strong>{typeof reason?.message === "string" && reason.message ? reason.message : String(reason?.code ?? ko("Unknown reason", "알 수 없는 원인"))}</strong>;
+}
+
+/**
+ * Why the save did not happen. `reasons` is a list of
+ *   { code: "missing-resources", items }            — the manifest's missing list
+ *   { code: "resources-too-large", bytes, limit }   — from createProjectDocument
+ *   { code, message? }                              — anything else, shown as is
+ */
+export function SaveBlockedDialog({ reasons, onClose }) {
+	const list = Array.isArray(reasons) ? reasons.filter(Boolean) : [];
+	return (
+		<div className="modal-overlay" onClick={onClose}>
+			<div className="modal save-blocked-dialog" role="dialog" aria-modal="true" aria-labelledby="save-blocked-title" onClick={(event) => event.stopPropagation()}>
+				<div className="modal-head">
+					<h3 id="save-blocked-title">{ko("The project was not saved", "프로젝트를 저장하지 못했어요")}</h3>
+					<button type="button" className="x" onClick={onClose} aria-label={ko("Close", "닫기")}>✕</button>
+				</div>
+				<ul className="save-blocked-reasons">
+					{list.map((reason, index) => <li key={`${reason.code ?? "reason"}:${index}`} className="save-blocked-reason" data-code={reason.code}>{reasonBody(reason)}</li>)}
+				</ul>
+				<div className="modal-actions">
+					<button type="button" className="btn" onClick={onClose}>{ko("OK", "확인")}</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default ResourceStatus;

--- a/src/styles.css
+++ b/src/styles.css
@@ -11063,3 +11063,120 @@ input[type=range] {
 	}
 	.tutorial-cue { transition: none; }
 }
+
+/* ------------------------------------------------------------------------
+   Project resource status (#230). Mounted by the integrator in the project
+   surfaces; kept self-contained so it does not depend on their layout. */
+.resource-status {
+	background: var(--card2);
+	border: 1px solid var(--line2);
+	border-radius: var(--radius);
+	padding: 10px 12px;
+	color: var(--fg);
+	font-size: 12px;
+}
+.resource-status.is-compact { padding: 6px 8px; }
+.resource-status-totals {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px 16px;
+	margin: 0;
+}
+.resource-status-total {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--muted);
+}
+.resource-status-total::before {
+	content: "";
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--muted2);
+}
+.resource-status-total.is-embedded::before { background: #81c995; }
+.resource-status-total.is-external::before { background: var(--cyan); }
+.resource-status-total.is-missing::before { background: var(--warn, #e6a86b); }
+.resource-status-total.is-bytes::before { display: none; }
+.resource-status-total dt { margin: 0; }
+.resource-status-total dd {
+	margin: 0;
+	color: var(--fg);
+	font-family: var(--mono);
+	font-size: 11px;
+}
+.resource-status-warning {
+	margin: 8px 0 0;
+	color: var(--warn, #e6a86b);
+}
+.resource-status-items,
+.save-blocked-missing,
+.save-blocked-reasons {
+	list-style: none;
+	margin: 8px 0 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.resource-status-item {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 4px 8px;
+	padding: 4px 6px;
+	border-left: 2px solid var(--line2);
+	color: var(--muted);
+}
+.resource-status-item.is-embedded { border-left-color: #81c995; }
+.resource-status-item.is-external { border-left-color: var(--cyan); }
+.resource-status-item.is-missing { border-left-color: var(--warn, #e6a86b); }
+.resource-status-select {
+	display: contents;
+	background: none;
+	border: none;
+	padding: 0;
+	color: inherit;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+.resource-status-kind { color: var(--fg); }
+.resource-status-id {
+	font-family: var(--mono);
+	font-size: 11px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 22ch;
+	white-space: nowrap;
+}
+.resource-status-state { font-size: 11px; }
+.resource-status-state.is-embedded { color: #81c995; }
+.resource-status-state.is-external { color: var(--cyan); }
+.resource-status-state.is-missing { color: var(--warn, #e6a86b); }
+.resource-status-url,
+.resource-status-refs {
+	flex-basis: 100%;
+	font-size: 11px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.save-blocked-reason {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 8px 10px;
+	border-left: 2px solid var(--warn, #e6a86b);
+	background: var(--card2);
+	font-size: 13px;
+}
+.save-blocked-size {
+	color: var(--muted);
+	font-family: var(--mono);
+	font-size: 11px;
+}
+@media (max-width: 520px) {
+	.resource-status-totals { flex-direction: column; gap: 4px; }
+}

--- a/src/workflow/workflow-resources.js
+++ b/src/workflow/workflow-resources.js
@@ -1,0 +1,275 @@
+/**
+ * Workflow outputs as project resources (#230).
+ *
+ * Image, Video, Scene and Upload nodes keep what they produced inline in node
+ * data as data: URLs. Left alone, a `.cclayproject` carries every generated
+ * PNG twice over (resultUrl, outputs[0].value, each version) and nothing tells
+ * the author which of those pictures will survive a move to another browser.
+ * This module gives the save path a way to pull those pictures out into the
+ * project's content-addressed `resources.assets` and the open path a way to
+ * put them back, so the running graph never learns the file changed shape.
+ *
+ * Only `data:image/*` URLs of a type the asset store accepts are interned.
+ * Video data URLs, blob: URLs and http(s) URLs stay in place and are merely
+ * classified so the resource manifest can report them. Everything else in a
+ * node's data is passed through untouched, by reference.
+ *
+ * No React, no DOM: `atob`/`btoa` and Web Crypto exist in the browser and in
+ * Node, so the intern -> resolve round trip is verifiable under Node.
+ */
+
+import { ASSET_IMAGE_TYPES, ASSET_MAX_SOURCE_BYTES, assetIdForBytes as defaultAssetIdForBytes, isAssetId } from "../scene-assets.js";
+
+/** The node-data fields a generated output can land in. `[]` marks an array. */
+export const WORKFLOW_OUTPUT_FIELDS = Object.freeze([
+	"resultUrl",
+	"videoUrl",
+	"lastOutput.renderUrl",
+	"lastOutput.sceneUrl",
+	"versions[].dataUrl",
+	"fileUrl",
+	"outputs[].value",
+]);
+
+function plainRecord(value) {
+	if (!value || typeof value !== "object") return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+/** A value already swapped for an embedded asset: `{ assetRef: "img-…" }`. */
+export function isAssetRef(value) {
+	return plainRecord(value) && isAssetId(value.assetRef);
+}
+
+/** Classify one output value; null for values that are not an output at all. */
+export function outputKind(value) {
+	if (isAssetRef(value)) return "asset-ref";
+	if (typeof value !== "string") return null;
+	if (/^data:/i.test(value)) return "data-url";
+	if (/^https?:\/\//i.test(value)) return "http";
+	if (/^blob:/i.test(value)) return "blob";
+	return value.trim() ? "other" : null;
+}
+
+/* ------------------------------------------------------------- paths ---- */
+
+function outputPaths(data) {
+	const paths = [["resultUrl"], ["videoUrl"], ["lastOutput", "renderUrl"], ["lastOutput", "sceneUrl"], ["fileUrl"]];
+	if (Array.isArray(data.versions)) data.versions.forEach((_, index) => paths.push(["versions", index, "dataUrl"]));
+	if (Array.isArray(data.outputs)) data.outputs.forEach((_, index) => paths.push(["outputs", index, "value"]));
+	return paths;
+}
+
+function fieldName(path) {
+	return path.map((key, index) => (typeof key === "number" ? `[${key}]` : index ? `.${key}` : key)).join("");
+}
+
+function getPath(data, path) {
+	let value = data;
+	for (const key of path) {
+		if (!value || typeof value !== "object") return undefined;
+		value = value[key];
+	}
+	return value;
+}
+
+/** Copy-on-write along `path`; every untouched sibling keeps its identity. */
+function setPath(data, path, value) {
+	if (!path.length) return value;
+	const [key, ...rest] = path;
+	const copy = Array.isArray(data) ? [...data] : { ...data };
+	copy[key] = setPath(data[key], rest, value);
+	return copy;
+}
+
+function nodesOf(graph) {
+	return Array.isArray(graph?.nodes) ? graph.nodes : null;
+}
+
+/** Walk every output slot of every node, replacing values through `visit`. */
+async function mapOutputs(graph, visit) {
+	const nodes = [];
+	for (const node of nodesOf(graph)) {
+		if (!plainRecord(node) || !plainRecord(node.data)) {
+			nodes.push(node);
+			continue;
+		}
+		let data = node.data;
+		for (const path of outputPaths(data)) {
+			const value = getPath(data, path);
+			const next = await visit(value);
+			if (next !== value) data = setPath(data, path, next);
+		}
+		nodes.push(data === node.data ? node : { ...node, data });
+	}
+	return { ...graph, nodes };
+}
+
+/* -------------------------------------------------------------- refs ---- */
+
+/**
+ * Every output slot that holds something, with where it lives and what it is.
+ * `field` reads like a path (`versions[2].dataUrl`) so a manifest row can point
+ * the author at the exact slot.
+ */
+export function workflowOutputRefs(graph) {
+	const refs = [];
+	for (const node of nodesOf(graph) ?? []) {
+		if (!plainRecord(node) || typeof node.id !== "string" || !plainRecord(node.data)) continue;
+		for (const path of outputPaths(node.data)) {
+			const value = getPath(node.data, path);
+			const kind = outputKind(value);
+			if (kind) refs.push({ nodeId: node.id, field: fieldName(path), value, kind });
+		}
+	}
+	return refs;
+}
+
+/* ----------------------------------------------------------- data URLs -- */
+
+function bytesToBase64(bytes) {
+	let binary = "";
+	for (let offset = 0; offset < bytes.length; offset += 0x8000) binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+	return btoa(binary);
+}
+
+const IMAGE_DATA_URL = /^data:(image\/[a-z0-9.+-]+);base64,([A-Za-z0-9+/]+={0,2})$/;
+
+/**
+ * Decode a data URL the asset store can hold. Returns null for anything that
+ * would not come back byte-for-byte identical from the stored record — an
+ * unsupported type, a non-canonical encoding, an oversized picture — so such
+ * a value is left in the graph exactly as it was.
+ */
+function parseImageDataUrl(value) {
+	const match = typeof value === "string" ? IMAGE_DATA_URL.exec(value) : null;
+	if (!match) return null;
+	const [, type, base64] = match;
+	if (!ASSET_IMAGE_TYPES.includes(type) || base64.length % 4) return null;
+	let bytes;
+	try {
+		bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+	} catch {
+		return null;
+	}
+	if (!bytes.byteLength || bytes.byteLength > ASSET_MAX_SOURCE_BYTES || bytesToBase64(bytes) !== base64) return null;
+	return { type, bytes };
+}
+
+/**
+ * Pixel size from the container header, no decoder needed. The asset record
+ * needs a positive width/height to pass `normalizeAsset`; a picture whose
+ * header cannot be read is not interned rather than embedded as a record the
+ * reader would drop.
+ */
+export function imageDimensions(bytes) {
+	const b = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+	const view = new DataView(b.buffer, b.byteOffset, b.byteLength);
+	const ascii = (offset, length) => String.fromCharCode(...b.subarray(offset, offset + length));
+	const size = (width, height) => (width > 0 && height > 0 ? { width, height } : null);
+	try {
+		if (b[0] === 0x89 && ascii(1, 3) === "PNG") return size(view.getUint32(16), view.getUint32(20));
+		if (ascii(0, 4) === "GIF8") return size(view.getUint16(6, true), view.getUint16(8, true));
+		if (ascii(0, 4) === "RIFF" && ascii(8, 4) === "WEBP") {
+			const chunk = ascii(12, 4);
+			if (chunk === "VP8 ") return size(view.getUint16(26, true) & 0x3fff, view.getUint16(28, true) & 0x3fff);
+			if (chunk === "VP8L") return size(1 + (((b[22] & 0x3f) << 8) | b[21]), 1 + (((b[24] & 0x0f) << 10) | (b[23] << 2) | ((b[22] & 0xc0) >> 6)));
+			if (chunk === "VP8X") return size(1 + (b[24] | (b[25] << 8) | (b[26] << 16)), 1 + (b[27] | (b[28] << 8) | (b[29] << 16)));
+			return null;
+		}
+		if (b[0] === 0xff && b[1] === 0xd8) {
+			let offset = 2;
+			while (offset + 9 < b.length) {
+				if (b[offset] !== 0xff) return null;
+				const marker = b[offset + 1];
+				if (marker === 0xff) { offset += 1; continue; }
+				// SOF0..SOF15 carry the frame size; C4/C8/CC are tables, not frames.
+				if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) return size(view.getUint16(offset + 7), view.getUint16(offset + 5));
+				if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) { offset += 2; continue; }
+				offset += 2 + view.getUint16(offset + 2);
+			}
+		}
+	} catch {
+		// A truncated header: fall through to "unknown size".
+	}
+	return null;
+}
+
+/* --------------------------------------------------------- intern/resolve */
+
+/**
+ * Save path. Every `data:image/*` output becomes `{ assetRef }` and the bytes
+ * come back once per distinct picture as an asset record in the shape the
+ * asset store and `createProjectDocument` already take (`bytes` is an
+ * ArrayBuffer). The input graph is not mutated; untouched node data keeps its
+ * identity so a later deep-equal proves nothing else moved.
+ */
+export async function internWorkflowOutputs(graph, { assetIdForBytes = defaultAssetIdForBytes } = {}) {
+	if (!nodesOf(graph)) return { graph, assets: [] };
+	const assets = new Map();
+	const idsByUrl = new Map();
+	const next = await mapOutputs(graph, async (value) => {
+		if (typeof value !== "string" || !value.startsWith("data:image/")) return value;
+		let id = idsByUrl.get(value);
+		if (!id) {
+			const parsed = parseImageDataUrl(value);
+			const dimensions = parsed && imageDimensions(parsed.bytes);
+			if (!dimensions) return value;
+			id = await assetIdForBytes(parsed.bytes);
+			idsByUrl.set(value, id);
+			if (!assets.has(id)) assets.set(id, { id, type: parsed.type, ...dimensions, name: "", role: "workflow-output", bytes: parsed.bytes.buffer });
+		}
+		return { assetRef: id };
+	});
+	return { graph: next, assets: [...assets.values()] };
+}
+
+function assetLookup(assetsById) {
+	if (assetsById instanceof Map) return (id) => assetsById.get(id) ?? null;
+	if (Array.isArray(assetsById)) {
+		const byId = new Map(assetsById.filter((asset) => asset && typeof asset.id === "string").map((asset) => [asset.id, asset]));
+		return (id) => byId.get(id) ?? null;
+	}
+	return (id) => (plainRecord(assetsById) && Object.prototype.hasOwnProperty.call(assetsById, id) ? assetsById[id] : null);
+}
+
+function assetBytes(asset) {
+	if (asset?.bytes instanceof ArrayBuffer) return new Uint8Array(asset.bytes);
+	if (ArrayBuffer.isView(asset?.bytes)) return new Uint8Array(asset.bytes.buffer, asset.bytes.byteOffset, asset.bytes.byteLength);
+	return null;
+}
+
+/**
+ * Open path. Every `{ assetRef }` becomes the data URL the node had before
+ * the save, so the runtime node shape is what the canvas already renders. A
+ * ref whose asset is not in `assetsById` is left as it is: the manifest reports
+ * it as missing instead of the graph quietly losing the slot.
+ */
+export function resolveWorkflowOutputs(graph, assetsById) {
+	if (!nodesOf(graph)) return graph;
+	const lookup = assetLookup(assetsById);
+	const urls = new Map();
+	const nodes = [];
+	for (const node of graph.nodes) {
+		if (!plainRecord(node) || !plainRecord(node.data)) {
+			nodes.push(node);
+			continue;
+		}
+		let data = node.data;
+		for (const path of outputPaths(data)) {
+			const value = getPath(data, path);
+			if (!isAssetRef(value)) continue;
+			const id = value.assetRef;
+			if (!urls.has(id)) {
+				const asset = lookup(id);
+				const bytes = assetBytes(asset);
+				urls.set(id, bytes && typeof asset.type === "string" ? `data:${asset.type};base64,${bytesToBase64(bytes)}` : null);
+			}
+			const url = urls.get(id);
+			if (url) data = setPath(data, path, url);
+		}
+		nodes.push(data === node.data ? node : { ...node, data });
+	}
+	return { ...graph, nodes };
+}

--- a/test/verify-resource-status.mjs
+++ b/test/verify-resource-status.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * verify-resource-status (#230): the ResourceStatus and SaveBlockedDialog
+ * components render the manifest's counts, the missing list with kind / id /
+ * reference location, the per-item location labels, and every save-blocked
+ * reason — from props alone, with no App state in reach.
+ *
+ * The components are JSX. Node cannot import that directly, so a module
+ * loader hook hands `.jsx` files through Vite's oxc transform (the same one
+ * the dev server and build use). Everything else loads untouched.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { register } from "node:module";
+
+const hook = `
+let transform;
+export async function initialize({ viteUrl }) { ({ transformWithOxc: transform } = await import(viteUrl)); }
+export async function load(url, context, nextLoad) {
+	if (!url.endsWith(".jsx")) return nextLoad(url, context);
+	const { readFileSync } = await import("node:fs");
+	const { fileURLToPath } = await import("node:url");
+	const path = fileURLToPath(url);
+	const { code } = await transform(readFileSync(path, "utf8"), path, { lang: "jsx", jsx: { runtime: "automatic" } });
+	return { format: "module", source: code, shortCircuit: true };
+}`;
+register(`data:text/javascript,${encodeURIComponent(hook)}`, { data: { viteUrl: import.meta.resolve("vite") } });
+
+// locale.js reads localStorage once at import; without one it is English.
+const { renderToStaticMarkup } = await import("react-dom/server");
+const { ResourceStatus, SaveBlockedDialog, formatMiB, resourceRefLabel, resourceStatusLabel } = await import("../src/resource-status.jsx");
+const { createElement: h } = await import("react");
+
+const render = (component, props) => renderToStaticMarkup(h(component, props));
+const count = (html, needle) => html.split(needle).length - 1;
+
+/* ---------------------------------------------------------- fixtures --- */
+
+const manifest = {
+	items: [
+		{ kind: "image", id: "img-0123456789abcdef0123456789abcdef", status: "embedded", bytes: 2048, refs: [{ sceneId: "scene-a", objectId: "obj-1", field: "assetId" }] },
+		{ kind: "image", id: "img-ffffffffffffffffffffffffffffffff", status: "missing", stored: true, refs: [{ sceneId: "scene-a", objectId: "obj-2", field: "matteAssetId" }] },
+		{ kind: "motion", id: "a".repeat(64), status: "embedded", bytes: 4096, refs: [{ sceneId: "scene-a", characterId: "char-1", field: "motionRef.motionId" }] },
+		{ kind: "motion", id: "b".repeat(64), status: "missing", refs: [{ sceneId: "scene-b", characterId: "char-2", field: "motionRef.motionId" }] },
+		{ kind: "pose", id: "pose-hero", status: "embedded", refs: [{ sceneId: "scene-a", characterId: "char-1", field: "pose" }] },
+		{ kind: "workflow-output", id: "img-1234567890abcdef1234567890abcdef", status: "embedded", bytes: 512, refs: [{ nodeId: "image-1", field: "versions[0].dataUrl" }] },
+		{ kind: "workflow-output", id: "https://example.com/take-3.mp4", status: "external", url: "https://example.com/take-3.mp4", refs: [{ nodeId: "video-2", field: "videoUrl" }] },
+	],
+};
+manifest.totals = { embedded: 4, external: 1, missing: 2, bytes: 6656 };
+manifest.missing = manifest.items.filter((item) => item.status === "missing");
+
+/* ------------------------------------------------------------ labels --- */
+
+assert.equal(resourceStatusLabel({ status: "embedded" }), "In project file");
+assert.equal(resourceStatusLabel({ status: "external" }), "External URL");
+assert.equal(resourceStatusLabel({ status: "missing", stored: true }), "Browser-only copy");
+assert.equal(resourceStatusLabel({ status: "missing" }), "Missing");
+assert.equal(resourceRefLabel({ sceneId: "scene-a", objectId: "obj-1", field: "assetId" }), "scene-a / obj-1 · assetId");
+assert.equal(resourceRefLabel({ nodeId: "image-1", field: "versions[0].dataUrl" }), "image-1 · versions[0].dataUrl");
+assert.equal(resourceRefLabel({ field: "pose" }), "pose");
+assert.equal(resourceRefLabel(null), "");
+assert.equal(formatMiB(6656), "0.0 MiB");
+assert.equal(formatMiB(300 * 1024 * 1024), "300 MiB");
+assert.equal(formatMiB(256 * 1024 * 1024 + 512 * 1024), "257 MiB", "large sizes round to whole MiB");
+assert.equal(formatMiB(12 * 1024 * 1024 + 512 * 1024), "12.5 MiB", "small sizes keep one decimal");
+assert.equal(formatMiB(-1), "");
+console.log("PASS resource status: location labels and reference locations read as specified");
+
+/* ---------------------------------------------------- ResourceStatus --- */
+
+const full = render(ResourceStatus, { manifest });
+assert.match(full, /<section class="resource-status has-missing" aria-label="Project resources" data-missing-count="2">/);
+assert.match(full, /<dd data-total="embedded">4<\/dd>/);
+assert.match(full, /<dd data-total="external">1<\/dd>/);
+assert.match(full, /<dd data-total="missing">2<\/dd>/);
+assert.match(full, /<dd data-total="bytes">0\.0 MiB<\/dd>/);
+assert.match(full, /2 resources will not travel with this project file\./);
+assert.equal(count(full, '<li class="resource-status-item'), 7, "every manifest item is listed");
+const rowStatuses = [...full.matchAll(/<li class="resource-status-item[^>]*data-status="([a-z]+)"/g)].map((match) => match[1]);
+assert.deepEqual(rowStatuses, ["missing", "missing", "embedded", "embedded", "embedded", "embedded", "external"], "missing items sort to the top; the rest keep manifest order");
+// The missing rows carry kind, id and where they are referenced.
+assert.match(full, new RegExp(`<li class="resource-status-item is-missing" data-kind="motion" data-id="${"b".repeat(64)}" data-status="missing">`));
+assert.match(full, new RegExp(`<span class="resource-status-kind">Motion</span><code class="resource-status-id">${"b".repeat(64)}</code><span class="resource-status-state is-missing">Missing</span><span class="resource-status-refs">scene-b / char-2 · motionRef.motionId</span>`));
+assert.match(full, /data-kind="image" data-id="img-ffffffffffffffffffffffffffffffff" data-status="missing" data-stored="true"/);
+assert.match(full, /<span class="resource-status-state is-missing is-stored">Browser-only copy<\/span><span class="resource-status-refs">scene-a \/ obj-2 · matteAssetId<\/span>/);
+// Every location label appears for the item that has it.
+assert.match(full, /<span class="resource-status-kind">Image<\/span><code class="resource-status-id">img-0123456789abcdef0123456789abcdef<\/code><span class="resource-status-state is-embedded">In project file<\/span>/);
+assert.match(full, /<span class="resource-status-kind">Workflow output<\/span><code class="resource-status-id">https:\/\/example\.com\/take-3\.mp4<\/code><span class="resource-status-state is-external">External URL<\/span><span class="resource-status-url" title="https:\/\/example\.com\/take-3\.mp4">https:\/\/example\.com\/take-3\.mp4<\/span>/);
+assert.match(full, /<span class="resource-status-kind">Pose<\/span><code class="resource-status-id">pose-hero<\/code>/);
+assert.match(full, /image-1 · versions\[0\]\.dataUrl/);
+assert.doesNotMatch(full, /<button/, "without onSelect the rows are not buttons");
+console.log("PASS resource status: counts, the sorted item list, and per-item kind / id / location / refs render");
+
+const selectable = render(ResourceStatus, { manifest, onSelect: () => {} });
+assert.equal(count(selectable, '<button type="button" class="resource-status-select">'), 7, "with onSelect every row is a button");
+
+const compact = render(ResourceStatus, { manifest, compact: true });
+assert.match(compact, /<section class="resource-status is-compact has-missing"/);
+assert.match(compact, /<dd data-total="embedded">4<\/dd>/);
+assert.match(compact, /2 resources will not travel/);
+assert.equal(count(compact, '<li class="resource-status-item'), 2, "compact lists only the missing items");
+assert.match(compact, /<ul class="resource-status-items is-missing-only" aria-label="Missing resources">/);
+assert.doesNotMatch(compact, /pose-hero/, "compact hides the embedded rows");
+
+const clean = render(ResourceStatus, { manifest: { items: manifest.items.filter((item) => item.status !== "missing") } });
+assert.match(clean, /<section class="resource-status" aria-label="Project resources" data-missing-count="0">/);
+assert.match(clean, /<dd data-total="embedded">4<\/dd>/, "totals are computed from items when the manifest omits them");
+assert.match(clean, /<dd data-total="missing">0<\/dd>/);
+assert.match(clean, /<dd data-total="bytes">0\.0 MiB<\/dd>/);
+assert.doesNotMatch(clean, /will not travel/);
+assert.doesNotMatch(clean, /resource-status-warning/);
+
+const empty = render(ResourceStatus, { manifest: null });
+assert.match(empty, /<dd data-total="embedded">0<\/dd>/);
+assert.doesNotMatch(empty, /<ul/, "an empty manifest renders totals only");
+assert.doesNotMatch(empty, /data-total="bytes"/, "a zero size is not shown");
+console.log("PASS resource status: compact, select, empty and all-embedded variants");
+
+/* -------------------------------------------------- SaveBlockedDialog --- */
+
+const blocked = render(SaveBlockedDialog, {
+	reasons: [
+		{ code: "missing-resources", items: manifest.missing },
+		{ code: "resources-too-large", bytes: 300 * 1024 * 1024, limit: 256 * 1024 * 1024 },
+		{ code: "disk-full", message: "The drive is full." },
+		{ code: "mystery" },
+	],
+	onClose: () => {},
+});
+assert.match(blocked, /<div class="modal-overlay"><div class="modal save-blocked-dialog" role="dialog" aria-modal="true" aria-labelledby="save-blocked-title">/);
+assert.match(blocked, /<h3 id="save-blocked-title">The project was not saved<\/h3>/);
+assert.match(blocked, /<button type="button" class="x" aria-label="Close">/);
+assert.equal(count(blocked, '<li class="save-blocked-reason"'), 4, "every reason is listed");
+assert.match(blocked, /<li class="save-blocked-reason" data-code="missing-resources"><strong>2 resources are missing\.<\/strong><ul class="save-blocked-missing">/);
+assert.equal(count(blocked, '<li class="resource-status-item is-missing"'), 2, "the missing reason lists the missing items");
+assert.match(blocked, new RegExp(`data-kind="motion" data-id="${"b".repeat(64)}" data-status="missing"`));
+assert.match(blocked, /scene-b \/ char-2 · motionRef\.motionId/);
+assert.match(blocked, /<li class="save-blocked-reason" data-code="resources-too-large"><strong>The project file would be too large\.<\/strong><span class="save-blocked-size" data-bytes="314572800" data-limit="268435456">300 MiB of embedded resources; the limit is 256 MiB\.<\/span>/);
+assert.match(blocked, /<li class="save-blocked-reason" data-code="disk-full"><strong>The drive is full\.<\/strong>/);
+assert.match(blocked, /<li class="save-blocked-reason" data-code="mystery"><strong>mystery<\/strong>/);
+assert.match(blocked, /<button type="button" class="btn">OK<\/button>/);
+
+const single = render(SaveBlockedDialog, { reasons: [{ code: "missing-resources", items: [manifest.missing[0]] }], onClose: () => {} });
+assert.match(single, /<strong>1 resource is missing\.<\/strong>/);
+const none = render(SaveBlockedDialog, { reasons: null, onClose: () => {} });
+assert.match(none, /<ul class="save-blocked-reasons"><\/ul>/, "no reasons renders an empty list, not a crash");
+console.log("PASS resource status: SaveBlockedDialog lists missing resources and the bytes/limit overflow");
+
+/* ------------------------------------------------------------ source --- */
+
+const source = readFileSync(new URL("../src/resource-status.jsx", import.meta.url), "utf8");
+assert.doesNotMatch(source, /from "\.\/App\.jsx"|useContext|useState|useEffect|localStorage|indexedDB/, "the components are pure functions of their props");
+assert.match(source, /import \{ ko \} from "\.\/locale\.js"/);
+for (const label of ["프로젝트 파일에 포함됨", "브라우저 임시 저장", "외부 URL", "누락"]) assert.ok(source.includes(`"${label}"`), `Korean label present: ${label}`);
+const css = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
+for (const selector of [".resource-status {", ".resource-status-totals {", ".resource-status-item {", ".resource-status-warning {", ".save-blocked-reason {", ".save-blocked-size {"]) assert.ok(css.includes(selector), `styles.css carries ${selector}`);
+console.log("PASS resource status: pure props components, locale pairs, and stylesheet rules present");
+
+console.log("verify-resource-status: ok");

--- a/test/verify-workflow-resources.mjs
+++ b/test/verify-workflow-resources.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * verify-workflow-resources (#230): generated pictures in workflow node data
+ * are found in every slot they can land in, pulled out into content-addressed
+ * asset records on save, and put back on open so the graph is deep-equal to
+ * what the canvas had. Video, blob: and http(s) outputs are classified, never
+ * moved.
+ */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { crc32, deflateSync } from "node:zlib";
+import {
+	WORKFLOW_OUTPUT_FIELDS,
+	imageDimensions,
+	internWorkflowOutputs,
+	isAssetRef,
+	outputKind,
+	resolveWorkflowOutputs,
+	workflowOutputRefs,
+} from "../src/workflow/workflow-resources.js";
+import { assetIdForBytes, normalizeAsset } from "../src/scene-assets.js";
+import { normalizeWorkflowGraph } from "../src/project.js";
+
+/* ------------------------------------------------------------ fixtures --- */
+
+function pngChunk(type, payload) {
+	const length = Buffer.alloc(4);
+	length.writeUInt32BE(payload.length);
+	const body = Buffer.concat([Buffer.from(type, "latin1"), payload]);
+	const crc = Buffer.alloc(4);
+	crc.writeUInt32BE(crc32(body));
+	return Buffer.concat([length, body, crc]);
+}
+
+/** A real RGBA PNG of the given size; `seed` changes the pixels so two calls
+ * produce two different pictures with two different ids. */
+function pngBytes(width, height, seed) {
+	const header = Buffer.alloc(13);
+	header.writeUInt32BE(width, 0);
+	header.writeUInt32BE(height, 4);
+	header[8] = 8; header[9] = 6; header[10] = 0; header[11] = 0; header[12] = 0;
+	const raw = Buffer.alloc((width * 4 + 1) * height);
+	for (let y = 0; y < height; y += 1) for (let x = 0; x < width; x += 1) raw.set([(x * 37 + seed) & 255, (y * 91 + seed) & 255, seed & 255, 255], y * (width * 4 + 1) + 1 + x * 4);
+	return new Uint8Array(Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), pngChunk("IHDR", header), pngChunk("IDAT", deflateSync(raw)), pngChunk("IEND", Buffer.alloc(0))]));
+}
+
+const dataUrl = (type, bytes) => `data:${type};base64,${Buffer.from(bytes).toString("base64")}`;
+const expectedId = (bytes) => `img-${createHash("sha256").update(bytes).digest("hex").slice(0, 32)}`;
+
+const frame = pngBytes(4, 3, 1);
+const takeOne = pngBytes(2, 2, 2);
+const takeTwo = pngBytes(2, 2, 3);
+const frameUrl = dataUrl("image/png", frame);
+const takeOneUrl = dataUrl("image/png", takeOne);
+const takeTwoUrl = dataUrl("image/png", takeTwo);
+const videoUrl = "data:video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDE=";
+const blobUrl = "blob:http://127.0.0.1:5180/1c1d1b5e-6a45-4f0a-9d4e-0f0c1a2b3c4d";
+const httpUrl = "https://example.com/renders/take-3.mp4";
+
+const graph = normalizeWorkflowGraph({
+	version: 1,
+	nodes: [
+		{ id: "scene-1", type: "cozyScene", position: { x: 0, y: 0 }, data: { sceneName: "Alley", preview: "render", lastOutput: { renderUrl: frameUrl, sceneUrl: "/app/", jobId: null, meta: { fps: 24 }, references: [] }, outputs: [{ value: frameUrl }], resultUrl: frameUrl } },
+		{ id: "image-1", type: "image", position: { x: 300, y: 0 }, data: { model: "image-generation", versions: [{ dataUrl: takeOneUrl, prompt: "take 1", referenceDataUrl: null, frameDataUrl: frameUrl, at: 1 }, { dataUrl: takeTwoUrl, prompt: "take 2", referenceDataUrl: null, frameDataUrl: frameUrl, at: 2 }], versionIndex: 1, outputs: [{ value: takeTwoUrl }], resultUrl: takeTwoUrl, pinReferences: false } },
+		{ id: "video-1", type: "video", position: { x: 600, y: 0 }, data: { provider: "fal", videoUrl, resultUrl: videoUrl, outputs: [{ value: videoUrl }], preservation: null } },
+		{ id: "video-2", type: "video", position: { x: 600, y: 200 }, data: { provider: "comfy", videoUrl: httpUrl, resultUrl: httpUrl, outputs: [{ value: httpUrl }] } },
+		{ id: "upload-1", type: "upload", position: { x: 0, y: 300 }, data: { fileName: "ref.png", mimeType: "image/png", fileUrl: takeOneUrl, image_url: takeOneUrl, localPreview: true, outputs: [{ value: takeOneUrl }] } },
+		{ id: "upload-2", type: "upload", position: { x: 0, y: 500 }, data: { fileName: "clip.mp4", mimeType: "video/mp4", fileUrl: blobUrl, outputs: [{ value: blobUrl }] } },
+		{ id: "prompt-1", type: "shotPrompt", position: { x: 300, y: 300 }, data: { prompt: "wide two-shot", outputs: [{ value: "wide two-shot" }], resultUrl: null } },
+		{ id: "empty-1", type: "default", position: { x: 0, y: 0 }, data: {} },
+	],
+	edges: [{ id: "e1", source: "scene-1", target: "image-1", sourceHandle: "render", targetHandle: "input" }],
+});
+const snapshot = structuredClone(graph);
+
+/* -------------------------------------------------------- outputKind ----- */
+
+assert.equal(outputKind(frameUrl), "data-url");
+assert.equal(outputKind(videoUrl), "data-url");
+assert.equal(outputKind(httpUrl), "http");
+assert.equal(outputKind("http://127.0.0.1:5180/app/"), "http");
+assert.equal(outputKind(blobUrl), "blob");
+assert.equal(outputKind("/app/"), "other");
+assert.equal(outputKind("wide two-shot"), "other");
+assert.equal(outputKind({ assetRef: "img-0123456789abcdef0123456789abcdef" }), "asset-ref");
+assert.equal(outputKind({ assetRef: "not-an-id" }), null, "a ref must carry a real asset id");
+assert.equal(outputKind(null), null);
+assert.equal(outputKind(""), null);
+assert.equal(outputKind(42), null);
+assert.ok(isAssetRef({ assetRef: "img-0123456789abcdef0123456789abcdef" }));
+assert.equal(isAssetRef("img-0123456789abcdef0123456789abcdef"), false, "a bare id string is not a ref");
+console.log("PASS workflow resources: output values classify as data-url / http / blob / asset-ref / other");
+
+/* ------------------------------------------------- workflowOutputRefs ---- */
+
+assert.deepEqual(WORKFLOW_OUTPUT_FIELDS, ["resultUrl", "videoUrl", "lastOutput.renderUrl", "lastOutput.sceneUrl", "versions[].dataUrl", "fileUrl", "outputs[].value"]);
+const refs = workflowOutputRefs(graph);
+const refKey = (ref) => `${ref.nodeId}:${ref.field}`;
+const byKey = new Map(refs.map((ref) => [refKey(ref), ref]));
+assert.deepEqual(byKey.get("scene-1:resultUrl"), { nodeId: "scene-1", field: "resultUrl", value: frameUrl, kind: "data-url" });
+assert.deepEqual(byKey.get("scene-1:lastOutput.renderUrl"), { nodeId: "scene-1", field: "lastOutput.renderUrl", value: frameUrl, kind: "data-url" });
+assert.deepEqual(byKey.get("scene-1:lastOutput.sceneUrl"), { nodeId: "scene-1", field: "lastOutput.sceneUrl", value: "/app/", kind: "other" });
+assert.deepEqual(byKey.get("scene-1:outputs[0].value"), { nodeId: "scene-1", field: "outputs[0].value", value: frameUrl, kind: "data-url" });
+assert.deepEqual(byKey.get("image-1:versions[0].dataUrl"), { nodeId: "image-1", field: "versions[0].dataUrl", value: takeOneUrl, kind: "data-url" });
+assert.deepEqual(byKey.get("image-1:versions[1].dataUrl"), { nodeId: "image-1", field: "versions[1].dataUrl", value: takeTwoUrl, kind: "data-url" });
+assert.deepEqual(byKey.get("video-1:videoUrl"), { nodeId: "video-1", field: "videoUrl", value: videoUrl, kind: "data-url" });
+assert.deepEqual(byKey.get("video-2:videoUrl"), { nodeId: "video-2", field: "videoUrl", value: httpUrl, kind: "http" });
+assert.deepEqual(byKey.get("video-2:outputs[0].value"), { nodeId: "video-2", field: "outputs[0].value", value: httpUrl, kind: "http" });
+assert.deepEqual(byKey.get("upload-1:fileUrl"), { nodeId: "upload-1", field: "fileUrl", value: takeOneUrl, kind: "data-url" });
+assert.deepEqual(byKey.get("upload-2:fileUrl"), { nodeId: "upload-2", field: "fileUrl", value: blobUrl, kind: "blob" });
+assert.deepEqual(byKey.get("prompt-1:outputs[0].value"), { nodeId: "prompt-1", field: "outputs[0].value", value: "wide two-shot", kind: "other" });
+assert.equal(byKey.has("prompt-1:resultUrl"), false, "a null slot is not a ref");
+assert.equal(byKey.has("image-1:versions[0].frameDataUrl"), false, "a version's inputs are not outputs");
+assert.equal(byKey.has("upload-1:image_url"), false, "upload input aliases are not outputs");
+assert.equal(refs.filter((ref) => ref.nodeId === "empty-1").length, 0);
+assert.equal(refs.length, 19, `every populated output slot is listed once (got ${refs.map(refKey).join(", ")})`);
+assert.deepEqual(workflowOutputRefs(null), []);
+assert.deepEqual(workflowOutputRefs({ nodes: [{ id: "x" }, null, { id: "y", data: { resultUrl: httpUrl } }] }), [{ nodeId: "y", field: "resultUrl", value: httpUrl, kind: "http" }]);
+console.log("PASS workflow resources: refs come from resultUrl, videoUrl, lastOutput, versions[], fileUrl and outputs[]");
+
+/* ----------------------------------------------------- imageDimensions --- */
+
+assert.deepEqual(imageDimensions(frame), { width: 4, height: 3 });
+assert.deepEqual(imageDimensions(Buffer.from("GIF89a" + "\x10\x00\x20\x00", "latin1")), { width: 16, height: 32 });
+assert.deepEqual(imageDimensions(Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x4a, 0x46, 0xff, 0xc0, 0x00, 0x0b, 0x08]), Buffer.from([0x01, 0x00, 0x02, 0x80, 0x03])])), { width: 640, height: 256 });
+assert.deepEqual(imageDimensions(Buffer.concat([Buffer.from("RIFF\0\0\0\0WEBPVP8X", "latin1"), Buffer.from([0x0a, 0, 0, 0, 0x10, 0, 0, 0, 0x7f, 0x01, 0x00, 0x3f, 0x01, 0x00])])), { width: 384, height: 320 });
+assert.equal(imageDimensions(new Uint8Array([1, 2, 3])), null, "an unknown header has no size");
+assert.equal(imageDimensions(Buffer.from("GIF89a")), null, "a truncated header has no size");
+console.log("PASS workflow resources: pixel size read from PNG / GIF / JPEG / WebP headers");
+
+/* ----------------------------------------------- internWorkflowOutputs --- */
+
+const interned = await internWorkflowOutputs(graph, { assetIdForBytes: (bytes) => assetIdForBytes(bytes, globalThis.crypto.subtle) });
+assert.deepEqual(graph, snapshot, "interning does not mutate the graph it is given");
+const ids = { frame: expectedId(frame), takeOne: expectedId(takeOne), takeTwo: expectedId(takeTwo) };
+assert.deepEqual(interned.assets.map((asset) => asset.id).sort(), Object.values(ids).sort(), "one record per distinct picture, even when a picture sits in several slots");
+for (const asset of interned.assets) {
+	assert.equal(asset.type, "image/png");
+	assert.equal(asset.role, "workflow-output");
+	assert.ok(asset.bytes instanceof ArrayBuffer, "asset bytes are an ArrayBuffer, the shape the asset store and createProjectDocument take");
+	assert.equal(await assetIdForBytes(asset.bytes, globalThis.crypto.subtle), asset.id, "the record's bytes hash to its id");
+	assert.ok(normalizeAsset(asset), "the record passes the asset store's own validation");
+}
+assert.deepEqual(interned.assets.find((asset) => asset.id === ids.frame), { id: ids.frame, type: "image/png", width: 4, height: 3, name: "", role: "workflow-output", bytes: interned.assets.find((asset) => asset.id === ids.frame).bytes });
+
+const node = (g, id) => g.nodes.find((entry) => entry.id === id);
+const scene = node(interned.graph, "scene-1");
+assert.deepEqual(scene.data.resultUrl, { assetRef: ids.frame });
+assert.deepEqual(scene.data.lastOutput.renderUrl, { assetRef: ids.frame });
+assert.deepEqual(scene.data.outputs, [{ value: { assetRef: ids.frame } }]);
+assert.equal(scene.data.lastOutput.sceneUrl, "/app/", "a plain path is left alone");
+assert.deepEqual(scene.data.lastOutput.meta, { fps: 24 }, "the rest of lastOutput is untouched");
+assert.equal(scene.data.sceneName, "Alley");
+const image = node(interned.graph, "image-1");
+assert.deepEqual(image.data.versions.map((version) => version.dataUrl), [{ assetRef: ids.takeOne }, { assetRef: ids.takeTwo }]);
+assert.equal(image.data.versions[0].frameDataUrl, frameUrl, "a version's input frame is not an output and stays inline");
+assert.equal(image.data.versions[0].prompt, "take 1");
+assert.deepEqual(image.data.resultUrl, { assetRef: ids.takeTwo });
+assert.equal(image.data.versionIndex, 1);
+const video = node(interned.graph, "video-1");
+assert.equal(video.data.videoUrl, videoUrl, "a video data URL is not an image asset and stays inline");
+assert.equal(video.data.resultUrl, videoUrl);
+assert.deepEqual(video.data.outputs, [{ value: videoUrl }]);
+assert.equal(node(interned.graph, "video-2").data.videoUrl, httpUrl, "http(s) stays external");
+assert.equal(node(interned.graph, "video-2").data.resultUrl, httpUrl);
+const upload = node(interned.graph, "upload-1");
+assert.deepEqual(upload.data.fileUrl, { assetRef: ids.takeOne });
+assert.deepEqual(upload.data.outputs, [{ value: { assetRef: ids.takeOne } }]);
+assert.equal(upload.data.image_url, takeOneUrl, "upload input aliases are not in the output field list and stay inline");
+assert.equal(node(interned.graph, "upload-2").data.fileUrl, blobUrl, "blob: stays inline");
+assert.deepEqual(node(interned.graph, "prompt-1").data, snapshot.nodes.find((entry) => entry.id === "prompt-1").data, "a text-only node is untouched");
+assert.equal(node(interned.graph, "prompt-1"), node(graph, "prompt-1"), "an untouched node keeps its identity");
+assert.equal(node(interned.graph, "empty-1"), node(graph, "empty-1"));
+assert.deepEqual(interned.graph.edges, graph.edges);
+assert.equal(interned.graph.version, graph.version);
+const internedRefs = workflowOutputRefs(interned.graph);
+assert.equal(internedRefs.filter((ref) => ref.kind === "asset-ref").length, 9, "every image slot now reads as an asset-ref");
+assert.equal(internedRefs.filter((ref) => ref.kind === "data-url").length, 3, "the video data URL slots still read as data-url");
+assert.equal(internedRefs.filter((ref) => ref.kind === "http").length, 3);
+assert.equal(internedRefs.filter((ref) => ref.kind === "blob").length, 2);
+
+// Pictures the asset store would refuse are left in place rather than
+// embedded as records the reader would drop.
+const odd = { version: 1, edges: [], nodes: [
+	{ id: "svg", position: { x: 0, y: 0 }, data: { resultUrl: "data:image/svg+xml;base64,PHN2Zy8+" } },
+	{ id: "nohdr", position: { x: 0, y: 0 }, data: { resultUrl: "data:image/png;base64,AAAA" } },
+	{ id: "utf8", position: { x: 0, y: 0 }, data: { resultUrl: "data:image/png,%89PNG" } },
+] };
+const oddInterned = await internWorkflowOutputs(odd, { assetIdForBytes: (bytes) => assetIdForBytes(bytes, globalThis.crypto.subtle) });
+assert.deepEqual(oddInterned.assets, []);
+assert.deepEqual(oddInterned.graph, odd, "unsupported or unreadable image data URLs stay exactly as they were");
+assert.deepEqual(await internWorkflowOutputs(null, {}), { graph: null, assets: [] });
+console.log("PASS workflow resources: data:image/* outputs intern to { assetRef } + content-addressed asset records");
+
+/* ---------------------------------------------- resolveWorkflowOutputs --- */
+
+const assetsById = new Map(interned.assets.map((asset) => [asset.id, asset]));
+const resolved = resolveWorkflowOutputs(interned.graph, assetsById);
+assert.deepEqual(resolved, snapshot, "intern -> resolve round-trips to the original graph");
+assert.deepEqual(resolveWorkflowOutputs(interned.graph, interned.assets), snapshot, "an asset array works as the lookup too");
+assert.deepEqual(resolveWorkflowOutputs(interned.graph, Object.fromEntries(assetsById)), snapshot, "a plain id -> record object works as the lookup too");
+assert.deepEqual(normalizeWorkflowGraph(JSON.parse(JSON.stringify(interned.graph))), interned.graph, "the interned graph survives the project file's JSON normalization");
+assert.deepEqual(resolveWorkflowOutputs(normalizeWorkflowGraph(JSON.parse(JSON.stringify(interned.graph))), assetsById), snapshot, "…and still resolves after it");
+
+// Typed-array bytes (what the asset store hands back after a structured clone
+// in some browsers) resolve the same way.
+const viewAssets = new Map([...assetsById].map(([id, asset]) => [id, { ...asset, bytes: new Uint8Array(asset.bytes) }]));
+assert.deepEqual(resolveWorkflowOutputs(interned.graph, viewAssets), snapshot);
+
+// A ref whose asset is gone is kept as a ref: the manifest reports it as
+// missing instead of the slot silently emptying.
+const partial = new Map(assetsById);
+partial.delete(ids.takeOne);
+const partiallyResolved = resolveWorkflowOutputs(interned.graph, partial);
+assert.deepEqual(node(partiallyResolved, "upload-1").data.fileUrl, { assetRef: ids.takeOne });
+assert.deepEqual(node(partiallyResolved, "image-1").data.versions[0].dataUrl, { assetRef: ids.takeOne });
+assert.equal(node(partiallyResolved, "image-1").data.versions[1].dataUrl, takeTwoUrl, "the sibling version with a present asset still resolves");
+assert.equal(node(partiallyResolved, "scene-1").data.resultUrl, frameUrl);
+assert.deepEqual(workflowOutputRefs(partiallyResolved).filter((ref) => ref.kind === "asset-ref").map((ref) => `${ref.nodeId}:${ref.field}`), ["image-1:versions[0].dataUrl", "upload-1:fileUrl", "upload-1:outputs[0].value"]);
+assert.deepEqual(resolveWorkflowOutputs(interned.graph, new Map()), interned.graph, "no assets at all leaves every ref in place");
+assert.equal(resolveWorkflowOutputs(null, assetsById), null);
+assert.equal(resolveWorkflowOutputs(graph, assetsById).nodes.every((entry, index) => entry === graph.nodes[index]), true, "a graph without refs keeps every node's identity");
+console.log("PASS workflow resources: assetRef -> data URL restores the runtime node shape; absent assets stay as refs");
+
+console.log("verify-workflow-resources: ok");

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -173,6 +173,8 @@ const NODE_FILES = [
 	"test/verify-speed-envelope.mjs",
 	"test/verify-motion-resources.mjs",
 	"test/verify-project-resources.mjs",
+	"test/verify-workflow-resources.mjs",
+	"test/verify-resource-status.mjs",
 ];
 
 const BROWSER_FILES = [


### PR DESCRIPTION
# Summary

Workflow nodes keep what they generated inline in node data as `data:` URLs (`resultUrl`, `outputs[0].value`, every Image version, the Scene node's `lastOutput.renderUrl`, an Upload's `fileUrl`). Saved as is, a `.cclayproject` carries each PNG several times over and nothing tells the author which outputs will survive a move to another browser. This track adds the pure module that pulls those pictures out into content-addressed asset records on save and puts them back on open, plus the two props-only UI components the integrator will mount: a resource status panel and a save-blocked dialog.

App.jsx and WorkflowBuilder.jsx are not touched; wiring is the integration issue's.

# Changes

- `src/workflow/workflow-resources.js` (new)
  - `workflowOutputRefs(graph)` — every populated output slot with `{ nodeId, field, value, kind }`, `kind` in `data-url | http | asset-ref | blob | other`. Fields: `resultUrl`, `videoUrl`, `lastOutput.renderUrl`, `lastOutput.sceneUrl`, `versions[i].dataUrl`, `fileUrl`, `outputs[i].value`.
  - `internWorkflowOutputs(graph, { assetIdForBytes })` → `{ graph, assets }`. Only `data:image/*` of an `ASSET_IMAGE_TYPES` type is interned to `{ assetRef: "img-…" }`; one asset record per distinct picture (`id` from `assetIdForBytes`, `bytes` as an ArrayBuffer, `width`/`height` read from the PNG/GIF/JPEG/WebP header, `role: "workflow-output"`), the shape `normalizeAsset` / `createProjectDocument` already accept. Video data URLs, `blob:`, `http(s)` and everything else in node data are left as is; untouched nodes keep identity.
  - `resolveWorkflowOutputs(graph, assetsById)` — `assetRef` → data URL, so the runtime node shape is what the canvas renders today. Accepts a Map, an array of records, or a plain id→record object. A ref whose asset is absent stays a ref so the manifest reports it as missing rather than the slot emptying.
  - intern → resolve round-trips deep-equal, including through `normalizeWorkflowGraph` / JSON.
- `src/resource-status.jsx` (new) + `src/styles.css` (append only)
  - `ResourceStatus({ manifest, compact?, onSelect? })` — embedded / external / missing counts (+ size when known), the missing warning, and an item list sorted missing-first with kind, id, location label ("In project file / Browser-only copy / External URL / Missing" — Korean via `ko()`: "프로젝트 파일에 포함됨 / 브라우저 임시 저장 / 외부 URL / 누락"), external URL, and reference locations (`scene-a / obj-2 · matteAssetId`, `image-1 · versions[0].dataUrl`). `compact` shows totals + missing only. With `onSelect` each row is a button.
  - `SaveBlockedDialog({ reasons, onClose })` — `{ code: "missing-resources", items }` renders the missing list; `{ code: "resources-too-large", bytes, limit }` renders the overflow with both sizes; other codes render their `message`/`code`.
  - Both are pure functions of props: no App state, no hooks, no storage access (pinned by the test).
- `test/verify-workflow-resources.mjs`, `test/verify-resource-status.mjs` (new); `tools/run-tests.mjs` — two `NODE_FILES` lines appended.

The component test renders through `react-dom/server`'s `renderToStaticMarkup`. Node cannot import JSX, and no existing Node test renders a `.jsx` file, so the test registers a `node:module` loader hook that runs `.jsx` through Vite's own `transformWithOxc` (the transform the dev server and build use). Nothing else is transformed.

# Tests

`node test/verify-workflow-resources.mjs` (exit 0):

```
PASS workflow resources: output values classify as data-url / http / blob / asset-ref / other
PASS workflow resources: refs come from resultUrl, videoUrl, lastOutput, versions[], fileUrl and outputs[]
PASS workflow resources: pixel size read from PNG / GIF / JPEG / WebP headers
PASS workflow resources: data:image/* outputs intern to { assetRef } + content-addressed asset records
PASS workflow resources: assetRef -> data URL restores the runtime node shape; absent assets stay as refs
verify-workflow-resources: ok
```

`node test/verify-resource-status.mjs` (exit 0):

```
PASS resource status: location labels and reference locations read as specified
PASS resource status: counts, the sorted item list, and per-item kind / id / location / refs render
PASS resource status: compact, select, empty and all-embedded variants
PASS resource status: SaveBlockedDialog lists missing resources and the bytes/limit overflow
PASS resource status: pure props components, locale pairs, and stylesheet rules present
verify-resource-status: ok
```

`npm run build && node tools/run-tests.mjs` (exit 0), final line:

```
PASS 168 Node verification files
```

(The first full run failed in `test/verify-agent-routes.mjs` with `Cannot find package 'ws'` because this fresh worktree had no `mcp/node_modules`; `npm --prefix mcp ci` fixed it. Pre-existing environment gap, unrelated to this change.)

# QA evidence

Both components rendered in Chrome (headless, CDP) against the vite dev server on port 5210 through a scratch harness page (`artifacts/qa-230/`, gitignored) that mounts them with a fixture manifest of 7 items (4 embedded, 1 external, 2 missing). No console exceptions on any page.

- `resource-status.png` (1000×720) — full panel on the left: totals row "In project file 4 · External URL 1 · Missing 2 · Size 6.5 MiB", the amber "2 resources will not travel with this project file." line, then the two missing rows first (Image `img-ffff…` "Browser-only copy" at `scene-a / obj-2 · matteAssetId`; Motion `bbbb…` "Missing" at `scene-b / char-2 · motionRef.motionId`), then the embedded image/motion/pose/workflow-output rows in green and the external `https://example.com/take-3.mp4` row in blue with its URL. Compact panel on the right: same totals + warning, only the two missing rows.
- `resource-status-selected.png` — after clicking the first missing row through `onSelect`, the harness readout shows `selected: img-ffffffffffffffffffffffffffffffff`.
- `save-blocked.png` — `SaveBlockedDialog` over the blurred page: title "The project was not saved", reason 1 "2 resources are missing." with the two missing rows, reason 2 "The project file would be too large. / 300 MiB of embedded resources; the limit is 256 MiB.", OK button.
- `resource-status-narrow.png` (420×900) — totals stack vertically, rows wrap, ids ellipsize; nothing overflows.

# Notes for the integrator (not changed here)

- `internWorkflowOutputs` returns asset records with `role: "workflow-output"`. `asset-shelf.js` treats any non-`"derived"` role as a source, so these would show on the shelf unless the integrator filters that role (or stamps `"derived"`). Left as specified for the manifest; flagging so the shelf decision is made deliberately.
- `createProjectDocument` currently embeds only assets in `referencedAssetIds(scenes)`. Interned workflow assets need to be added to that set (or passed separately) by the integrator for them to land in `resources.assets`.

Closes #230
