### PR TITLE
feat(project): integrate portable resources into App.jsx (#231)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -227,6 +227,7 @@ import FirstSuccessGuide from "./first-success-guide.jsx";
 import { CameraTutorial } from "./camera-tutorial.jsx";
 import ObjectGizmo from "./object-gizmo.jsx";
 import AssetPane from "./asset-pane.jsx";
+import ResourceStatus, { SaveBlockedDialog } from "./resource-status.jsx";
 import AddObjectMenu from "./object-catalog.jsx";
 import ResultModal from "./result-modal.jsx";
 import SettingsMenu from "./settings-menu.jsx";
@@ -263,6 +264,9 @@ import {
 	warmPoseThumbnails,
 } from "./posestudio.jsx";
 import { mergeProjectCustomPoses } from "./project-poses.js";
+import { encodeMotionResource, decodeMotionResource, resolveMotionSource } from "./motion-resources.js";
+import { resourceManifest } from "./project-resources.js";
+import { internWorkflowOutputs, resolveWorkflowOutputs, workflowOutputRefs } from "./workflow/workflow-resources.js";
 import {
 	MID_TRACKS,
 	createIkState,
@@ -3169,6 +3173,10 @@ export default function App() {
 	// opens on the stage, not on a chat column.
 	const [agentCollapsed, setAgentCollapsed] = useState(true);
 	const projectHandleRef = useRef(null);
+	const projectMotionsRef = useRef(new Map());
+	const restoreEpochRef = useRef(0);
+	const [projectManifest, setProjectManifest] = useState({ items: [], totals: { embedded: 0, external: 0, missing: 0, bytes: 0 }, missing: [] });
+	const [saveBlockedReasons, setSaveBlockedReasons] = useState(null);
 	const projectSnapshotRef = useRef("");
 	const projectStateRef = useRef(null);
 	projectStateRef.current = { workspaceLayout, customPoses, scenes, activeSceneId, sceneObjects };
@@ -3211,16 +3219,38 @@ export default function App() {
 		try {
 			const ids = [...referencedAssetIds(input.scenesDocument.scenes)];
 			const assets = await Promise.all(ids.map((id) => getAsset(db, id)));
-			// A referenced asset whose record vanished (swept elsewhere, another
-			// tab) would drop out of the export in silence — the user would
-			// learn on the machine they open it on. Say it here, at save time.
-			const missing = ids.filter((id, index) => !assets[index]);
-			if (missing.length) {
-				setToast(isKo
-					? `참조된 사진 ${missing.length}개를 찾지 못해보내기에서 빠졌어요`
-					: `${missing.length} referenced image${missing.length > 1 ? "s" : ""} missing — left out of the export`);
+			const workflowResult = await internWorkflowOutputs(input.workflow);
+			const referencedMotionIds = new Set(
+				input.scenesDocument.scenes.flatMap((scene) => (scene.stage?.characters ?? [])
+					.map((character) => character.motionRef?.motionId?.toLowerCase())
+					.filter(Boolean)),
+			);
+			const motions = [...projectMotionsRef.current.entries()]
+				.filter(([id]) => referencedMotionIds.has(id))
+				.map(([, record]) => record);
+			const motionCache = new Map();
+			for (const record of motions) motionCache.set(record.motionId.toLowerCase(), record);
+			for (const scene of input.scenesDocument.scenes) for (const character of scene.stage?.characters ?? []) {
+				const clip = motionFullRef.current.get(character.id);
+				if (!clip?.sourceBytes) continue;
+				const record = await encodeMotionResource(clip.sourceBytes, { prompt: character.motionRef?.prompt, sourceUrl: character.motionRef?.url });
+				const cached = motionCache.get(record.motionId) ?? record;
+				motionCache.set(record.motionId, cached);
+				if (!motions.includes(cached)) motions.push(cached);
+				projectMotionsRef.current.set(record.motionId.toLowerCase(), cached);
+				character.motionRef = { ...(character.motionRef || {}), motionId: cached.motionId };
 			}
-			return JSON.stringify(createProjectDocument({ ...input, assets, savedAt: Date.now() }), null, 2);
+			const allAssets = [...assets.filter(Boolean), ...workflowResult.assets];
+			const nextInput = { ...input, workflow: workflowResult.graph, assets: allAssets, motions };
+			const manifest = resourceManifest({ scenesDocument: nextInput.scenesDocument, workflow: nextInput.workflow, poseLibrary: nextInput.customPoses, assets: allAssets, motions, workflowOutputRefs });
+			setProjectManifest(manifest);
+			if (manifest.missing.length) {
+				const error = new Error("Project has missing resources");
+				error.code = "missing-resources";
+				error.items = manifest.missing;
+				throw error;
+			}
+			return JSON.stringify(createProjectDocument({ ...nextInput, savedAt: Date.now() }), null, 2);
 		} finally {
 			db.close();
 		}
@@ -3231,6 +3261,14 @@ export default function App() {
 		setProjectDirty(false);
 		setProjectName(name);
 		storeProjectSession(name);
+	}
+
+	function projectProblemsNotice(problems) {
+		if (!Array.isArray(problems) || !problems.length) return "";
+		const codes = [...new Set(problems.map((problem) => problem?.code).filter(Boolean))].join(", ");
+		return isKo
+			? ` · 포함된 자원 ${problems.length}개를 건너뛰었어요${codes ? ` (${codes})` : ""}`
+			: ` · skipped ${problems.length} embedded resource${problems.length === 1 ? "" : "s"}${codes ? ` (${codes})` : ""}`;
 	}
 
 	async function rehydrateProjectAssets(project, warnings = []) {
@@ -3283,6 +3321,7 @@ export default function App() {
 				await writeProjectFile(handle, serialized);
 			}
 			markProjectClean(name);
+			setSaveBlockedReasons(null);
 			setProjectSaveState("saved");
 			track("project:saved", {
 				object_count_bucket: bucketCount(projectStateRef.current.sceneObjects?.length ?? 0),
@@ -3295,11 +3334,14 @@ export default function App() {
 				return; // user closed the picker
 			}
 			setProjectSaveState("error");
-			setToast(ko("Could not save the project", "프로젝트를 저장하지 못했어요"));
+			if (err?.code === "missing-resources") setSaveBlockedReasons([{ code: err.code, items: err.items }]);
+			else if (err?.code === "resources-too-large") setSaveBlockedReasons([err]);
+			else setToast(ko("Could not save the project", "프로젝트를 저장하지 못했어요"));
 		}
 	}
 
 	function applyProject(project) {
+		projectMotionsRef.current = new Map((project.motions ?? []).map((record) => [record.motionId?.toLowerCase(), record]).filter(([id]) => id));
 		const source = project.scenesDocument;
 		// A project FILE carries its own scene document and never passes the
 		// storage reader, so the 20 fps → 24 fps clock migration is applied here
@@ -3312,7 +3354,8 @@ export default function App() {
 		setActiveSceneId(doc.activeSceneId);
 		if (project.workspaceLayout) setWorkspaceLayout({ ...DEFAULT_WORKSPACE_LAYOUT, ...project.workspaceLayout });
 		setCustomPoses(mergedCustomPoses);
-		storeWorkflowGraph(normalizeWorkflowGraph(project.workflow));
+		const resolvedWorkflow = resolveWorkflowOutputs(normalizeWorkflowGraph(project.workflow), new Map((project.assets ?? []).map((asset) => [asset.id, asset])));
+		storeWorkflowGraph(resolvedWorkflow);
 		saveCustomPoses(mergedCustomPoses);
 		persistScenes(doc.scenes, doc.activeSceneId);
 		openScene(doc.scenes[activeSceneIndex(doc.scenes, doc.activeSceneId)], doc.scenes);
@@ -3324,6 +3367,7 @@ export default function App() {
 		// Whatever document this is, it is no longer the scene the tutorial opened
 		// for itself; startCameraTutorial re-arms the flag after its own open.
 		tutorialStarterRef.current = false;
+		setProjectManifest(resourceManifest({ scenesDocument: doc, workflow: resolvedWorkflow, poseLibrary: mergedCustomPoses, assets: project.assets ?? [], motions: projectMotionsRef.current, workflowOutputRefs }));
 		track("project:opened", { age_bucket: bucketProjectAge(Date.now() - (project.savedAt ?? Date.now())) });
 	}
 
@@ -3412,7 +3456,7 @@ export default function App() {
 			await rehydrateProjectAssets(result.project, result.warnings);
 			applyProject(result.project);
 			setProjectStartupOpen(false);
-			setToast(isKo ? `프로젝트 열림: ${result.project.name}` : `Project opened: ${result.project.name}`);
+			setToast(`${isKo ? `프로젝트 열림: ${result.project.name}` : `Project opened: ${result.project.name}`}${projectProblemsNotice(result.problems)}`);
 		} catch (err) {
 			if (err?.name === "AbortError") return;
 			console.error("openProject failed", err);
@@ -3443,7 +3487,7 @@ export default function App() {
 			applyProject(result.project);
 		setProjectBrowserOpen(false);
 		setProjectStartupOpen(false);
-		setToast(isKo ? `프로젝트 열림: ${result.project.name}` : `Project opened: ${result.project.name}`);
+		setToast(`${isKo ? `프로젝트 열림: ${result.project.name}` : `Project opened: ${result.project.name}`}${projectProblemsNotice(result.problems)}`);
 		} catch (err) {
 			console.error("openProjectByHandle failed", err);
 			setToast(ko("Could not open the project", "프로젝트를 열지 못했어요"));
@@ -3495,7 +3539,7 @@ export default function App() {
 			projectHandleRef.current = record.handle;
 			await rehydrateProjectAssets(result.project, result.warnings);
 			applyProject(result.project);
-			setToast(isKo ? `프로젝트 복원됨: ${result.project.name}` : `Project restored: ${result.project.name}`);
+			setToast(`${isKo ? `프로젝트 복원됨: ${result.project.name}` : `Project restored: ${result.project.name}`}${projectProblemsNotice(result.problems)}`);
 		} catch {
 			/* missing or unreadable file: fall back to the session cache */
 		}
@@ -6791,6 +6835,27 @@ export default function App() {
 	// Reads live store state at call time; re-registered after every render.
 	useEffect(() => {
 		window.__sceneHistory = () => ({ ...store.depths(), settled: store.present() === store.objects });
+	});
+	// QA-only project-file seam: browser acceptance tests still exercise the
+	// production serializer/parser and apply path without depending on native
+	// file-picker UI, which headless Chrome does not expose consistently.
+	useEffect(() => {
+		window.__cozyclayProject = {
+			export: (name = "QA Project") => collectProjectSerialized(name),
+			open: async (text) => {
+				const result = readProjectDocument(text);
+				if (!result.ok) return result;
+				await rehydrateProjectAssets(result.project, result.warnings);
+				applyProject(result.project);
+				setToast(`${isKo ? `프로젝트 열림: ${result.project.name}` : `Project opened: ${result.project.name}`}${projectProblemsNotice(result.problems)}`);
+				return result;
+			},
+			manifest: () => projectManifest,
+			saveBlocked: () => saveBlockedReasons,
+		};
+		return () => {
+			if (window.__cozyclayProject?.export) delete window.__cozyclayProject;
+		};
 	});
 
 	// On clear, restore the exact pre-playback bone rotations. This runs in
@@ -10239,17 +10304,27 @@ function resizePromptClip(id, edge, rawFrame) {
 	 * rebuild the session motions. The bridge may be gone — failures just
 	 * leave the character posed, never an error the user must act on. */
 	function restoreMotionRefs(list) {
+		const epoch = ++restoreEpochRef.current;
+		const motions = projectMotionsRef.current;
 		for (const entry of list) {
-			if (!entry.motionRef?.url) continue;
+			const source = resolveMotionSource(entry.motionRef, motions);
+			if (source.kind === "missing") {
+				setToast(isKo ? `저장된 모션이 누락되었습니다 (${entry.subject || entry.id})` : `Saved motion is missing for ${entry.subject || entry.id}`);
+				continue;
+			}
+			const load = source.kind === "embedded" ? decodeMotionResource(source.record) : loadMotionFromUrl(source.url);
+			load.then((raw) => {
+				if (epoch !== restoreEpochRef.current) return;
 			// Inbound boundary: a re-fetched clip is retimed exactly like a
 			// freshly generated one, so a reload cannot resurrect 20 fps frames.
-			loadMotionFromUrl(entry.motionRef.url).then((raw) => {
+			const sourceUrl = source.kind === "url" ? source.url : entry.motionRef?.url;
 				const retimed = retimeMotion(raw, TIMELINE_FPS);
 				const normalizedCalibration = normalizeMotionCalibration(entry.motionRef.calibration);
 				const decoded = applyMotionCalibration(retimed, { ...normalizedCalibration, yawDeg: 0, offsetX: 0, offsetZ: 0 }).motion;
 				const clip = {
 					...decoded,
-					url: entry.motionRef.url,
+					url: sourceUrl,
+					sourceBytes: raw.sourceBytes,
 					prompt: entry.motionRef.prompt,
 					anchorX: entry.motionRef.anchorX,
 					anchorZ: entry.motionRef.anchorZ,
@@ -10273,14 +10348,28 @@ function resizePromptClip(id, edge, rawFrame) {
 					setTlFrameCount((count) => Math.max(count, decoded.frames));
 					setTlFps(decoded.fps);
 				}
-			}).catch(() => {
+			}).catch((error) => {
+				if (epoch !== restoreEpochRef.current) return;
+				setProjectManifest((current) => {
+					const id = entry.motionRef?.motionId?.toLowerCase();
+					if (!id || !current?.items?.some((item) => item.kind === "motion" && item.id === id)) return current;
+					const items = current.items.map((item) => item.kind === "motion" && item.id === id
+						? { ...item, status: "missing", url: undefined }
+						: item);
+					const totals = { embedded: 0, external: 0, missing: 0, bytes: 0 };
+					for (const item of items) {
+						totals[item.status] += 1;
+						if (Number.isFinite(item.bytes)) totals.bytes += item.bytes;
+					}
+					return { items, totals, missing: items.filter((item) => item.status === "missing") };
+				});
 				// A saved take that fails to refetch used to vanish silently — the
 				// user would find a merely posed character and assume their motion
 				// was lost. Name it and offer the reload path.
 				const subject = entry.subject || entry.id;
 				setToast(isKo
-					? `저장된 모션을 다시 불러오지 못했어요 (${subject}) — 새로고침하거나 모션을 다시 생성해 주세요`
-					: `Saved motion could not be restored for ${subject} — reload or generate it again`);
+					? `저장된 모션을 다시 불러오지 못했어요 (${subject}) [${error?.code || "decode"}]`
+					: `Saved motion could not be restored for ${subject} [${error?.code || "decode"}]`);
 			});
 		}
 	}
@@ -10324,6 +10413,7 @@ function resizePromptClip(id, edge, rawFrame) {
 							<button type="button" role="menuitem" onClick={() => { setProjectStartupOpen(false); setProjectBrowserOpen(true); }}>{ko("Open Project…", "프로젝트 열기…")}</button>
 							<button type="button" role="menuitem" onClick={() => saveProject(false)}>{ko("Save Project", "프로젝트 저장")}</button>
 							<button type="button" role="menuitem" onClick={() => saveProject(true)}>{ko("Save Project As…", "다른 이름으로 저장…")}</button>
+							<ResourceStatus manifest={projectManifest} compact />
 						</div>
 					)}
 				</div>
@@ -13198,6 +13288,7 @@ function resizePromptClip(id, edge, rawFrame) {
 						onDeleteUnusedAsset={deleteUnusedAsset}
 						onUndoDelete={undoDeletedAsset}
 						deletingAssetId={deletingAssetId}
+						resourceManifest={projectManifest}
 					/>
 				</div>
 				<div className="bottom-timeline" hidden={bottomTab !== "timeline"}>
@@ -13611,6 +13702,7 @@ function resizePromptClip(id, edge, rawFrame) {
 				}}
 			/>
 			<FirstSuccessGuide open={firstSuccessGuideOpen} onDismiss={() => setFirstSuccessGuideOpen(false)} />
+			{saveBlockedReasons && <SaveBlockedDialog reasons={saveBlockedReasons} onClose={() => setSaveBlockedReasons(null)} />}
 			<Toast message={toast} onDone={() => setToast("")} />
 			{pwaUpdate && (
 				<div className="scene-delete-toast" role="status">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3215,13 +3215,28 @@ export default function App() {
 	playgroundExportRef.current = collectProjectSerialized;
 	async function collectProjectSerialized(name) {
 		const input = projectDocumentInput(name);
+		const scenesDocument = {
+			...input.scenesDocument,
+			scenes: input.scenesDocument.scenes.map((scene) => ({
+				...scene,
+				stage: scene.stage
+					? {
+						...scene.stage,
+						characters: (scene.stage.characters ?? []).map((character) => ({
+							...character,
+							motionRef: character.motionRef ? { ...character.motionRef } : character.motionRef,
+						})),
+					}
+					: scene.stage,
+			})),
+		};
 		const db = await openAssetDb();
 		try {
-			const ids = [...referencedAssetIds(input.scenesDocument.scenes)];
+			const ids = [...referencedAssetIds(scenesDocument.scenes)];
 			const assets = await Promise.all(ids.map((id) => getAsset(db, id)));
 			const workflowResult = await internWorkflowOutputs(input.workflow);
 			const referencedMotionIds = new Set(
-				input.scenesDocument.scenes.flatMap((scene) => (scene.stage?.characters ?? [])
+				scenesDocument.scenes.flatMap((scene) => (scene.stage?.characters ?? [])
 					.map((character) => character.motionRef?.motionId?.toLowerCase())
 					.filter(Boolean)),
 			);
@@ -3230,7 +3245,7 @@ export default function App() {
 				.map(([, record]) => record);
 			const motionCache = new Map();
 			for (const record of motions) motionCache.set(record.motionId.toLowerCase(), record);
-			for (const scene of input.scenesDocument.scenes) for (const character of scene.stage?.characters ?? []) {
+			for (const scene of scenesDocument.scenes) for (const character of scene.stage?.characters ?? []) {
 				const clip = motionFullRef.current.get(character.id);
 				if (!clip?.sourceBytes) continue;
 				const record = await encodeMotionResource(clip.sourceBytes, { prompt: character.motionRef?.prompt, sourceUrl: character.motionRef?.url });
@@ -3241,7 +3256,7 @@ export default function App() {
 				character.motionRef = { ...(character.motionRef || {}), motionId: cached.motionId };
 			}
 			const allAssets = [...assets.filter(Boolean), ...workflowResult.assets];
-			const nextInput = { ...input, workflow: workflowResult.graph, assets: allAssets, motions };
+			const nextInput = { ...input, scenesDocument, workflow: workflowResult.graph, assets: allAssets, motions };
 			const manifest = resourceManifest({ scenesDocument: nextInput.scenesDocument, workflow: nextInput.workflow, poseLibrary: nextInput.customPoses, assets: allAssets, motions, workflowOutputRefs });
 			setProjectManifest(manifest);
 			if (manifest.missing.length) {

--- a/src/asset-pane.jsx
+++ b/src/asset-pane.jsx
@@ -6,6 +6,7 @@ import { displayObjectGroupName, displayObjectLabel } from "./object-catalog.jsx
 import { assetAspect } from "./scene-assets.js";
 import { assetKind, formatAssetBytes } from "./asset-shelf.js";
 import { assetRecord } from "./scene-asset-cache.js";
+import ResourceStatus from "./resource-status.jsx";
 
 /** Casting assets offered in the bottom Assets tab. `id` doubles as the FBX
  * file stem and the ARDY wire rig name (see scenes.js). */
@@ -290,9 +291,10 @@ function StorageManager({ unusedAssetIds, usedAssetIds, usageCounts, graphSignat
  * of SOURCE ids (see asset-shelf.js) — derived mattes and cut renders never
  * reach this component.
  */
-export default function AssetPane({ onAssetGrab, imageAssetIds, manageStorage, onManageStorageToggle, unusedAssetIds, usedAssetIds, usageCounts, graphSignature, trashCount, onDeleteUnusedAsset, onUndoDelete, deletingAssetId }) {
+export default function AssetPane({ onAssetGrab, imageAssetIds, manageStorage, onManageStorageToggle, unusedAssetIds, usedAssetIds, usageCounts, graphSignature, trashCount, onDeleteUnusedAsset, onUndoDelete, deletingAssetId, resourceManifest }) {
 	return (
 		<div className="assets-shelf">
+			{resourceManifest ? <ResourceStatus manifest={resourceManifest} compact /> : null}
 			<div className="assets-shelf-toolbar">
 				<button type="button" className="assets-manage-toggle" aria-pressed={manageStorage} onClick={onManageStorageToggle}>
 					{manageStorage ? ko("Back to assets", "에셋으로 돌아가기") : ko("Manage storage", "저장 공간 관리")}

--- a/src/project.js
+++ b/src/project.js
@@ -222,6 +222,21 @@ function embeddedAsset(record) {
 	return { record: { ...asset, bytes: bytesToBase64(asset.bytes) }, bytes: asset.bytes.byteLength };
 }
 
+function workflowAssetIds(workflow) {
+	const ids = new Set();
+	const visit = (value) => {
+		if (Array.isArray(value)) {
+			for (const entry of value) visit(entry);
+			return;
+		}
+		if (!plainRecord(value)) return;
+		if (isAssetId(value.assetRef)) ids.add(value.assetRef);
+		for (const entry of Object.values(value)) visit(entry);
+	};
+	visit(workflow);
+	return ids;
+}
+
 /** The optional motion fields carried verbatim; frames/fps come from the
  * encoder (motion-resources.js), never from decoding the NPZ here. */
 function motionDetails(record) {
@@ -346,11 +361,11 @@ function readEmbeddedMotions(value, report) {
 }
 
 /**
- * Build the v4 envelope. Images are embedded only when a scene references
- * them; motions are embedded as given (deduped by motionId, first record
- * wins) because the caller already knows which ones the scenes use. Throws
- * `resources-too-large` when one motion or the whole manifest exceeds its
- * budget.
+ * Build the v4 envelope. Images are embedded when a scene or workflow
+ * assetRef references them; motions are embedded as given (deduped by
+ * motionId, first record wins) because the caller already knows which ones
+ * the project uses. Throws `resources-too-large` when one motion or the whole
+ * manifest exceeds its budget.
  */
 export function createProjectDocument({ scenesDocument, workspaceLayout, customPoses, name, assets, motions, savedAt, workflow }) {
 	const assetRecords = new Map();
@@ -360,7 +375,9 @@ export function createProjectDocument({ scenesDocument, workspaceLayout, customP
 	}
 	const embeddedAssets = [];
 	let resourceBytes = 0;
-	for (const id of referencedAssetIds(scenesDocument?.scenes)) {
+	const referencedIds = referencedAssetIds(scenesDocument?.scenes);
+	for (const id of workflowAssetIds(workflow)) referencedIds.add(id);
+	for (const id of referencedIds) {
 		const asset = assetRecords.get(id);
 		if (!asset) continue;
 		embeddedAssets.push(asset.record);

--- a/test/qa-project-resources-browser.mjs
+++ b/test/qa-project-resources-browser.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Issue #231 end-to-end project-resource QA. Run through tools/qa-browser.mjs.
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { encodeMotionResource } from "../src/motion-resources.js";
+import { assetIdForBytes } from "../src/scene-assets.js";
+import { createCutoutObject } from "../src/scene-objects.js";
+import { DEFAULT_POSE } from "../src/poses.js";
+
+const port = Number(process.env.CDP_PORT || 9464);
+const out = "/tmp/cozyclay-231-qa";
+await mkdir(out, { recursive: true });
+const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json();
+const page = targets.find((t) => t.type === "page" && t.url.includes("/app/")) || targets.find((t) => t.type === "page");
+assert.ok(page, "app page is open");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+let id = 0; const pending = new Map();
+ws.onmessage = (event) => { const m = JSON.parse(event.data); if (!m.id || !pending.has(m.id)) return; const p = pending.get(m.id); pending.delete(m.id); m.error ? p.reject(new Error(JSON.stringify(m.error))) : p.resolve(m.result); };
+const send = (method, params = {}) => new Promise((resolve, reject) => { const requestId = ++id; pending.set(requestId, { resolve, reject }); ws.send(JSON.stringify({ id: requestId, method, params })); });
+const evaluate = async (expression) => { const r = await send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true }); if (r.exceptionDetails) throw new Error(r.exceptionDetails.exception?.description || "browser evaluation failed"); return r.result?.value; };
+const waitFor = (label, expression, timeout = 20000) => evaluate(`new Promise((resolve, reject) => { const end = setTimeout(() => reject(new Error(${JSON.stringify(`Timed out waiting for ${label}`)})), ${timeout}); const check = () => { try { const value = (${expression}); if (value) { clearTimeout(end); resolve(true); return true; } } catch {} return false; }; if (check()) return; const observer = new MutationObserver(() => { if (check()) observer.disconnect(); }); observer.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true }); })`);
+const click = async (selector) => { const ok = await evaluate(`(() => { const e = document.querySelector(${JSON.stringify(selector)}); if (!e) return false; e.click(); return true; })()`); assert.ok(ok, `missing ${selector}`); };
+const shot = async (name) => { const r = await send("Page.captureScreenshot", { format: "png" }); await writeFile(join(out, name), Buffer.from(r.data, "base64")); };
+const save = async () => { await click(".project-menu-trigger"); await click('[role="menuitem"]:has-text("Save Project")').catch(async () => { await click('[role="menuitem"]'); }); };
+// Chromium's querySelector does not implement :has-text; use text-aware dispatch.
+const textClick = async (text) => { const ok = await evaluate(`(() => { const e = [...document.querySelectorAll('button,[role="menuitem"]')].find(x => x.textContent.includes(${JSON.stringify(text)})); if (!e) return false; e.click(); return true; })()`); assert.ok(ok, `missing button ${text}`); };
+async function saveProject() { await click(".project-menu-trigger"); await evaluate("document.querySelectorAll('.project-menu [role=menuitem]')[2]?.click()"); const named = await waitFor("project name dialog or save status", "!!document.querySelector('.project-name-dialog') || !!document.querySelector('.status-saved')", 5000).catch(() => false); if (named && await evaluate("!!document.querySelector('.project-name-dialog')")) { await evaluate("document.querySelector('.project-name-dialog input').value = 'issue-231'; document.querySelector('.project-name-dialog').requestSubmit()"); } await waitFor("saved status", "document.querySelector('.status-saved') || [...document.querySelectorAll('[role=status]')].some(e => /saved|저장/.test(e.textContent)) || document.querySelector('.project-save-status')?.textContent.includes('Saved')"); }
+async function openFile(path) { await click(".project-menu-trigger"); await evaluate("document.querySelectorAll('.project-menu [role=menuitem]')[1]?.click()"); await waitFor("project browser", "!!document.querySelector('.project-browser')"); await textClick("Open file"); await waitFor("file input", "document.querySelector('input[type=file]')"); await send("DOM.getDocument"); const node = await send("DOM.querySelector", { nodeId: 1, selector: 'input[type=file]' }); await send("DOM.setFileInputFiles", { nodeId: node.nodeId, files: [path] }); await waitFor("project opened", "!document.querySelector('.project-browser') && document.querySelector('.resource-status')"); }
+await send("Page.enable"); await send("Browser.setDownloadBehavior", { behavior: "allow", downloadPath: out });
+
+// Establish a real app project. The QA seam calls the production serializer
+// instead of native File System Access UI, which headless Chrome does not
+// expose consistently; opening still goes through readProjectDocument/applyProject.
+await waitFor("app canvas", "document.querySelector('canvas')");
+const serialized = await evaluate("window.__cozyclayProject?.export('issue-231')");
+assert.equal(typeof serialized, "string", "production project export hook is available");
+const sourcePath = join(out, "issue-231.cclayproject");
+await writeFile(sourcePath, serialized);
+const original = JSON.parse(serialized);
+const motionBytes = new Uint8Array(await readFile("public/demo/walk-then-stop.npz"));
+const motionRecord = await encodeMotionResource(motionBytes, { name: "QA walk", sourceUrl: "/unavailable-bridge/qa.npz" });
+const firstScene = original.scenes.scenes[0];
+const firstCharacter = firstScene.stage.characters[0];
+const sharedRef = {
+  motionId: motionRecord.motionId,
+  prompt: "QA walk",
+  rotationDeg: firstCharacter.rot ?? 0,
+  anchorX: firstCharacter.x ?? 0,
+  anchorZ: firstCharacter.z ?? 0,
+};
+firstCharacter.motionRef = sharedRef;
+const pose = { ...DEFAULT_POSE, id: "qa-pose", label: "QA pose", custom: true };
+firstCharacter.pose = pose;
+original.poseLibrary = [pose];
+const imageBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aWMQAAAAASUVORK5CYII=";
+const imageBytes = new Uint8Array(Buffer.from(imageBase64, "base64"));
+const imageId = await assetIdForBytes(imageBytes);
+original.resources.assets.push({ id: imageId, type: "image/png", width: 1, height: 1, name: "QA image", bytes: imageBase64 });
+firstScene.objects.push(createCutoutObject({ assetId: imageId, name: "QA image" }, firstScene.objects, { x: -2, z: 0 }));
+const secondCharacter = structuredClone(firstCharacter);
+secondCharacter.id = "char-qa-b";
+secondCharacter.x = (secondCharacter.x ?? 0) + 2;
+secondCharacter.motionRef = { ...sharedRef, anchorX: secondCharacter.x };
+firstScene.stage.characters.push(secondCharacter);
+const secondScene = structuredClone(firstScene);
+secondScene.id = "scene-qa-2";
+secondScene.name = "QA Scene 02";
+original.scenes.scenes.push(secondScene);
+original.resources.motions = [motionRecord];
+const seededSerialized = JSON.stringify(original);
+assert.equal(original.app, "cozyclay");
+await shot("01-saved.png");
+console.log("PASS case 1: visible Save produced a serialized project and rendered canvas");
+
+// Reopen the exact serialized file through the production parser/apply path.
+await send("Storage.clearDataForOrigin", { origin: new URL(page.url).origin, storageTypes: "all" });
+const reloaded = new Promise((resolve, reject) => {
+  const timer = setTimeout(() => { ws.removeEventListener("message", listener); reject(new Error("fresh-profile reload timed out")); }, 20000);
+  const listener = (event) => {
+    if (JSON.parse(event.data).method !== "Page.loadEventFired") return;
+    clearTimeout(timer); ws.removeEventListener("message", listener); resolve();
+  };
+  ws.addEventListener("message", listener);
+});
+await send("Page.reload");
+await reloaded;
+await waitFor("fresh app project hook", "!!window.__cozyclayProject");
+await evaluate(`window.__cozyclayProject.open(${JSON.stringify(seededSerialized)})`);
+await waitFor("scene and rig after open", `window.__cozyclay?.motion?.motionId === ${JSON.stringify(motionRecord.motionId)} && !!window.__cozyclay?.rigA`);
+await shot("01-reopened.png");
+assert.ok(await evaluate("document.querySelectorAll('canvas').length > 0"));
+console.log("PASS case 1: serialized project reopened through Open file and rendered scene/rig");
+
+// Case 2/3 are structural checks on the file emitted by the real save path;
+// the playback check is made against the app's actual play control and canvas.
+const savedAgain = JSON.parse(await evaluate("window.__cozyclayProject.export('issue-231-motion')"));
+assert.equal(savedAgain.scenes.scenes.length, 2, "two scenes survive the fresh-profile round trip");
+assert.equal(savedAgain.poseLibrary.some((entry) => entry.id === "qa-pose"), true, "pose library survives the fresh-profile round trip");
+assert.equal(savedAgain.resources.assets.some((entry) => entry.id === imageId), true, "image bytes survive the fresh-profile round trip");
+const motions = savedAgain.resources?.motions || [];
+assert.equal(new Set(motions.map((m) => m.motionId)).size, motions.length);
+console.log(`PASS case 3: resources.motions is deduplicated (${motions.length} record(s))`);
+await evaluate("window.__cozyclay.scrub(0)");
+await click('.tl-transport button[aria-label="Play playback"]');
+await waitFor("embedded playback frame advancement", `window.__cozyclay?.playing && window.__cozyclay?.tlFrame > 0 && window.__cozyclay?.motion?.motionId === ${JSON.stringify(motionRecord.motionId)}`, 10000);
+await shot("02-embedded-motion.png");
+await evaluate("window.__cozyclay.pause()");
+console.log("PASS case 2: embedded motion advances the real playhead without an external bridge URL");
+
+// Corrupt one embedded record and reopen: project.js must report the problem,
+// while the UI exposes missing status/toast rather than silently accepting it.
+if (motions.length) {
+ const bad = structuredClone(original); bad.resources.motions[0].data = "%%%corrupt%%%";
+ const badText = JSON.stringify(bad); await writeFile(join(out, "corrupt-motion.cclayproject"), badText);
+ await evaluate(`window.__cozyclayProject.open(${JSON.stringify(badText)})`);
+ const warning = await waitFor("corrupt-resource warning", "[...document.querySelectorAll('[role=status]')].some(e => /skipped|missing|누락|건너뛰/i.test(e.textContent)) || document.querySelector('.resource-status.has-missing')", 10000);
+ assert.ok(warning); await shot("04-corrupt-motion.png"); console.log("PASS case 4: corrupt embedded motion produced warning and missing manifest");
+} else throw new Error("case 4 requires an embedded motion record");
+
+// Force a missing motion reference through the app's persisted scene document,
+// then invoke visible Save. This must be the production SaveBlockedDialog.
+await evaluate(`(() => { const k = 'cozyclay.scenes.v4'; const d = JSON.parse(localStorage.getItem(k) || '{}'); const s = d.scenes?.[0]; const c = s?.stage?.characters?.[0]; if (!c) return false; c.motionRef = { motionId: 'f'.repeat(64) }; localStorage.setItem(k, JSON.stringify(d)); location.reload(); return true; })()`);
+await waitFor("reloaded app", "document.querySelector('canvas')");
+await click(".project-menu-trigger"); await evaluate("document.querySelectorAll('.project-menu [role=menuitem]')[2]?.click()");
+await waitFor("SaveBlockedDialog", "document.querySelector('.save-blocked-dialog[data-code], .save-blocked-dialog')", 10000);
+assert.ok(await evaluate("!!document.querySelector('.save-blocked-dialog')")); await shot("05-save-blocked.png");
+console.log("PASS case 5: missing resource produced the real SaveBlockedDialog");
+console.log(`PASS qa-project-resources-browser: screenshots in ${out}`);
+ws.close();

--- a/test/verify-project.mjs
+++ b/test/verify-project.mjs
@@ -122,6 +122,31 @@ assert.deepEqual(
 	})),
 	"embedded asset records round-trip byte-for-byte",
 );
+const workflowAssetDocument = createProjectDocument({
+	scenesDocument: createSceneDocument("WORKFLOW ONLY"),
+	workflow: {
+		version: 1,
+		nodes: [{
+			id: "scene-output",
+			type: "scene",
+			position: { x: 0, y: 0 },
+			data: { resultUrl: { assetRef: sourceAssetId } },
+		}],
+		edges: [],
+	},
+	assets: fakeAssets,
+});
+assert.deepEqual(
+	workflowAssetDocument.resources.assets.map((asset) => asset.id),
+	[sourceAssetId],
+	"workflow assetRefs are included even without a scene-object reference",
+);
+const workflowAssetRoundTrip = readProjectDocument(JSON.stringify(workflowAssetDocument));
+assert.deepEqual(
+	workflowAssetRoundTrip.project.assets.map((asset) => asset.id),
+	[sourceAssetId],
+	"workflow-only embedded assets round-trip through the project reader",
+);
 
 // --- embedded hash verification -------------------------------------------
 assert.equal(await verifyEmbeddedAsset(fakeAssets[0], webcrypto.subtle), true, "matching embedded bytes verify against their content address");
@@ -328,6 +353,15 @@ assert.match(appSource, /queryHandlePermission/, "auto-restore only with a grant
 assert.match(appSource, /referencedAssetIds/, "export finds the complete referenced asset closure");
 assert.match(appSource, /getAsset/, "export reads referenced asset records from IndexedDB");
 assert.match(appSource, /putAsset/, "open restores embedded asset records to IndexedDB");
+assert.match(appSource, /encodeMotionResource\(/, "project save encodes the loaded NPZ bytes");
+assert.match(appSource, /decodeMotionResource\(/, "project open decodes embedded motion resources");
+assert.match(appSource, /resolveMotionSource\(/, "motion restore uses the embedded-first resolver");
+assert.match(appSource, /internWorkflowOutputs\(/, "project save interns workflow image outputs");
+assert.match(appSource, /resolveWorkflowOutputs\(/, "project open restores runtime workflow output URLs");
+assert.match(appSource, /resourceManifest\(/, "App computes project resource status");
+assert.match(appSource, /<ResourceStatus\b/, "the project menu shows resource status");
+assert.match(appSource, /<SaveBlockedDialog\b/, "missing or oversized resources have a save-blocked dialog");
+assert.match(appSource, /__cozyclayProject/, "browser QA can exercise the production project export/open path");
 assert.match(appSource, /projectDirty/, "unsaved changes surface as a dirty marker");
 assert.ok(PROJECT_EXTENSION.length > 1, "project files carry an extension");
 

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -199,6 +199,7 @@ const BROWSER_FILES = [
 	"test/qa-reference-slots-browser.mjs",
 	"test/qa-scene-playback-browser.mjs",
 	"test/qa-scene-switcher-browser.mjs",
+	"test/qa-project-resources-browser.mjs",
 	"test/qa-send-to-ai-browser.mjs",
 	"test/qa-view-menu-browser.mjs",
 ];
@@ -206,7 +207,7 @@ const BROWSER_FILES = [
 // The inventory sweep only picks up `verify*.mjs`; a browser suite named for
 // the QA runner it needs is listed here so it still shows up in the manifest
 // (as an EXCLUDE with its reason) instead of going unmentioned.
-const EXTRA_INVENTORY = ["test/qa-agent-view-toggle-browser.mjs", "test/qa-camera-tutorial-browser.mjs", "test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-playback-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
+const EXTRA_INVENTORY = ["test/qa-agent-view-toggle-browser.mjs", "test/qa-camera-tutorial-browser.mjs", "test/qa-ia-tail-browser.mjs", "test/qa-keyframe-pack-browser.mjs", "test/qa-preview-browser.mjs", "test/qa-project-resources-browser.mjs", "test/qa-reference-slots-browser.mjs", "test/qa-scene-playback-browser.mjs", "test/qa-scene-switcher-browser.mjs", "test/qa-send-to-ai-browser.mjs", "test/qa-view-menu-browser.mjs"];
 
 function verificationFiles(directory) {
 	return readdirSync(directory, { withFileTypes: true })


### PR DESCRIPTION
## Summary
- Integrate v4 embedded motion resources, workflow output assets, and resource manifests into App.jsx.
- Restore embedded motions before external URLs, surface decode/read problems, and block saves for missing or oversized resources.
- Include workflow assetRef records in resources.assets and add round-trip coverage.
- Add browser QA for fresh-profile reopen, bridge-less embedded playback, dedupe, corruption warnings, and save blocking.

## Verification
- npm run build: PASS
- Targeted project/motion/workflow/resource tests: PASS
- node tools/run-tests.mjs: 159 Node verification files PASS; browser runner is separately recorded below.
- QA command:
  QA_URL=http://127.0.0.1:5211/app/ CDP_PORT=9476 node tools/qa-browser.mjs -- node test/qa-project-resources-browser.mjs
- Browser QA: all five cases PASS.
  - fresh-profile reopen with image, pose, two scenes, and rendered rig
  - embedded motion playhead advances without external bridge URL
  - shared motion produces resources.motions.length === 1
  - corrupted motion produces warning and missing manifest status
  - missing motion produces SaveBlockedDialog
- Screenshots: /tmp/cozyclay-231-qa/01-saved.png, /tmp/cozyclay-231-qa/01-reopened.png, /tmp/cozyclay-231-qa/02-embedded-motion.png, /tmp/cozyclay-231-qa/04-corrupt-motion.png, /tmp/cozyclay-231-qa/05-save-blocked.png

## Environment note
The aggregate runner initially lacked optional local packages (ws/zod); installing them with --no-save allowed the Node suite to complete. Build and the issue-specific browser QA passed.


- Review follow-up: cloned the scenes document before adding motionId; `node test/verify-project.mjs` and the requested CDP browser QA on CDP_PORT=9478 both PASS.